### PR TITLE
RFC: (graphcache) - Nullability Operators

### DIFF
--- a/exchanges/graphcache/package.json
+++ b/exchanges/graphcache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urql/exchange-graphcache",
-  "version": "4.3.6-spec-nullability-1",
+  "version": "4.3.6-spec-nullability-2",
   "description": "A normalized and configurable cache exchange for urql",
   "sideEffects": false,
   "homepage": "https://formidable.com/open-source/urql/docs/graphcache",

--- a/exchanges/graphcache/package.json
+++ b/exchanges/graphcache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urql/exchange-graphcache",
-  "version": "4.3.6-spec-nullability",
+  "version": "4.3.6-spec-nullability-1",
   "description": "A normalized and configurable cache exchange for urql",
   "sideEffects": false,
   "homepage": "https://formidable.com/open-source/urql/docs/graphcache",

--- a/exchanges/graphcache/package.json
+++ b/exchanges/graphcache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urql/exchange-graphcache",
-  "version": "4.3.5",
+  "version": "4.3.6-spec-nullability",
   "description": "A normalized and configurable cache exchange for urql",
   "sideEffects": false,
   "homepage": "https://formidable.com/open-source/urql/docs/graphcache",

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -1,6 +1,8 @@
+import { visit, DocumentNode } from 'graphql';
+
 import {
   Exchange,
-  formatDocument,
+  formatDocument as core_formatDocument,
   makeOperation,
   Operation,
   OperationResult,
@@ -29,6 +31,14 @@ import { addCacheOutcome, toRequestPolicy } from './helpers/operation';
 import { filterVariables, getMainOperation } from './ast';
 import { Store, noopDataState, hydrateData, reserveLayer } from './store';
 import { Data, Dependencies, CacheExchangeOpts } from './types';
+
+/** Modified to strip out nullability operators. */
+const formatDocument = <T extends DocumentNode>(node: T): T =>
+  core_formatDocument(
+    visit(node, {
+      Field: field => ({ ...field, required: 'unset' }),
+    })
+  );
 
 type OperationResultWithMeta = OperationResult & {
   outcome: CacheOutcome;

--- a/exchanges/graphcache/src/operations/shared.ts
+++ b/exchanges/graphcache/src/operations/shared.ts
@@ -148,8 +148,13 @@ const isFragmentHeuristicallyMatching = (
   });
 };
 
+export type RequiredStatus = 'required' | 'optional' | 'unset';
+export interface ExtendedFieldNode extends FieldNode {
+  readonly required?: RequiredStatus;
+}
+
 interface SelectionIterator {
-  (): FieldNode | undefined;
+  (): ExtendedFieldNode | undefined;
 }
 
 export const makeSelectionIterator = (


### PR DESCRIPTION
> A preview of this change has been published under the `spec-nullability` tag.

## Context

The ["Nullability RFC" for GraphQL](https://github.com/graphql/graphql-wg/issues/694) allows fields to individually be marked as optional or required in a query by the client-side. ([See Strawman Proposal](https://github.com/graphql/graphql-spec/issues/867))

If a field is marked as optional then it's allowed to be missing and `null`, which
can control where missing values cascade to:

```graphql
query {
  me {
    name?
  }
}
```

If a field is marked as required it may never be allowed to become `null` and must
cascade if it otherwise would have been set to `null`:

```graphql
query {
  me {
    name!
  }
}
```

## Summary

This is extremely interesting for us in Graphcache. Currently, ["schema awareness"](https://formidable.com/open-source/urql/docs/graphcache/schema-awareness/#partial-results) is very tangential to this idea. When schema information is available in Graphcache, we're able to read a field and react to a cache miss accordingly. We can independently cascade across non-nullable fields upwards and set the result to `null` partially.

However, this feature is dependent entirely on the user's schema, and furthermore, is not accessible to anyone who isn't using schema awareness.

When a field is marked as nullable and schema awareness is enabled, then Graphcache will automatically deliver partial results, without the UI being able to indicate beforehand if that's desired. Now, a field may be set to "required" (i.e. `{ field! }`), which means that this can be prevented.

Similarly, even without schema awareness entire fields may be marked as optional (i.e. `{ field? }`), which enables Graphcache to act as if the schema described this field as nullable, which allows us to actively craft a partial result, even if schema awareness isn't enabled, since we know that this field may in fact be `null`.

In other words, the nullability RFC guarantees a "forced outcome" in both cases, without having to
look up whether a field is nullable in the schema.
In the future, we may even derive the `RequiredStatus` of a `FieldNode` in an
external place and never call `isFieldNullable` with a schema in the query
traversal.

## Set of changes

- Add temporary `ExtendedFieldNode` type in iterator
- Add additional check for `field.required` in `readSelection`

An [implementation for `graphql-js` exists](https://github.com/graphql/graphql-js/pull/3281), but I've created a separate PR against [the `graphql-web-lite` overlay package](https://github.com/kitten/graphql-web-lite/tree/spec/nullability-rfc), which is published and can be used to test this change, as long as an API supports this. This [has been published](https://github.com/kitten/graphql-web-lite/releases/tag/v15.5.1002-spec-nullability) to npm under the `spec-nullability` tag.

> **Note:** This PR currently strips out the nullability operators before forwarding the query. This is **temporary** for testing. This isn't what we'd ship, since we assume that we can trust the result to correspond to the operation document.

## Further Considerations

- This may be interesting for `useFragment` and fragment masking, See #1408
- ~This raises a case of what happens when a field marked as nullable is written to the cache. We may have dissonance here when a field is marked as nullable but is required in the schema; if the same field is then unmarked, we run the risk of setting a required field to null. Maybe we have to skip caching it then, if we don't have schema awareness turned on.~ (Solved by erasing field instead)