### PR TITLE
(core) - Add ability to customize logs in debugExchange

### DIFF
--- a/.changeset/wicked-queens-applaud.md
+++ b/.changeset/wicked-queens-applaud.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': minor
+---
+
+Adds ability to customize logs in the debugExchange

--- a/.changeset/wicked-queens-applaud.md
+++ b/.changeset/wicked-queens-applaud.md
@@ -1,5 +1,5 @@
 ---
-'@urql/core': minor
+'@urql/core': major
 ---
 
 Adds ability to customize logs in the debugExchange

--- a/docs/advanced/debugging.md
+++ b/docs/advanced/debugging.md
@@ -138,3 +138,8 @@ custom exchanges:
 - ❌ **Don't send warnings in debug events**: Informing your user about warnings isn't effective
   when the event isn't seen. You should still rely on `console.warn` so all users see your important
   warnings.
+
+## Debug Exchange
+
+Another debugging option is to use the `debugExchange` included in urql core. This exchange adds
+customizable logs which may be helpful for debugging. See the ["debugExchange" on the @urql/core API page.](../api/core/#debugexchange)

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -320,6 +320,16 @@ the `fetchExchange`.
 An exchange that writes incoming `Operation`s to `console.log` and
 writes completed `OperationResult`s to `console.log`.
 
+It accepts two optional input functions `onIncoming` and `onCompleted` which can
+be supplied to override the default log behavior
+
+```ts
+debugExchange({
+  onIncoming: op => console.warn('Incoming Operation: ', op.key, op.kind),
+  onCompleted: result => console.warn('Result data: ', result.operation.key, result.data),
+});
+```
+
 ### dedupExchange
 
 An exchange that keeps track of ongoing `Operation`s that haven't returned had

--- a/packages/core/src/exchanges/debug.test.ts
+++ b/packages/core/src/exchanges/debug.test.ts
@@ -29,7 +29,7 @@ beforeEach(() => {
 it('forwards query operations correctly', async () => {
   jest.spyOn(global.console, 'log').mockImplementation();
   const { source: ops$, next, complete } = input;
-  const exchange = debugExchange(exchangeArgs)(ops$);
+  const exchange = debugExchange({})(exchangeArgs)(ops$);
 
   publish(exchange);
   next(queryOperation);
@@ -38,6 +38,24 @@ it('forwards query operations correctly', async () => {
   expect(console.log).toBeCalled();
   // eslint-disable-next-line no-console
   expect(console.log).toBeCalledTimes(2);
+});
+
+it('calls custom functions when supplied', async () => {
+  jest.spyOn(global.console, 'log').mockImplementation();
+  const onIncoming = jest.fn();
+  const onCompleted = jest.fn();
+  const { source: ops$, next, complete } = input;
+  const exchange = debugExchange({ onIncoming, onCompleted })(exchangeArgs)(
+    ops$
+  );
+
+  publish(exchange);
+  next(queryOperation);
+  complete();
+  // eslint-disable-next-line no-console
+  expect(console.log).not.toBeCalled();
+  expect(onIncoming).toHaveBeenCalledTimes(1);
+  expect(onCompleted).toHaveBeenCalledTimes(1);
 });
 
 describe('production', () => {
@@ -52,7 +70,7 @@ describe('production', () => {
   it('is a noop in production', () => {
     const { source: ops$ } = input;
 
-    debugExchange({
+    debugExchange({})({
       forward: ops => {
         expect(ops).toBe(ops$);
       },


### PR DESCRIPTION
## Summary
Adds the ability for customizable logs in the `debugExchange`  which makes it more useful for a few reasons:
- Can have multiple debug exchanges since you can adjust the exchange to label log output depending which order its in
- Can change console severity  (useful for react-native since `warn`/`error`'s can show up on screen)
- Can drill down to only log pertinent information about an operation or result

This `debugExchange` has been especially useful for me since the library ships minified which makes stepping through library code with a debugger less viable.


## Set of changes
- Adds optional configuration options  `onIncoming` and `onCompleted` to the debugExchange. Both are functions intented to be used for custom log output.
- Updates documentation.
- As a consequence of having configuation options in the `debugExchange` api changes 

Before:
```
createClient({
   ...
   debugExchange,
   ...
})
```

After
```
createClient({
   ...
   debugExchange({}),
   ...
})
```
Not sure if this is considered a breaking change. 
