### PR TITLE
chore: cleanup readmes for the new repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <a href="https://github.com/urql-graphql/urql/actions/workflows/ci.yml">
     <img alt="CI Status" src="https://github.com/urql-graphql/urql/actions/workflows/ci.yml/badge.svg?branch=main" />
   </a>
-  <a href="https://www.npmjs.com/package/urql">
+  <a href="https://www.npmjs.com/package/@urql/core">
     <img alt="Weekly downloads" src="https://badgen.net/npm/dw/urql?color=blue" />
   </a>
   <a href="https://formidable.com/open-source/urql/docs/">
@@ -28,7 +28,7 @@
 
 ## ✨ Features
 
-- 📦 **One package** to get a working GraphQL client in React, Preact, and Svelte
+- 📦 **One package** to get a working GraphQL client in React, Preact, Vue, and Svelte
 - ⚙️ Fully **customisable** behaviour [via "exchanges"](https://formidable.com/open-source/urql/docs/advanced/authoring-exchanges/)
 - 🗂 Logical but simple default behaviour and document caching
 - 🌱 Normalized caching via [`@urql/exchange-graphcache`](https://formidable.com/open-source/urql/docs/graphcache)
@@ -38,14 +38,6 @@
 you can take it from getting started with your first GraphQL project all the way to building complex apps and experimenting with GraphQL clients.
 
 **📃 For more information, [check out the docs](https://formidable.com/open-source/urql/docs/).**
-
-## Installation
-
-```sh
-yarn add urql graphql
-# or
-npm install --save urql graphql
-```
 
 ## 🙌 Contributing
 

--- a/docs/advanced/server-side-rendering.md
+++ b/docs/advanced/server-side-rendering.md
@@ -181,7 +181,7 @@ If you're using [Next.js](https://nextjs.org/) you can save yourself a lot of wo
 `next-urql`. The `next-urql` package includes setup for `react-ssr-prepass` already, which automates
 a lot of the complexity of setting up server-side rendering with `urql`.
 
-We have a custom integration with [`Next.js`](https://nextjs.org/), being [`next-urql`](https://github.com/FormidableLabs/urql/tree/main/packages/next-urql)
+We have a custom integration with [`Next.js`](https://nextjs.org/), being [`next-urql`](https://github.com/urql-graphql/urql/tree/main/packages/next-urql)
 this integration contains convenience methods specifically for `Next.js`.
 These will simplify the above setup for SSR.
 
@@ -265,7 +265,7 @@ export default withUrqlClient(
     url: 'http://localhost:3000/graphql',
     exchanges: [dedupExchange, cacheExchange, ssrExchange, fetchExchange],
   }),
-  { ssr: true }, // Enables server-side rendering using `getInitialProps`
+  { ssr: true } // Enables server-side rendering using `getInitialProps`
 )(Index);
 ```
 
@@ -310,7 +310,7 @@ export async function getStaticProps(ctx) {
   const ssrCache = ssrExchange({ isClient: false });
   const client = initUrqlClient(
     {
-      url: "your-url",
+      url: 'your-url',
       exchanges: [dedupExchange, cacheExchange, ssrCache, fetchExchange],
     },
     false
@@ -332,7 +332,7 @@ export async function getStaticProps(ctx) {
 export default withUrqlClient(
   ssr => ({
     url: 'your-url',
-  }),
+  })
   // Cannot specify { ssr: true } here so we don't wrap our component in getInitialProps
 )(Todos);
 ```
@@ -374,7 +374,7 @@ export async function getServerSideProps(ctx) {
   const ssrCache = ssrExchange({ isClient: false });
   const client = initUrqlClient(
     {
-      url: "", // not needed without `fetchExchange`
+      url: '', // not needed without `fetchExchange`
       exchanges: [
         dedupExchange,
         cacheExchange,
@@ -394,11 +394,9 @@ export async function getServerSideProps(ctx) {
   };
 }
 
-export default withUrqlClient(
-  ssr => ({
-    url: 'your-url',
-  }),
-)(Todos);
+export default withUrqlClient(ssr => ({
+  url: 'your-url',
+}))(Todos);
 ```
 
 Direct schema execution skips one network round trip by accessing your resolvers directly

--- a/exchanges/context/README.md
+++ b/exchanges/context/README.md
@@ -35,7 +35,3 @@ const client = createClient({
   ],
 });
 ```
-
-## Maintenance Status
-
-**Active:** Formidable is actively working on this project, and we expect to continue for work for the foreseeable future. Bug reports, feature requests and pull requests are welcome.

--- a/exchanges/execute/README.md
+++ b/exchanges/execute/README.md
@@ -82,7 +82,3 @@ executeExchange({
 }),
 // ...
 ```
-
-## Maintenance Status
-
-**Active:** Formidable is actively working on this project, and we expect to continue for work for the foreseeable future. Bug reports, feature requests and pull requests are welcome.

--- a/exchanges/graphcache/README.md
+++ b/exchanges/graphcache/README.md
@@ -2,7 +2,7 @@
 
 <p align="center"><strong>An exchange for normalized caching support in <code>urql</code></strong></p>
 
-`@urql/exchange-graphcache` is a normalized cache exchange for the [`urql`](https://github.com/FormidableLabs/urql) GraphQL client.
+`@urql/exchange-graphcache` is a normalized cache exchange for the [`urql`](https://github.com/urql-graphql/urql) GraphQL client.
 This is a drop-in replacement for the default `cacheExchange` that, instead of document
 caching, caches normalized data by keys and connections between data.
 
@@ -44,7 +44,3 @@ const client = createClient({
   ],
 });
 ```
-
-## Maintenance Status
-
-**Active:** Formidable is actively working on this project, and we expect to continue for work for the foreseeable future. Bug reports, feature requests and pull requests are welcome.

--- a/exchanges/graphcache/help.md
+++ b/exchanges/graphcache/help.md
@@ -2,7 +2,7 @@ This file (`exchanges/graphcache/help.md`) has been moved to `docs/graphcache/er
 
 If you are looking at this in a browser
 
-- ...and your URL looks like this: `github.com/FormidableLabs/urql/blob/main/exchanges/graphcache/help.md#15`
+- ...and your URL looks like this: `github.com/urql-graphql/urql/blob/main/exchanges/graphcache/help.md#15`
 - ...in the URL, replace `exchanges/graphcache/help.md` with `docs/graphcache/errors.md`
 - ...and keep the `#15`
 - ...and then you will get help with your error!

--- a/exchanges/graphcache/package.json
+++ b/exchanges/graphcache/package.json
@@ -4,11 +4,11 @@
   "description": "A normalized and configurable cache exchange for urql",
   "sideEffects": false,
   "homepage": "https://formidable.com/open-source/urql/docs/graphcache",
-  "bugs": "https://github.com/FormidableLabs/urql/issues",
+  "bugs": "https://github.com/urql-graphql/urql/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/FormidableLabs/urql.git",
+    "url": "https://github.com/urql-graphql/urql.git",
     "directory": "exchanges/graphcache"
   },
   "keywords": [

--- a/packages/preact-urql/README.md
+++ b/packages/preact-urql/README.md
@@ -7,7 +7,7 @@
   <a href="https://bundlephobia.com/result?p=@urql/preact">
     <img alt="Minified gzip size" src="https://img.shields.io/bundlephobia/minzip/@urql/preact.svg?label=gzip%20size" />
   </a>
-  <a href="https://github.com/FormidableLabs/urql/discussions">
+  <a href="https://github.com/urql-graphql/urql/discussions">
     <img alt="GitHub Discussions: Chat With Us" src="https://badgen.net/badge/discussions/chat%20with%20us/purple" />
   </a>
   <br />

--- a/packages/site/src/constants.js
+++ b/packages/site/src/constants.js
@@ -1,8 +1,8 @@
 const constants = {
   docsTitle: 'URQL',
-  githubIssues: 'https://www.github.com/FormidableLabs/urql/issues',
-  github: 'https://www.github.com/FormidableLabs/urql',
-  readme: 'https://github.com/FormidableLabs/urql/blob/main/README.md',
+  githubIssues: 'https://www.github.com/urql-graphql/urql/issues',
+  github: 'https://www.github.com/urql-graphql/urql',
+  readme: 'https://github.com/urql-graphql/urql/blob/main/README.md',
   color: '#6B78B8',
   googleAnalyticsId: 'UA-43290258-1',
 };

--- a/packages/site/src/screens/home/hero.js
+++ b/packages/site/src/screens/home/hero.js
@@ -238,13 +238,13 @@ const Hero = props => {
         <li>
           <a
             title="Issues"
-            href="https://www.github.com/FormidableLabs/urql/issues"
+            href="https://www.github.com/urql-graphql/urql/issues"
           >
             Issues
           </a>
         </li>
         <li>
-          <a title="GitHub" href="https://github.com/FormidableLabs/urql">
+          <a title="GitHub" href="https://github.com/urql-graphql/urql">
             GitHub
           </a>
         </li>

--- a/packages/storybook-addon/package.json
+++ b/packages/storybook-addon/package.json
@@ -63,7 +63,7 @@
     "access": "public"
   },
   "storybook": {
-    "icon": "https://github.com/FormidableLabs/urql/raw/main/packages/site/src/assets/sidebar-badge.svg",
+    "icon": "https://github.com/urql-graphql/urql/raw/main/packages/site/src/assets/sidebar-badge.svg",
     "displayName": "urql"
   }
 }

--- a/packages/vue-urql/README.md
+++ b/packages/vue-urql/README.md
@@ -7,7 +7,7 @@
   <a href="https://bundlephobia.com/result?p=@urql/vue">
     <img alt="Minified gzip size" src="https://img.shields.io/bundlephobia/minzip/@urql/vue.svg?label=gzip%20size" />
   </a>
-  <a href="https://github.com/FormidableLabs/urql/discussions">
+  <a href="https://github.com/urql-graphql/urql/discussions">
     <img alt="GitHub Discussions: Chat With Us" src="https://badgen.net/badge/discussions/chat%20with%20us/purple" />
   </a>
   <br />

--- a/scripts/changesets/changelog.js
+++ b/scripts/changesets/changelog.js
@@ -3,7 +3,7 @@ const { getInfo } = require('@changesets/get-github-info');
 
 config();
 
-const REPO = 'FormidableLabs/urql';
+const REPO = 'urql-graphql/urql';
 const SEE_LINE = /^See:\s*(.*)/i;
 const TRAILING_CHAR = /[.;:]$/g;
 const listFormatter = new Intl.ListFormat('en-US');


### PR DESCRIPTION
We had a few resdiual maintenance status, invalid links, ... This also changes a few things about the main readme, it adds Vue, uses `@urql/core` for the DL number and removes `react installation`