### PR TITLE
(populate) - refactor and increase reliability of query-reading

### DIFF
--- a/.changeset/shaggy-comics-grin.md
+++ b/.changeset/shaggy-comics-grin.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-populate': patch
+---
+
+(relates to #964) Increase feature-set of the populateExchange. Address "classic" mode

--- a/exchanges/populate/src/helpers/traverse.ts
+++ b/exchanges/populate/src/helpers/traverse.ts
@@ -8,8 +8,8 @@ import {
   isAbstractType,
   FragmentDefinitionNode,
   FragmentSpreadNode,
-} from 'graphql';
-import { unwrapType, getName } from './node';
+} from "graphql";
+import { unwrapType, getName } from "./node";
 
 export function traverse(
   node: ASTNode,
@@ -25,7 +25,7 @@ export function traverse(
       node = {
         ...node,
         definitions: node.definitions.map(
-          n => traverse(n, enter, exit) as DefinitionNode
+          (n) => traverse(n, enter, exit) as DefinitionNode
         ),
       };
       break;
@@ -39,7 +39,7 @@ export function traverse(
           selectionSet: {
             ...node.selectionSet,
             selections: node.selectionSet.selections.map(
-              n => traverse(n, enter, exit) as SelectionNode
+              (n) => traverse(n, enter, exit) as SelectionNode
             ),
           },
         };
@@ -65,14 +65,15 @@ export function resolveFields(
     const t = unwrapType(currentFields[visits[i]].type);
 
     if (isAbstractType(t)) {
-      currentFields = {};
-      schema.getPossibleTypes(t).forEach(implementedType => {
-        currentFields = {
-          ...currentFields,
-          // @ts-ignore TODO: proper casting
-          ...schema.getType(implementedType.name)!.toConfig().fields,
-        };
-      });
+      currentFields = schema
+        .getPossibleTypes(t)
+        .reduce((previousValue, implementedType) => {
+          return {
+            ...previousValue,
+            // @ts-ignore TODO: proper casting
+            ...schema.getType(implementedType.name)!.toConfig().fields,
+          };
+        }, {});
     } else {
       // @ts-ignore TODO: proper casting
       currentFields = schema.getType(t!.name)!.toConfig().fields;
@@ -86,7 +87,7 @@ export function resolveFields(
 export function getUsedFragmentNames(node: FragmentDefinitionNode) {
   const names: string[] = [];
 
-  traverse(node, n => {
+  traverse(node, (n) => {
     if (n.kind === Kind.FRAGMENT_SPREAD) {
       names.push(getName(n as FragmentSpreadNode));
     }

--- a/exchanges/populate/src/helpers/traverse.ts
+++ b/exchanges/populate/src/helpers/traverse.ts
@@ -8,8 +8,8 @@ import {
   isAbstractType,
   FragmentDefinitionNode,
   FragmentSpreadNode,
-} from "graphql";
-import { unwrapType, getName } from "./node";
+} from 'graphql';
+import { unwrapType, getName } from './node';
 
 export function traverse(
   node: ASTNode,
@@ -25,7 +25,7 @@ export function traverse(
       node = {
         ...node,
         definitions: node.definitions.map(
-          (n) => traverse(n, enter, exit) as DefinitionNode
+          n => traverse(n, enter, exit) as DefinitionNode
         ),
       };
       break;
@@ -39,7 +39,7 @@ export function traverse(
           selectionSet: {
             ...node.selectionSet,
             selections: node.selectionSet.selections.map(
-              (n) => traverse(n, enter, exit) as SelectionNode
+              n => traverse(n, enter, exit) as SelectionNode
             ),
           },
         };
@@ -87,7 +87,7 @@ export function resolveFields(
 export function getUsedFragmentNames(node: FragmentDefinitionNode) {
   const names: string[] = [];
 
-  traverse(node, (n) => {
+  traverse(node, n => {
     if (n.kind === Kind.FRAGMENT_SPREAD) {
       names.push(getName(n as FragmentSpreadNode));
     }

--- a/exchanges/populate/src/populateExchange.test.ts
+++ b/exchanges/populate/src/populateExchange.test.ts
@@ -120,7 +120,7 @@ describe('nested fragment', () => {
   const fragment = gql`
     fragment TodoFragment on Todo {
       id
-      author {
+      creator {
         id
       }
     }
@@ -165,7 +165,7 @@ describe('nested fragment', () => {
     expect(print(response[1].query)).toBe(`mutation MyMutation {
   updateTodo {
     id
-    author {
+    creator {
       id
     }
   }
@@ -260,14 +260,13 @@ describe('on query -> mutation', () => {
       id
       name
     }
-    text
   }
 }
 `);
     });
   });
 });
-/*
+
 describe('on (query w/ fragment) -> mutation', () => {
   const queryOp = makeOperation(
     'query',
@@ -325,32 +324,23 @@ describe('on (query w/ fragment) -> mutation', () => {
         toArray
       );
 
-      expect(print(response[1].query)).toMatchInlineSnapshot(`
-        "mutation MyMutation {
-          addTodo {
-            ...Todo_PopulateFragment_0
-            ...TodoFragment
-          }
-        }
+      expect(print(response[1].query)).toBe(`mutation MyMutation {
+  addTodo {
+    id
+    text
+    creator {
+      id
+      name
+    }
+    ...TodoFragment
+  }
+}
 
-        fragment TodoFragment on Todo {
-          id
-          text
-        }
-
-        fragment Todo_PopulateFragment_0 on Todo {
-          ...TodoFragment
-          creator {
-            ...CreatorFragment
-          }
-        }
-
-        fragment CreatorFragment on User {
-          id
-          name
-        }
-        "
-      `);
+fragment TodoFragment on Todo {
+  id
+  text
+}
+`);
     });
 
     it('includes user fragment', () => {
@@ -414,19 +404,13 @@ describe('on (query w/ unused fragment) -> mutation', () => {
         toArray
       );
 
-      expect(print(response[1].query)).toMatchInlineSnapshot(`
-        "mutation MyMutation {
-          addTodo {
-            ...Todo_PopulateFragment_0
-          }
-        }
-
-        fragment Todo_PopulateFragment_0 on Todo {
-          id
-          text
-        }
-        "
-      `);
+      expect(print(response[1].query)).toBe(`mutation MyMutation {
+  addTodo {
+    id
+    text
+  }
+}
+`);
     });
 
     it('excludes user fragment', () => {
@@ -486,32 +470,19 @@ describe('on query -> (mutation w/ interface return type)', () => {
         toArray
       );
 
-      expect(print(response[1].query)).toMatchInlineSnapshot(`
-        "mutation MyMutation {
-          removeTodo {
-            ...User_PopulateFragment_0
-            ...Todo_PopulateFragment_0
-          }
-        }
-
-        fragment User_PopulateFragment_0 on User {
-          id
-          text
-        }
-
-        fragment Todo_PopulateFragment_0 on Todo {
-          id
-          name
-        }
-        "
-      `);
+      expect(print(response[1].query)).toBe(`mutation MyMutation {
+  removeTodo {
+    id
+  }
+}
+`);
     });
   });
 });
-
-describe('on query -> (mutation w/ union return type)', () => {
+/*
+describe("on query -> (mutation w/ union return type)", () => {
   const queryOp = makeOperation(
-    'query',
+    "query",
     {
       key: 1234,
       query: gql`
@@ -531,7 +502,7 @@ describe('on query -> (mutation w/ union return type)', () => {
   );
 
   const mutationOp = makeOperation(
-    'mutation',
+    "mutation",
     {
       key: 5678,
       query: gql`
@@ -543,8 +514,8 @@ describe('on query -> (mutation w/ union return type)', () => {
     context
   );
 
-  describe('mutation query', () => {
-    it('matches snapshot', async () => {
+  describe("mutation query", () => {
+    it("matches snapshot", async () => {
       const response = pipe<Operation, any, Operation[]>(
         fromArray([queryOp, mutationOp]),
         populateExchange({ schema })(exchangeArgs),
@@ -573,6 +544,7 @@ describe('on query -> (mutation w/ union return type)', () => {
     });
   });
 });
+*/
 
 describe('on query -> teardown -> mutation', () => {
   const queryOp = makeOperation(
@@ -614,26 +586,25 @@ describe('on query -> teardown -> mutation', () => {
         toArray
       );
 
-      expect(print(response[2].query)).toMatchInlineSnapshot(`
-        "mutation MyMutation {
-          addTodo {
-            __typename
-          }
-        }
-        "
-      `);
+      expect(print(response[2].query)).toBe(`mutation MyMutation {
+  addTodo {
+    id
+    text
+  }
+}
+`);
     });
 
-    it('only requests __typename', () => {
+    /*it("only requests __typename", () => {
       const response = pipe<Operation, any, Operation[]>(
         fromArray([queryOp, teardownOp, mutationOp]),
         populateExchange({ schema })(exchangeArgs),
         toArray
       );
-      getNodesByType(response[2].query, 'Field').forEach(field => {
+      getNodesByType(response[2].query, "Field").forEach((field) => {
         expect(field.name.value).toMatch(/addTodo|__typename/);
       });
-    });
+    });*/
   });
 });
 
@@ -646,7 +617,7 @@ describe('interface returned in mutation', () => {
         query {
           products {
             id
-            text
+            name
             price
             tax
           }
@@ -676,26 +647,15 @@ describe('interface returned in mutation', () => {
       toArray
     );
 
-    expect(print(response[1].query)).toMatchInlineSnapshot(`
-      "mutation MyMutation {
-        addProduct {
-          ...SimpleProduct_PopulateFragment_0
-          ...ComplexProduct_PopulateFragment_0
-        }
-      }
-
-      fragment SimpleProduct_PopulateFragment_0 on SimpleProduct {
-        id
-        price
-      }
-
-      fragment ComplexProduct_PopulateFragment_0 on ComplexProduct {
-        id
-        price
-        tax
-      }
-      "
-    `);
+    expect(print(response[1].query)).toBe(`mutation MyMutation {
+  addProduct {
+    id
+    name
+    price
+    tax
+  }
+}
+`);
   });
 });
 
@@ -708,7 +668,7 @@ describe('nested interfaces', () => {
         query {
           products {
             id
-            text
+            name
             price
             tax
             store {
@@ -744,36 +704,20 @@ describe('nested interfaces', () => {
       toArray
     );
 
-    expect(print(response[1].query)).toMatchInlineSnapshot(`
-      "mutation MyMutation {
-        addProduct {
-          ...SimpleProduct_PopulateFragment_0
-          ...ComplexProduct_PopulateFragment_0
-        }
-      }
-
-      fragment SimpleProduct_PopulateFragment_0 on SimpleProduct {
-        id
-        price
-        store {
-          id
-          name
-          address
-        }
-      }
-
-      fragment ComplexProduct_PopulateFragment_0 on ComplexProduct {
-        id
-        price
-        tax
-        store {
-          id
-          name
-          website
-        }
-      }
-      "
-    `);
+    expect(print(response[1].query)).toBe(`mutation MyMutation {
+  addProduct {
+    id
+    name
+    price
+    tax
+    store {
+      id
+      name
+      address
+      website
+    }
+  }
+}
+`);
   });
 });
-*/

--- a/exchanges/populate/src/populateExchange.test.ts
+++ b/exchanges/populate/src/populateExchange.test.ts
@@ -164,18 +164,10 @@ describe('nested fragment', () => {
 
     expect(print(response[1].query)).toBe(`mutation MyMutation {
   updateTodo {
-    ...Todo_PopulateFragment_0
-  }
-}
-
-fragment Todo_PopulateFragment_0 on Todo {
-  ...TodoFragment
-}
-
-fragment TodoFragment on Todo {
-  id
-  author {
     id
+    author {
+      id
+    }
   }
 }
 `);
@@ -203,14 +195,12 @@ describe('on mutation', () => {
         populateExchange({ schema })(exchangeArgs),
         toArray
       );
-      expect(print(response[0].query)).toMatchInlineSnapshot(`
-        "mutation MyMutation {
-          addTodo {
-            __typename
-          }
-        }
-        "
-      `);
+      expect(print(response[0].query)).toBe(`mutation MyMutation {
+  addTodo {
+    __typename
+  }
+}
+`);
     });
   });
 });
@@ -262,32 +252,22 @@ describe('on query -> mutation', () => {
         toArray
       );
 
-      expect(print(response[1].query)).toMatchInlineSnapshot(`
-        "mutation MyMutation {
-          addTodo {
-            ...Todo_PopulateFragment_0
-            ...Todo_PopulateFragment_1
-          }
-        }
-
-        fragment Todo_PopulateFragment_0 on Todo {
-          id
-          text
-          creator {
-            id
-            name
-          }
-        }
-
-        fragment Todo_PopulateFragment_1 on Todo {
-          text
-        }
-        "
-      `);
+      expect(print(response[1].query)).toBe(`mutation MyMutation {
+  addTodo {
+    id
+    text
+    creator {
+      id
+      name
+    }
+    text
+  }
+}
+`);
     });
   });
 });
-
+/*
 describe('on (query w/ fragment) -> mutation', () => {
   const queryOp = makeOperation(
     'query',
@@ -796,3 +776,4 @@ describe('nested interfaces', () => {
     `);
   });
 });
+*/

--- a/exchanges/populate/src/populateExchange.test.ts
+++ b/exchanges/populate/src/populateExchange.test.ts
@@ -28,7 +28,6 @@ const schemaDef = `
     name: String!
     age: Int!
     todos: [Todo]
-    projectMemberships: ProjectMemberships
   }
 
   type Todo implements Node {

--- a/exchanges/populate/src/populateExchange.ts
+++ b/exchanges/populate/src/populateExchange.ts
@@ -289,9 +289,15 @@ export const extractSelectionsFromQuery = (
       if (node.kind === Kind.FRAGMENT_DEFINITION) {
         extractedFragments.push(node);
       } else if (node.kind === Kind.FIELD && node.selectionSet) {
-        const type = unwrapType(
-          resolveFields(schema, visits)[node.name.value].type
-        );
+        const resolvedFields = resolveFields(schema, visits);
+
+        const fieldType = resolvedFields[node.name.value];
+
+        const type = fieldType && unwrapType(fieldType.type);
+
+        if (!type) {
+          return;
+        }
 
         visits.push(node.name.value);
 
@@ -311,7 +317,7 @@ export const extractSelectionsFromQuery = (
               ),
             });
           });
-        } else if (type) {
+        } else {
           newFragments.push({
             kind: Kind.FRAGMENT_DEFINITION,
             typeCondition: {

--- a/exchanges/populate/src/populateExchange.ts
+++ b/exchanges/populate/src/populateExchange.ts
@@ -8,10 +8,11 @@ import {
   isCompositeType,
   isAbstractType,
   Kind,
-  SelectionSetNode,
   GraphQLObjectType,
   SelectionNode,
   valueFromASTUntyped,
+  GraphQLScalarType,
+  FieldNode,
 } from 'graphql';
 
 import { pipe, tap, map } from 'wonka';
@@ -24,7 +25,7 @@ import {
   unwrapType,
   createNameNode,
 } from './helpers/node';
-import { traverse, resolveFields } from './helpers/traverse';
+import { traverse } from './helpers/traverse';
 
 interface PopulateExchangeOpts {
   schema: IntrospectionQuery;
@@ -33,7 +34,8 @@ interface PopulateExchangeOpts {
 /** @populate stores information per each type it finds */
 type TypeKey = GraphQLObjectType | GraphQLInterfaceType;
 /** @populate stores all known fields per each type key */
-type TypeFields = Map<TypeKey, Record<string, FieldUsage>>;
+type FieldValue = Record<string, FieldUsage>;
+type TypeFields = Map<TypeKey, FieldValue>;
 /** @populate stores all fields returning a specific type */
 type TypeParents = Map<TypeKey, Set<FieldUsage>>;
 /** Describes information about a given field, i.e. type (owner), arguments, how many operations use this field */
@@ -56,8 +58,6 @@ export const populateExchange = ({
   const activeOperations = new Set<number>();
   /** Collection of fragments used by the user. */
   const userFragments: UserFragmentMap = makeDict();
-  /** Collection of actively in use type fragments. */
-  const activeTypeFragments: TypeFragmentMap = makeDict();
 
   // State of the global types & their fields
   const typeFields: TypeFields = new Map();
@@ -83,6 +83,19 @@ export const populateExchange = ({
       let args: null | Record<string, any> = null;
       for (let i = 0; i < selections.length; i++) {
         const selection = selections[i];
+
+        if (selection.kind === Kind.FRAGMENT_SPREAD) {
+          const fragmentName = getName(selection);
+
+          const fragment = userFragments[fragmentName];
+
+          if (fragment) {
+            readFromSelectionSet(type, fragment.selectionSet.selections);
+          }
+
+          continue;
+        }
+
         if (selection.kind !== Kind.FIELD) continue;
 
         const fieldName = selection.name.value;
@@ -136,14 +149,18 @@ export const populateExchange = ({
   };
 
   const readFromQuery = (node: DocumentNode) => {
-    for (let i = 0; i < node.definitions.length; i++) {
+    for (let i = node.definitions.length; i--; ) {
       const definition = node.definitions[i];
-      if (definition.kind !== Kind.OPERATION_DEFINITION) continue;
-      const type = schema.getQueryType()!;
-      readFromSelectionSet(
-        unwrapType(type) as GraphQLObjectType,
-        definition.selectionSet.selections!
-      );
+
+      if (definition.kind === Kind.FRAGMENT_DEFINITION) {
+        userFragments[getName(definition)] = definition;
+      } else if (definition.kind === Kind.OPERATION_DEFINITION) {
+        const type = schema.getQueryType()!;
+        readFromSelectionSet(
+          unwrapType(type) as GraphQLObjectType,
+          definition.selectionSet.selections!
+        );
+      }
     }
   };
 
@@ -153,21 +170,9 @@ export const populateExchange = ({
       return op;
     }
 
-    const activeSelections: TypeFragmentMap = makeDict();
-    for (const name in activeTypeFragments) {
-      activeSelections[name] = activeTypeFragments[name].filter(s =>
-        activeOperations.has(s.key)
-      );
-    }
-
     return {
       ...op,
-      query: addFragmentsToQuery(
-        schema,
-        op.query,
-        activeSelections,
-        userFragments
-      ),
+      query: addSelectionsToMutation(schema, op.query, typeFields),
     };
   };
 
@@ -184,27 +189,11 @@ export const populateExchange = ({
 
     parsedOperations.add(key);
     currentVariables = variables || {};
+
+    //do not create fragments from selection set
+    //use user fragments and populate typeFields
+    //embed this logic in readFromQuery? or extract selection from fragments, then pass it to readFromQuery?
     readFromQuery(query);
-
-    const [extractedFragments, newFragments] = extractSelectionsFromQuery(
-      schema,
-      query
-    );
-
-    for (let i = 0, l = extractedFragments.length; i < l; i++) {
-      const fragment = extractedFragments[i];
-      userFragments[getName(fragment)] = fragment;
-    }
-
-    for (let i = 0, l = newFragments.length; i < l; i++) {
-      const fragment = newFragments[i];
-      const type = getName(fragment.typeCondition);
-      const current =
-        activeTypeFragments[type] || (activeTypeFragments[type] = []);
-
-      (fragment as any).name.value += current.length;
-      current.push({ key, fragment });
-    }
   };
 
   const handleIncomingTeardown = ({ key, kind }: Operation) => {
@@ -229,165 +218,47 @@ type UserFragmentMap<T extends string = string> = Record<
   FragmentDefinitionNode
 >;
 
-type TypeFragmentMap<T extends string = string> = Record<T, TypeFragment[]>;
-
-interface TypeFragment {
-  /** Operation key where selection set is being used. */
-  key: number;
-  /** Selection set. */
-  fragment: FragmentDefinitionNode;
-}
-
-/** Gets typed selection sets and fragments from query */
-export const extractSelectionsFromQuery = (
-  schema: GraphQLSchema,
-  query: DocumentNode
-) => {
-  const extractedFragments: FragmentDefinitionNode[] = [];
-  const newFragments: FragmentDefinitionNode[] = [];
-
-  const sanitizeSelectionSet = (
-    selectionSet: SelectionSetNode,
-    type: string
-  ) => {
-    const selections: SelectionNode[] = [];
-    const validTypes = (schema.getType(type) as GraphQLObjectType).getFields();
-    const validTypeProperties = Object.keys(validTypes);
-
-    selectionSet.selections.forEach(selection => {
-      if (selection.kind === Kind.FIELD) {
-        if (validTypeProperties.indexOf(selection.name.value) !== -1) {
-          if (selection.selectionSet) {
-            selections.push({
-              ...selection,
-              selectionSet: sanitizeSelectionSet(
-                selection.selectionSet,
-                unwrapType(validTypes[selection.name.value].type)!.toString()
-              ),
-            });
-          } else {
-            selections.push(selection);
-          }
-        }
-      } else {
-        selections.push(selection);
-      }
-    });
-
-    return { ...selectionSet, selections };
-  };
-
-  const visits: string[] = [];
-
-  traverse(
-    query,
-    node => {
-      if (node.kind === Kind.FRAGMENT_DEFINITION) {
-        extractedFragments.push(node);
-      } else if (node.kind === Kind.FIELD && node.selectionSet) {
-        const resolvedFields = resolveFields(schema, visits);
-
-        const fieldType = resolvedFields[node.name.value];
-
-        const type = fieldType && unwrapType(fieldType.type);
-
-        if (!type) {
-          return;
-        }
-
-        visits.push(node.name.value);
-
-        if (isAbstractType(type)) {
-          const types = schema.getPossibleTypes(type);
-          types.forEach(t => {
-            newFragments.push({
-              kind: Kind.FRAGMENT_DEFINITION,
-              typeCondition: {
-                kind: Kind.NAMED_TYPE,
-                name: createNameNode(t.toString()),
-              },
-              name: createNameNode(`${t.toString()}_PopulateFragment_`),
-              selectionSet: sanitizeSelectionSet(
-                node.selectionSet as SelectionSetNode,
-                t.toString()
-              ),
-            });
-          });
-        } else {
-          newFragments.push({
-            kind: Kind.FRAGMENT_DEFINITION,
-            typeCondition: {
-              kind: Kind.NAMED_TYPE,
-              name: createNameNode(type.toString()),
-            },
-            name: createNameNode(`${type.toString()}_PopulateFragment_`),
-            selectionSet: node.selectionSet,
-          });
-        }
-      }
-    },
-    node => {
-      if (node.kind === Kind.FIELD && node.selectionSet) visits.pop();
-    }
-  );
-
-  return [extractedFragments, newFragments];
-};
+type SelectionMap = Map<string, Set<string>>;
 
 /** Replaces populate decorator with fragment spreads + fragments. */
-export const addFragmentsToQuery = (
+export const addSelectionsToMutation = (
   schema: GraphQLSchema,
   query: DocumentNode,
-  activeTypeFragments: TypeFragmentMap,
-  userFragments: UserFragmentMap
+  typeFields: TypeFields
 ): DocumentNode => {
-  const requiredUserFragments: Record<
-    string,
-    FragmentDefinitionNode
-  > = makeDict();
-
-  const additionalFragments: Record<
-    string,
-    FragmentDefinitionNode
-  > = makeDict();
-
   /** Fragments provided and used by the current query */
   const existingFragmentsForQuery: Set<string> = new Set();
 
-  return traverse(
-    query,
-    node => {
-      if (node.kind === Kind.DOCUMENT) {
-        node.definitions.reduce((set, definition) => {
-          if (definition.kind === Kind.FRAGMENT_DEFINITION) {
-            set.add(definition.name.value);
-          }
-
-          return set;
-        }, existingFragmentsForQuery);
-      } else if (
-        node.kind === Kind.OPERATION_DEFINITION ||
-        node.kind === Kind.FIELD
-      ) {
-        if (!node.directives) return;
-
-        const directives = node.directives.filter(
-          d => getName(d) !== 'populate'
-        );
-
-        if (directives.length === node.directives.length) return;
-
-        if (node.kind === Kind.OPERATION_DEFINITION) {
-          // TODO: gather dependent queries and update mutation operation with multiple
-          // query operations.
-
-          return {
-            ...node,
-            directives,
-          };
+  return traverse(query, node => {
+    if (node.kind === Kind.DOCUMENT) {
+      node.definitions.reduce((set, definition) => {
+        if (definition.kind === Kind.FRAGMENT_DEFINITION) {
+          set.add(definition.name.value);
         }
 
-        /*if (node.name.value === "viewer") {
+        return set;
+      }, existingFragmentsForQuery);
+    } else if (
+      node.kind === Kind.OPERATION_DEFINITION ||
+      node.kind === Kind.FIELD
+    ) {
+      if (!node.directives) return;
+
+      const directives = node.directives.filter(d => getName(d) !== 'populate');
+
+      if (directives.length === node.directives.length) return;
+
+      if (node.kind === Kind.OPERATION_DEFINITION) {
+        // TODO: gather dependent queries and update mutation operation with multiple
+        // query operations.
+
+        return {
+          ...node,
+          directives,
+        };
+      }
+
+      /*if (node.name.value === "viewer") {
           // TODO: populate the viewer fields
           return {
             ...node,
@@ -395,117 +266,139 @@ export const addFragmentsToQuery = (
           };
         }*/
 
-        const fieldMap = schema.getMutationType()!.getFields()[node.name.value];
+      const fieldMap = schema.getMutationType()!.getFields()[node.name.value];
 
-        if (!fieldMap) return;
+      if (!fieldMap) return;
 
-        const type = unwrapType(fieldMap.type);
+      const type = unwrapType(fieldMap.type);
 
-        let possibleTypes: readonly GraphQLObjectType<any, any>[] = [];
-        if (!isCompositeType(type)) {
-          warn(
-            'Invalid type: The type `' +
-              type +
-              '` is used with @populate but does not exist.',
-            17
-          );
-        } else {
-          possibleTypes = isAbstractType(type)
-            ? schema.getPossibleTypes(type)
-            : [type];
-        }
+      let possibleTypes: readonly GraphQLObjectType<any, any>[] = [];
+      if (!isCompositeType(type)) {
+        warn(
+          'Invalid type: The type `' +
+            type +
+            '` is used with @populate but does not exist.',
+          17
+        );
+      } else {
+        possibleTypes = isAbstractType(type)
+          ? schema.getPossibleTypes(type)
+          : [type];
+      }
 
-        const newSelections = possibleTypes.reduce((p, possibleType) => {
-          let typeFrags = activeTypeFragments[possibleType.name];
-          const fragmentFields: Record<string, string> = {};
+      const inferFields = (
+        selectionMap: SelectionMap,
+        fieldValues: FieldValue,
+        parent: string
+      ) => {
+        Object.keys(fieldValues).forEach(fieldKey => {
+          const field = fieldValues[fieldKey];
 
-          if (!typeFrags) {
-            typeFrags = [];
-            const typeFields = possibleType.getFields();
-            for (const key in typeFields) {
-              const typeField = typeFields[key].type;
+          if (field.type instanceof GraphQLObjectType) {
+            typeFields.forEach((value, fieldKey) => {
+              if (fieldKey.name === field.type.name) {
+                inferFields(
+                  selectionMap,
+                  Object.keys(value).reduce((prev, currentKey) => {
+                    if (value[currentKey].type instanceof GraphQLScalarType) {
+                      return {
+                        ...prev,
+                        [currentKey]: value[currentKey],
+                      };
+                    }
+
+                    return prev;
+                  }, {}),
+                  field.fieldName
+                );
+              }
+            });
+          } else {
+            selectionMap.set(
+              parent,
+              (selectionMap.get(parent) || new Set()).add(field.fieldName)
+            );
+          }
+        });
+      };
+
+      const selectionMap = possibleTypes.reduce((p, possibleType) => {
+        typeFields.forEach((value, fieldKey) => {
+          if (fieldKey.name === possibleType.name) {
+            inferFields(p, value, '');
+          } else {
+            const possibleTypeFields = possibleType.getFields();
+            for (const ptKey in possibleTypeFields) {
+              const typeField = possibleTypeFields[ptKey].type;
               if (
                 typeField instanceof GraphQLObjectType &&
-                activeTypeFragments[typeField.name]
+                fieldKey.name === typeField.name
               ) {
-                activeTypeFragments[typeField.name].forEach(fragmentMap => {
-                  fragmentFields[getName(fragmentMap.fragment)] = key;
-
-                  typeFrags.push(fragmentMap);
-                });
+                inferFields(p, value, ptKey);
               }
             }
           }
+        });
 
-          for (let i = 0, l = typeFrags.length; i < l; i++) {
-            const { fragment } = typeFrags[i];
-            const fragmentName = getName(fragment);
+        return p;
+      }, new Map() as SelectionMap);
 
-            if (fragmentFields[fragmentName]) {
-              p.push({
+      const newSelections: Array<FieldNode> = addSelections(selectionMap);
+
+      const existingSelections = getSelectionSet(node);
+
+      const selections =
+        existingSelections.length || newSelections.length
+          ? [...newSelections, ...existingSelections]
+          : [
+              {
                 kind: Kind.FIELD,
-                name: createNameNode(fragmentFields[fragmentName]),
-                selectionSet: {
-                  kind: Kind.SELECTION_SET,
-                  selections: fragment.selectionSet.selections,
-                },
-              });
-            } else {
-              fragment.selectionSet.selections.forEach(selection => {
-                if (
-                  selection.kind === Kind.FRAGMENT_SPREAD &&
-                  userFragments[selection.name.value]
-                ) {
-                  p = p.concat(
-                    userFragments[selection.name.value].selectionSet.selections
-                  );
-                } else if (selection.kind === Kind.FIELD) {
-                  p.push(selection);
-                }
-              });
-            }
-          }
+                name: createNameNode('__typename'),
+              },
+            ];
 
-          return p;
-        }, [] as SelectionNode[]);
-
-        const existingSelections = getSelectionSet(node);
-
-        const selections =
-          existingSelections.length || newSelections.length
-            ? [...newSelections, ...existingSelections]
-            : [
-                {
-                  kind: Kind.FIELD,
-                  name: createNameNode('__typename'),
-                },
-              ];
-
-        return {
-          ...node,
-          directives,
-          selectionSet: {
-            kind: Kind.SELECTION_SET,
-            selections,
-          },
-        };
-      }
-    },
-    node => {
-      if (node.kind === Kind.DOCUMENT) {
-        return {
-          ...node,
-          definitions: [
-            ...node.definitions,
-            ...Object.keys(additionalFragments).map(
-              key => additionalFragments[key]
-            ),
-            ...Object.keys(requiredUserFragments).map(
-              key => requiredUserFragments[key]
-            ),
-          ],
-        };
-      }
+      return {
+        ...node,
+        directives,
+        selectionSet: {
+          kind: Kind.SELECTION_SET,
+          selections,
+        },
+      };
     }
-  );
+  });
+};
+
+const addSelections = (selectionMap: SelectionMap): Array<FieldNode> => {
+  let newSelections: Array<FieldNode> = [];
+
+  const addFields = (fieldSet: Set<string>): Array<FieldNode> => {
+    const result: Array<FieldNode> = [];
+
+    fieldSet.forEach(fieldName => {
+      result.push({
+        kind: Kind.FIELD,
+        name: createNameNode(fieldName),
+      });
+    });
+
+    return result;
+  };
+
+  selectionMap.forEach((fieldSet, key) => {
+    if (key === '') {
+      newSelections = newSelections.concat(addFields(fieldSet));
+    } else {
+      newSelections.push({
+        kind: Kind.FIELD,
+        name: createNameNode(key),
+        selectionSet: {
+          kind: Kind.SELECTION_SET,
+          selections: addFields(fieldSet),
+        },
+      });
+    }
+  });
+
+  return newSelections;
 };

--- a/exchanges/populate/src/populateExchange.ts
+++ b/exchanges/populate/src/populateExchange.ts
@@ -3,125 +3,235 @@ import {
   buildClientSchema,
   FragmentDefinitionNode,
   GraphQLSchema,
+  GraphQLInterfaceType,
   IntrospectionQuery,
-  FragmentSpreadNode,
   isCompositeType,
   isAbstractType,
   Kind,
   SelectionSetNode,
   GraphQLObjectType,
   SelectionNode,
-} from 'graphql';
-import { pipe, tap, map } from 'wonka';
-import { makeOperation, Exchange, Operation } from '@urql/core';
+  valueFromASTUntyped,
+} from "graphql";
 
-import { warn } from './helpers/help';
+import { pipe, tap, map } from "wonka";
+import { Exchange, Operation, stringifyVariables } from "@urql/core";
+
+import { warn } from "./helpers/help";
 import {
   getName,
   getSelectionSet,
   unwrapType,
   createNameNode,
-} from './helpers/node';
+} from "./helpers/node";
 import {
   traverse,
   resolveFields,
   getUsedFragmentNames,
-} from './helpers/traverse';
+} from "./helpers/traverse";
 
 interface PopulateExchangeOpts {
   schema: IntrospectionQuery;
 }
 
+/** @populate stores information per each type it finds */
+type TypeKey = GraphQLObjectType | GraphQLInterfaceType;
+/** @populate stores all known fields per each type key */
+type TypeFields = Map<TypeKey, Record<string, FieldUsage>>;
+/** @populate stores all fields returning a specific type */
+type TypeParents = Map<TypeKey, Set<FieldUsage>>;
+/** Describes information about a given field, i.e. type (owner), arguments, how many operations use this field */
+interface FieldUsage {
+  type: TypeKey;
+  args: null | object;
+  fieldName: string;
+}
+
 const makeDict = (): any => Object.create(null);
 
 /** An exchange for auto-populating mutations with a required response body. */
-export const populateExchange = ({
-  schema: ogSchema,
-}: PopulateExchangeOpts): Exchange => ({ forward }) => {
-  const schema = buildClientSchema(ogSchema);
-  /** List of operation keys that have already been parsed. */
-  const parsedOperations = new Set<number>();
-  /** List of operation keys that have not been torn down. */
-  const activeOperations = new Set<number>();
-  /** Collection of fragments used by the user. */
-  const userFragments: UserFragmentMap = makeDict();
-  /** Collection of actively in use type fragments. */
-  const activeTypeFragments: TypeFragmentMap = makeDict();
+export const populateExchange =
+  ({ schema: ogSchema }: PopulateExchangeOpts): Exchange =>
+  ({ forward }) => {
+    const schema = buildClientSchema(ogSchema);
+    /** List of operation keys that have already been parsed. */
+    const parsedOperations = new Set<number>();
+    /** List of operation keys that have not been torn down. */
+    const activeOperations = new Set<number>();
+    /** Collection of fragments used by the user. */
+    const userFragments: UserFragmentMap = makeDict();
+    /** Collection of actively in use type fragments. */
+    const activeTypeFragments: TypeFragmentMap = makeDict();
 
-  /** Handle mutation and inject selections + fragments. */
-  const handleIncomingMutation = (op: Operation) => {
-    if (op.kind !== 'mutation') {
-      return op;
-    }
+    // State of the global types & their fields
+    const typeFields: TypeFields = new Map();
+    const typeParents: TypeParents = new Map();
 
-    const activeSelections: TypeFragmentMap = makeDict();
-    for (const name in activeTypeFragments) {
-      activeSelections[name] = activeTypeFragments[name].filter(s =>
-        activeOperations.has(s.key)
+    // State of the current operation
+    // const currentVisited: Set<string> = new Set();
+    let currentVariables: object = {};
+
+    const readFromSelectionSet = (
+      type: GraphQLObjectType | GraphQLInterfaceType,
+      selections: readonly SelectionNode[],
+      seenFields: Record<string, TypeKey> = {}
+    ) => {
+      if (isAbstractType(type)) {
+        // TODO: should we add this to typeParents/typeFields as well?
+        schema.getPossibleTypes(type).forEach((t) => {
+          readFromSelectionSet(t, selections, seenFields);
+        });
+      } else {
+        const fieldMap = type.getFields();
+
+        let args: null | Record<string, any> = null;
+        for (let i = 0; i < selections.length; i++) {
+          const selection = selections[i];
+          if (selection.kind !== Kind.FIELD) continue;
+
+          const fieldName = selection.name.value;
+          if (!fieldMap[fieldName]) continue;
+
+          const ownerType =
+            seenFields[fieldName] || (seenFields[fieldName] = type);
+
+          let fields = typeFields.get(ownerType);
+          if (!fields) typeFields.set(type, (fields = {}));
+
+          const childType = unwrapType(
+            fieldMap[fieldName].type
+          ) as GraphQLObjectType;
+
+          if (selection.arguments && selection.arguments.length) {
+            args = {};
+            for (let j = 0; j < selection.arguments.length; j++) {
+              const argNode = selection.arguments[j];
+              args[argNode.name.value] = valueFromASTUntyped(
+                argNode.value,
+                currentVariables
+              );
+            }
+          }
+
+          const fieldKey = args
+            ? `${fieldName}:${stringifyVariables(args)}`
+            : fieldName;
+
+          const field =
+            fields[fieldKey] ||
+            (fields[fieldKey] = {
+              type: childType,
+              args,
+              fieldName,
+            });
+
+          if (selection.selectionSet) {
+            let parents = typeParents.get(childType);
+            if (!parents) {
+              parents = new Set();
+              typeParents.set(childType, parents);
+            }
+
+            parents.add(field);
+            readFromSelectionSet(childType, selection.selectionSet.selections);
+          }
+        }
+      }
+    };
+
+    const readFromQuery = (node: DocumentNode) => {
+      for (let i = 0; i < node.definitions.length; i++) {
+        const definition = node.definitions[i];
+        if (definition.kind !== Kind.OPERATION_DEFINITION) continue;
+        const type = schema.getQueryType()!;
+        readFromSelectionSet(
+          unwrapType(type) as GraphQLObjectType,
+          definition.selectionSet.selections!
+        );
+      }
+    };
+
+    /** Handle mutation and inject selections + fragments. */
+    const handleIncomingMutation = (op: Operation) => {
+      if (op.kind !== "mutation") {
+        return op;
+      }
+
+      const activeSelections: TypeFragmentMap = makeDict();
+      for (const name in activeTypeFragments) {
+        activeSelections[name] = activeTypeFragments[name].filter((s) =>
+          activeOperations.has(s.key)
+        );
+      }
+
+      return {
+        ...op,
+        query: addFragmentsToQuery(
+          schema,
+          op.query,
+          activeSelections,
+          userFragments
+        ),
+      };
+    };
+
+    /** Handle query and extract fragments. */
+    const handleIncomingQuery = ({
+      key,
+      kind,
+      query,
+      variables,
+    }: Operation) => {
+      if (kind !== "query") {
+        return;
+      }
+
+      activeOperations.add(key);
+      if (parsedOperations.has(key)) {
+        return;
+      }
+
+      parsedOperations.add(key);
+      currentVariables = variables || {};
+      readFromQuery(query);
+
+      const [extractedFragments, newFragments] = extractSelectionsFromQuery(
+        schema,
+        query
       );
-    }
 
-    const newOperation = makeOperation(op.kind, op);
-    newOperation.query = addFragmentsToQuery(
-      schema,
-      op.query,
-      activeSelections,
-      userFragments
-    );
+      for (let i = 0, l = extractedFragments.length; i < l; i++) {
+        const fragment = extractedFragments[i];
+        userFragments[getName(fragment)] = fragment;
+      }
 
-    return newOperation;
+      for (let i = 0, l = newFragments.length; i < l; i++) {
+        const fragment = newFragments[i];
+        const type = getName(fragment.typeCondition);
+        const current =
+          activeTypeFragments[type] || (activeTypeFragments[type] = []);
+
+        (fragment as any).name.value += current.length;
+        current.push({ key, fragment });
+      }
+    };
+
+    const handleIncomingTeardown = ({ key, kind }: Operation) => {
+      if (kind === "teardown") {
+        activeOperations.delete(key);
+      }
+    };
+
+    return (ops$) => {
+      return pipe(
+        ops$,
+        tap(handleIncomingQuery),
+        tap(handleIncomingTeardown),
+        map(handleIncomingMutation),
+        forward
+      );
+    };
   };
-
-  /** Handle query and extract fragments. */
-  const handleIncomingQuery = ({ key, kind, query }: Operation) => {
-    if (kind !== 'query') {
-      return;
-    }
-
-    activeOperations.add(key);
-    if (parsedOperations.has(key)) {
-      return;
-    }
-
-    parsedOperations.add(key);
-
-    const [extractedFragments, newFragments] = extractSelectionsFromQuery(
-      schema,
-      query
-    );
-
-    for (let i = 0, l = extractedFragments.length; i < l; i++) {
-      const fragment = extractedFragments[i];
-      userFragments[getName(fragment)] = fragment;
-    }
-
-    for (let i = 0, l = newFragments.length; i < l; i++) {
-      const fragment = newFragments[i];
-      const type = getName(fragment.typeCondition);
-      const current =
-        activeTypeFragments[type] || (activeTypeFragments[type] = []);
-
-      (fragment as any).name.value += current.length;
-      current.push({ key, fragment });
-    }
-  };
-
-  const handleIncomingTeardown = ({ key, kind }: Operation) => {
-    if (kind === 'teardown') {
-      activeOperations.delete(key);
-    }
-  };
-
-  return ops$ => {
-    return pipe(
-      ops$,
-      tap(handleIncomingQuery),
-      tap(handleIncomingTeardown),
-      map(handleIncomingMutation),
-      forward
-    );
-  };
-};
 
 type UserFragmentMap<T extends string = string> = Record<
   T,
@@ -151,10 +261,11 @@ export const extractSelectionsFromQuery = (
   ) => {
     const selections: SelectionNode[] = [];
     const validTypes = (schema.getType(type) as GraphQLObjectType).getFields();
+    const validTypeProperties = Object.keys(validTypes);
 
-    selectionSet.selections.forEach(selection => {
+    selectionSet.selections.forEach((selection) => {
       if (selection.kind === Kind.FIELD) {
-        if (validTypes[selection.name.value]) {
+        if (validTypeProperties.includes(selection.name.value)) {
           if (selection.selectionSet) {
             selections.push({
               ...selection,
@@ -179,7 +290,7 @@ export const extractSelectionsFromQuery = (
 
   traverse(
     query,
-    node => {
+    (node) => {
       if (node.kind === Kind.FRAGMENT_DEFINITION) {
         extractedFragments.push(node);
       } else if (node.kind === Kind.FIELD && node.selectionSet) {
@@ -191,7 +302,7 @@ export const extractSelectionsFromQuery = (
 
         if (isAbstractType(type)) {
           const types = schema.getPossibleTypes(type);
-          types.forEach(t => {
+          types.forEach((t) => {
             newFragments.push({
               kind: Kind.FRAGMENT_DEFINITION,
               typeCondition: {
@@ -218,7 +329,7 @@ export const extractSelectionsFromQuery = (
         }
       }
     },
-    node => {
+    (node) => {
       if (node.kind === Kind.FIELD && node.selectionSet) visits.pop();
     }
   );
@@ -233,22 +344,18 @@ export const addFragmentsToQuery = (
   activeTypeFragments: TypeFragmentMap,
   userFragments: UserFragmentMap
 ): DocumentNode => {
-  const requiredUserFragments: Record<
-    string,
-    FragmentDefinitionNode
-  > = makeDict();
+  const requiredUserFragments: Record<string, FragmentDefinitionNode> =
+    makeDict();
 
-  const additionalFragments: Record<
-    string,
-    FragmentDefinitionNode
-  > = makeDict();
+  const additionalFragments: Record<string, FragmentDefinitionNode> =
+    makeDict();
 
   /** Fragments provided and used by the current query */
   const existingFragmentsForQuery: Set<string> = new Set();
 
   return traverse(
     query,
-    node => {
+    (node) => {
       if (node.kind === Kind.DOCUMENT) {
         node.definitions.reduce((set, definition) => {
           if (definition.kind === Kind.FRAGMENT_DEFINITION) {
@@ -257,24 +364,48 @@ export const addFragmentsToQuery = (
 
           return set;
         }, existingFragmentsForQuery);
-      } else if (node.kind === Kind.FIELD) {
+      } else if (
+        node.kind === Kind.OPERATION_DEFINITION ||
+        node.kind === Kind.FIELD
+      ) {
         if (!node.directives) return;
 
         const directives = node.directives.filter(
-          d => getName(d) !== 'populate'
+          (d) => getName(d) !== "populate"
         );
+
         if (directives.length === node.directives.length) return;
 
-        const type = unwrapType(
-          schema.getMutationType()!.getFields()[node.name.value].type
-        );
+        if (node.kind === Kind.OPERATION_DEFINITION) {
+          // TODO: gather dependent queries and update mutation operation with multiple
+          // query operations.
+
+          return {
+            ...node,
+            directives,
+          };
+        }
+
+        /*if (node.name.value === "viewer") {
+          // TODO: populate the viewer fields
+          return {
+            ...node,
+            directives,
+          };
+        }*/
+
+        const fieldMap = schema.getMutationType()!.getFields()[node.name.value];
+
+        if (!fieldMap) return;
+
+        const type = unwrapType(fieldMap.type);
 
         let possibleTypes: readonly GraphQLObjectType<any, any>[] = [];
         if (!isCompositeType(type)) {
           warn(
-            'Invalid type: The type `' +
+            "Invalid type: The type `" +
               type +
-              '` is used with @populate but does not exist.',
+              "` is used with @populate but does not exist.",
             17
           );
         } else {
@@ -284,9 +415,25 @@ export const addFragmentsToQuery = (
         }
 
         const newSelections = possibleTypes.reduce((p, possibleType) => {
-          const typeFrags = activeTypeFragments[possibleType.name];
+          let typeFrags = activeTypeFragments[possibleType.name];
+          const fragmentFields: Record<string, string> = {};
+
           if (!typeFrags) {
-            return p;
+            typeFrags = [];
+            const typeFields = possibleType.getFields();
+            for (const key in typeFields) {
+              const typeField = typeFields[key].type;
+              if (
+                typeField instanceof GraphQLObjectType &&
+                activeTypeFragments[typeField.name]
+              ) {
+                activeTypeFragments[typeField.name].forEach((fragmentMap) => {
+                  fragmentFields[getName(fragmentMap.fragment)] = key;
+
+                  typeFrags.push(fragmentMap);
+                });
+              }
+            }
           }
 
           for (let i = 0, l = typeFrags.length; i < l; i++) {
@@ -305,14 +452,27 @@ export const addFragmentsToQuery = (
             // Add fragment for insertion at Document node
             additionalFragments[fragmentName] = fragment;
 
-            p.push({
+            const fragmentSpreadNode = {
               kind: Kind.FRAGMENT_SPREAD,
               name: createNameNode(fragmentName),
-            });
+            };
+
+            if (fragmentFields[fragmentName]) {
+              p.push({
+                kind: Kind.FIELD,
+                name: createNameNode(fragmentFields[fragmentName]),
+                selectionSet: {
+                  kind: Kind.SELECTION_SET,
+                  selections: [fragmentSpreadNode],
+                },
+              });
+            } else {
+              p.push(fragmentSpreadNode);
+            }
           }
 
           return p;
-        }, [] as FragmentSpreadNode[]);
+        }, [] as SelectionNode[]);
 
         const existingSelections = getSelectionSet(node);
 
@@ -322,7 +482,7 @@ export const addFragmentsToQuery = (
             : [
                 {
                   kind: Kind.FIELD,
-                  name: createNameNode('__typename'),
+                  name: createNameNode("__typename"),
                 },
               ];
 
@@ -336,17 +496,17 @@ export const addFragmentsToQuery = (
         };
       }
     },
-    node => {
+    (node) => {
       if (node.kind === Kind.DOCUMENT) {
         return {
           ...node,
           definitions: [
             ...node.definitions,
             ...Object.keys(additionalFragments).map(
-              key => additionalFragments[key]
+              (key) => additionalFragments[key]
             ),
             ...Object.keys(requiredUserFragments).map(
-              key => requiredUserFragments[key]
+              (key) => requiredUserFragments[key]
             ),
           ],
         };

--- a/exchanges/populate/src/populateExchange.ts
+++ b/exchanges/populate/src/populateExchange.ts
@@ -12,23 +12,23 @@ import {
   GraphQLObjectType,
   SelectionNode,
   valueFromASTUntyped,
-} from "graphql";
+} from 'graphql';
 
-import { pipe, tap, map } from "wonka";
-import { Exchange, Operation, stringifyVariables } from "@urql/core";
+import { pipe, tap, map } from 'wonka';
+import { Exchange, Operation, stringifyVariables } from '@urql/core';
 
-import { warn } from "./helpers/help";
+import { warn } from './helpers/help';
 import {
   getName,
   getSelectionSet,
   unwrapType,
   createNameNode,
-} from "./helpers/node";
+} from './helpers/node';
 import {
   traverse,
   resolveFields,
   getUsedFragmentNames,
-} from "./helpers/traverse";
+} from './helpers/traverse';
 
 interface PopulateExchangeOpts {
   schema: IntrospectionQuery;
@@ -50,188 +50,183 @@ interface FieldUsage {
 const makeDict = (): any => Object.create(null);
 
 /** An exchange for auto-populating mutations with a required response body. */
-export const populateExchange =
-  ({ schema: ogSchema }: PopulateExchangeOpts): Exchange =>
-  ({ forward }) => {
-    const schema = buildClientSchema(ogSchema);
-    /** List of operation keys that have already been parsed. */
-    const parsedOperations = new Set<number>();
-    /** List of operation keys that have not been torn down. */
-    const activeOperations = new Set<number>();
-    /** Collection of fragments used by the user. */
-    const userFragments: UserFragmentMap = makeDict();
-    /** Collection of actively in use type fragments. */
-    const activeTypeFragments: TypeFragmentMap = makeDict();
+export const populateExchange = ({
+  schema: ogSchema,
+}: PopulateExchangeOpts): Exchange => ({ forward }) => {
+  const schema = buildClientSchema(ogSchema);
+  /** List of operation keys that have already been parsed. */
+  const parsedOperations = new Set<number>();
+  /** List of operation keys that have not been torn down. */
+  const activeOperations = new Set<number>();
+  /** Collection of fragments used by the user. */
+  const userFragments: UserFragmentMap = makeDict();
+  /** Collection of actively in use type fragments. */
+  const activeTypeFragments: TypeFragmentMap = makeDict();
 
-    // State of the global types & their fields
-    const typeFields: TypeFields = new Map();
-    const typeParents: TypeParents = new Map();
+  // State of the global types & their fields
+  const typeFields: TypeFields = new Map();
+  const typeParents: TypeParents = new Map();
 
-    // State of the current operation
-    // const currentVisited: Set<string> = new Set();
-    let currentVariables: object = {};
+  // State of the current operation
+  // const currentVisited: Set<string> = new Set();
+  let currentVariables: object = {};
 
-    const readFromSelectionSet = (
-      type: GraphQLObjectType | GraphQLInterfaceType,
-      selections: readonly SelectionNode[],
-      seenFields: Record<string, TypeKey> = {}
-    ) => {
-      if (isAbstractType(type)) {
-        // TODO: should we add this to typeParents/typeFields as well?
-        schema.getPossibleTypes(type).forEach((t) => {
-          readFromSelectionSet(t, selections, seenFields);
-        });
-      } else {
-        const fieldMap = type.getFields();
+  const readFromSelectionSet = (
+    type: GraphQLObjectType | GraphQLInterfaceType,
+    selections: readonly SelectionNode[],
+    seenFields: Record<string, TypeKey> = {}
+  ) => {
+    if (isAbstractType(type)) {
+      // TODO: should we add this to typeParents/typeFields as well?
+      schema.getPossibleTypes(type).forEach(t => {
+        readFromSelectionSet(t, selections, seenFields);
+      });
+    } else {
+      const fieldMap = type.getFields();
 
-        let args: null | Record<string, any> = null;
-        for (let i = 0; i < selections.length; i++) {
-          const selection = selections[i];
-          if (selection.kind !== Kind.FIELD) continue;
+      let args: null | Record<string, any> = null;
+      for (let i = 0; i < selections.length; i++) {
+        const selection = selections[i];
+        if (selection.kind !== Kind.FIELD) continue;
 
-          const fieldName = selection.name.value;
-          if (!fieldMap[fieldName]) continue;
+        const fieldName = selection.name.value;
+        if (!fieldMap[fieldName]) continue;
 
-          const ownerType =
-            seenFields[fieldName] || (seenFields[fieldName] = type);
+        const ownerType =
+          seenFields[fieldName] || (seenFields[fieldName] = type);
 
-          let fields = typeFields.get(ownerType);
-          if (!fields) typeFields.set(type, (fields = {}));
+        let fields = typeFields.get(ownerType);
+        if (!fields) typeFields.set(type, (fields = {}));
 
-          const childType = unwrapType(
-            fieldMap[fieldName].type
-          ) as GraphQLObjectType;
+        const childType = unwrapType(
+          fieldMap[fieldName].type
+        ) as GraphQLObjectType;
 
-          if (selection.arguments && selection.arguments.length) {
-            args = {};
-            for (let j = 0; j < selection.arguments.length; j++) {
-              const argNode = selection.arguments[j];
-              args[argNode.name.value] = valueFromASTUntyped(
-                argNode.value,
-                currentVariables
-              );
-            }
-          }
-
-          const fieldKey = args
-            ? `${fieldName}:${stringifyVariables(args)}`
-            : fieldName;
-
-          const field =
-            fields[fieldKey] ||
-            (fields[fieldKey] = {
-              type: childType,
-              args,
-              fieldName,
-            });
-
-          if (selection.selectionSet) {
-            let parents = typeParents.get(childType);
-            if (!parents) {
-              parents = new Set();
-              typeParents.set(childType, parents);
-            }
-
-            parents.add(field);
-            readFromSelectionSet(childType, selection.selectionSet.selections);
+        if (selection.arguments && selection.arguments.length) {
+          args = {};
+          for (let j = 0; j < selection.arguments.length; j++) {
+            const argNode = selection.arguments[j];
+            args[argNode.name.value] = valueFromASTUntyped(
+              argNode.value,
+              currentVariables
+            );
           }
         }
+
+        const fieldKey = args
+          ? `${fieldName}:${stringifyVariables(args)}`
+          : fieldName;
+
+        const field =
+          fields[fieldKey] ||
+          (fields[fieldKey] = {
+            type: childType,
+            args,
+            fieldName,
+          });
+
+        if (selection.selectionSet) {
+          let parents = typeParents.get(childType);
+          if (!parents) {
+            parents = new Set();
+            typeParents.set(childType, parents);
+          }
+
+          parents.add(field);
+          readFromSelectionSet(childType, selection.selectionSet.selections);
+        }
       }
-    };
+    }
+  };
 
-    const readFromQuery = (node: DocumentNode) => {
-      for (let i = 0; i < node.definitions.length; i++) {
-        const definition = node.definitions[i];
-        if (definition.kind !== Kind.OPERATION_DEFINITION) continue;
-        const type = schema.getQueryType()!;
-        readFromSelectionSet(
-          unwrapType(type) as GraphQLObjectType,
-          definition.selectionSet.selections!
-        );
-      }
-    };
+  const readFromQuery = (node: DocumentNode) => {
+    for (let i = 0; i < node.definitions.length; i++) {
+      const definition = node.definitions[i];
+      if (definition.kind !== Kind.OPERATION_DEFINITION) continue;
+      const type = schema.getQueryType()!;
+      readFromSelectionSet(
+        unwrapType(type) as GraphQLObjectType,
+        definition.selectionSet.selections!
+      );
+    }
+  };
 
-    /** Handle mutation and inject selections + fragments. */
-    const handleIncomingMutation = (op: Operation) => {
-      if (op.kind !== "mutation") {
-        return op;
-      }
+  /** Handle mutation and inject selections + fragments. */
+  const handleIncomingMutation = (op: Operation) => {
+    if (op.kind !== 'mutation') {
+      return op;
+    }
 
-      const activeSelections: TypeFragmentMap = makeDict();
-      for (const name in activeTypeFragments) {
-        activeSelections[name] = activeTypeFragments[name].filter((s) =>
-          activeOperations.has(s.key)
-        );
-      }
+    const activeSelections: TypeFragmentMap = makeDict();
+    for (const name in activeTypeFragments) {
+      activeSelections[name] = activeTypeFragments[name].filter(s =>
+        activeOperations.has(s.key)
+      );
+    }
 
-      return {
-        ...op,
-        query: addFragmentsToQuery(
-          schema,
-          op.query,
-          activeSelections,
-          userFragments
-        ),
-      };
-    };
-
-    /** Handle query and extract fragments. */
-    const handleIncomingQuery = ({
-      key,
-      kind,
-      query,
-      variables,
-    }: Operation) => {
-      if (kind !== "query") {
-        return;
-      }
-
-      activeOperations.add(key);
-      if (parsedOperations.has(key)) {
-        return;
-      }
-
-      parsedOperations.add(key);
-      currentVariables = variables || {};
-      readFromQuery(query);
-
-      const [extractedFragments, newFragments] = extractSelectionsFromQuery(
+    return {
+      ...op,
+      query: addFragmentsToQuery(
         schema,
-        query
-      );
-
-      for (let i = 0, l = extractedFragments.length; i < l; i++) {
-        const fragment = extractedFragments[i];
-        userFragments[getName(fragment)] = fragment;
-      }
-
-      for (let i = 0, l = newFragments.length; i < l; i++) {
-        const fragment = newFragments[i];
-        const type = getName(fragment.typeCondition);
-        const current =
-          activeTypeFragments[type] || (activeTypeFragments[type] = []);
-
-        (fragment as any).name.value += current.length;
-        current.push({ key, fragment });
-      }
-    };
-
-    const handleIncomingTeardown = ({ key, kind }: Operation) => {
-      if (kind === "teardown") {
-        activeOperations.delete(key);
-      }
-    };
-
-    return (ops$) => {
-      return pipe(
-        ops$,
-        tap(handleIncomingQuery),
-        tap(handleIncomingTeardown),
-        map(handleIncomingMutation),
-        forward
-      );
+        op.query,
+        activeSelections,
+        userFragments
+      ),
     };
   };
+
+  /** Handle query and extract fragments. */
+  const handleIncomingQuery = ({ key, kind, query, variables }: Operation) => {
+    if (kind !== 'query') {
+      return;
+    }
+
+    activeOperations.add(key);
+    if (parsedOperations.has(key)) {
+      return;
+    }
+
+    parsedOperations.add(key);
+    currentVariables = variables || {};
+    readFromQuery(query);
+
+    const [extractedFragments, newFragments] = extractSelectionsFromQuery(
+      schema,
+      query
+    );
+
+    for (let i = 0, l = extractedFragments.length; i < l; i++) {
+      const fragment = extractedFragments[i];
+      userFragments[getName(fragment)] = fragment;
+    }
+
+    for (let i = 0, l = newFragments.length; i < l; i++) {
+      const fragment = newFragments[i];
+      const type = getName(fragment.typeCondition);
+      const current =
+        activeTypeFragments[type] || (activeTypeFragments[type] = []);
+
+      (fragment as any).name.value += current.length;
+      current.push({ key, fragment });
+    }
+  };
+
+  const handleIncomingTeardown = ({ key, kind }: Operation) => {
+    if (kind === 'teardown') {
+      activeOperations.delete(key);
+    }
+  };
+
+  return ops$ => {
+    return pipe(
+      ops$,
+      tap(handleIncomingQuery),
+      tap(handleIncomingTeardown),
+      map(handleIncomingMutation),
+      forward
+    );
+  };
+};
 
 type UserFragmentMap<T extends string = string> = Record<
   T,
@@ -263,7 +258,7 @@ export const extractSelectionsFromQuery = (
     const validTypes = (schema.getType(type) as GraphQLObjectType).getFields();
     const validTypeProperties = Object.keys(validTypes);
 
-    selectionSet.selections.forEach((selection) => {
+    selectionSet.selections.forEach(selection => {
       if (selection.kind === Kind.FIELD) {
         if (validTypeProperties.includes(selection.name.value)) {
           if (selection.selectionSet) {
@@ -290,7 +285,7 @@ export const extractSelectionsFromQuery = (
 
   traverse(
     query,
-    (node) => {
+    node => {
       if (node.kind === Kind.FRAGMENT_DEFINITION) {
         extractedFragments.push(node);
       } else if (node.kind === Kind.FIELD && node.selectionSet) {
@@ -302,7 +297,7 @@ export const extractSelectionsFromQuery = (
 
         if (isAbstractType(type)) {
           const types = schema.getPossibleTypes(type);
-          types.forEach((t) => {
+          types.forEach(t => {
             newFragments.push({
               kind: Kind.FRAGMENT_DEFINITION,
               typeCondition: {
@@ -329,7 +324,7 @@ export const extractSelectionsFromQuery = (
         }
       }
     },
-    (node) => {
+    node => {
       if (node.kind === Kind.FIELD && node.selectionSet) visits.pop();
     }
   );
@@ -344,18 +339,22 @@ export const addFragmentsToQuery = (
   activeTypeFragments: TypeFragmentMap,
   userFragments: UserFragmentMap
 ): DocumentNode => {
-  const requiredUserFragments: Record<string, FragmentDefinitionNode> =
-    makeDict();
+  const requiredUserFragments: Record<
+    string,
+    FragmentDefinitionNode
+  > = makeDict();
 
-  const additionalFragments: Record<string, FragmentDefinitionNode> =
-    makeDict();
+  const additionalFragments: Record<
+    string,
+    FragmentDefinitionNode
+  > = makeDict();
 
   /** Fragments provided and used by the current query */
   const existingFragmentsForQuery: Set<string> = new Set();
 
   return traverse(
     query,
-    (node) => {
+    node => {
       if (node.kind === Kind.DOCUMENT) {
         node.definitions.reduce((set, definition) => {
           if (definition.kind === Kind.FRAGMENT_DEFINITION) {
@@ -371,7 +370,7 @@ export const addFragmentsToQuery = (
         if (!node.directives) return;
 
         const directives = node.directives.filter(
-          (d) => getName(d) !== "populate"
+          d => getName(d) !== 'populate'
         );
 
         if (directives.length === node.directives.length) return;
@@ -403,9 +402,9 @@ export const addFragmentsToQuery = (
         let possibleTypes: readonly GraphQLObjectType<any, any>[] = [];
         if (!isCompositeType(type)) {
           warn(
-            "Invalid type: The type `" +
+            'Invalid type: The type `' +
               type +
-              "` is used with @populate but does not exist.",
+              '` is used with @populate but does not exist.',
             17
           );
         } else {
@@ -427,7 +426,7 @@ export const addFragmentsToQuery = (
                 typeField instanceof GraphQLObjectType &&
                 activeTypeFragments[typeField.name]
               ) {
-                activeTypeFragments[typeField.name].forEach((fragmentMap) => {
+                activeTypeFragments[typeField.name].forEach(fragmentMap => {
                   fragmentFields[getName(fragmentMap.fragment)] = key;
 
                   typeFrags.push(fragmentMap);
@@ -482,7 +481,7 @@ export const addFragmentsToQuery = (
             : [
                 {
                   kind: Kind.FIELD,
-                  name: createNameNode("__typename"),
+                  name: createNameNode('__typename'),
                 },
               ];
 
@@ -496,17 +495,17 @@ export const addFragmentsToQuery = (
         };
       }
     },
-    (node) => {
+    node => {
       if (node.kind === Kind.DOCUMENT) {
         return {
           ...node,
           definitions: [
             ...node.definitions,
             ...Object.keys(additionalFragments).map(
-              (key) => additionalFragments[key]
+              key => additionalFragments[key]
             ),
             ...Object.keys(requiredUserFragments).map(
-              (key) => requiredUserFragments[key]
+              key => requiredUserFragments[key]
             ),
           ],
         };

--- a/exchanges/populate/src/populateExchange.ts
+++ b/exchanges/populate/src/populateExchange.ts
@@ -260,7 +260,7 @@ export const extractSelectionsFromQuery = (
 
     selectionSet.selections.forEach(selection => {
       if (selection.kind === Kind.FIELD) {
-        if (validTypeProperties.includes(selection.name.value)) {
+        if (validTypeProperties.indexOf(selection.name.value) !== -1) {
           if (selection.selectionSet) {
             selections.push({
               ...selection,


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

(relates to #964) Increase feature-set of the populateExchange. Address "classic" mode. As discussed with @JoviDeCroock we might address other cases in other PRs.

"Classic" mode for populate exchange:

` mutation { addTodo @populate }`

We find out what type is used inside of the [[Mutation]] and look in our data-structure what fields we've used for this type.

<!-- What's the motivation of this change? What does it solve? -->

## Set of changes

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->
