### PR TITLE
(auth) separate initial and refresh auth

### DIFF
--- a/.changeset/friendly-brooms-peel.md
+++ b/.changeset/friendly-brooms-peel.md
@@ -1,0 +1,11 @@
+---
+'@urql/exchange-auth': major
+---
+
+Split `getAuth` into two functions: `getInitialAuth` and `refreshAuth`. The existing `getAuth` is removed.
+
+In order to improve developer experience, we're spliting the `getAuth` into two functions to more easily distinguish the two cases when it's called:
+- `getInitialAuth` is called only once when the exchange first loads. It should be used to get any initial auth state (e.g. form a coolie or async storage)
+- `refreshAuth` is called then `willAuthError` returns true, or when a request fails with an auth error (as determined by `didAuthError`)
+
+In order to migrate: look at your application logic in `getAuth` and separate it into two parts. The logic for getting inital auth should go in `getInitialAuth` (remember, this will be called only once in the urql client lifecycle) and the refresh logic should go in `refreshAuth`.

--- a/exchanges/auth/README.md
+++ b/exchanges/auth/README.md
@@ -59,17 +59,16 @@ const client = createClient({
         // check if the error was an auth error (this can be implemented in various ways, e.g. 401 or a special error code)
         return error.graphQLErrors.some(e => e.extensions?.code === 'FORBIDDEN');
       },
-      getAuth: async ({ authState, mutate }) => {
+      getInitialAuth: async ({ authState, mutate }) => {
         // for initial launch, fetch the auth state from storage (local storage, async storage etc)
-        if (!authState) {
-          const token = localStorage.getItem('token');
-          const refreshToken = localStorage.getItem('refreshToken');
-          if (token && refreshToken) {
-            return { token, refreshToken };
-          }
-          return null;
+        const token = localStorage.getItem('token');
+        const refreshToken = localStorage.getItem('refreshToken');
+        if (token && refreshToken) {
+          return { token, refreshToken };
         }
-
+        return null;
+      },
+      refreshAuth: async ({ authState, mutate }) => {
         /**
          * the following code gets executed when an auth error has occurred
          * we should refresh the token if possible and return a new auth state
@@ -101,7 +100,7 @@ const client = createClient({
         logout();
 
         return null;
-      },
+      }
     }),
     fetchExchange,
   ],


### PR DESCRIPTION
## Summary
Currently, the auth exchange has a single function - `getAuth` - that gets called for both initial auth as well as refreshing. This is not great form a DX point of views, since "get initial auth" and "handle auth error" are very different things.

## Set of changes
- `auth-exhange`: remove `getAuth` and split it into `getInitialAuth` and `refreshAuth`.
