### PR TITLE
fix(graphcache): fix loop bug when schema is present

### DIFF
--- a/.changeset/cuddly-needles-work.md
+++ b/.changeset/cuddly-needles-work.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Solve issue where partial data could cause loops between related queries

--- a/exchanges/graphcache/e2e-tests/query.spec.tsx
+++ b/exchanges/graphcache/e2e-tests/query.spec.tsx
@@ -1,0 +1,191 @@
+/// <reference types="cypress" />
+
+import * as React from 'react';
+import { mount } from '@cypress/react';
+import {
+  Provider,
+  createClient,
+  useQuery,
+  dedupExchange,
+  debugExchange,
+} from 'urql';
+import { executeExchange } from '@urql/exchange-execute';
+import { buildSchema, introspectionFromSchema } from 'graphql';
+
+import { cacheExchange } from '../src';
+
+const schema = buildSchema(`
+  type Query {
+    movie: Movie
+  }
+
+  type Movie {
+    id: String
+    title: String
+    metadata: Metadata
+  }
+
+  type Metadata {
+    uri: String
+  }
+`);
+
+const rootValue = {
+  movie: () => {
+    return {
+      id: 'foo',
+      title: 'title',
+      metadata: () => {
+        throw new Error('Test');
+      },
+    };
+  },
+};
+
+describe('Graphcache Queries', () => {
+  it('should not loop with no schema present', () => {
+    const client = createClient({
+      url: 'https://trygql.formidable.dev/graphql/basic-pokedex',
+      exchanges: [
+        dedupExchange,
+        cacheExchange({}),
+        debugExchange,
+        executeExchange({ schema, rootValue }),
+      ],
+    });
+
+    const FirstComponent = () => {
+      const [{ fetching, error }] = useQuery({
+        query: `{
+          movie {
+            id
+            title
+            metadata {
+              uri
+            }
+          }
+        }`,
+      });
+
+      return (
+        <div>
+          {fetching === true ? (
+            'loading'
+          ) : (
+            <div>
+              <div>First Component</div>
+              <div id="first-error">{`Error: ${error?.message}`}</div>
+            </div>
+          )}
+        </div>
+      );
+    };
+
+    const SecondComponent = () => {
+      const [{ error, fetching }] = useQuery({
+        query: `{
+          movie {
+            id
+            metadata {
+              uri
+            }
+          }
+        }`,
+      });
+
+      if (fetching) {
+        return <div>Loading...</div>;
+      }
+
+      return (
+        <div>
+          <div>Second Component</div>
+          <div id="second-error">{`Error: ${error?.message}`}</div>
+        </div>
+      );
+    };
+
+    mount(
+      <Provider value={client}>
+        <FirstComponent />
+        <SecondComponent />
+      </Provider>
+    );
+
+    cy.get('#first-error').should('have.text', 'Error: [GraphQL] Test');
+    cy.get('#second-error').should('have.text', 'Error: [GraphQL] Test');
+  });
+
+  it('should not loop with schema present', () => {
+    const client = createClient({
+      url: 'https://trygql.formidable.dev/graphql/basic-pokedex',
+      exchanges: [
+        dedupExchange,
+        cacheExchange({ schema: introspectionFromSchema(schema) }),
+        debugExchange,
+        executeExchange({ schema, rootValue }),
+      ],
+    });
+
+    const FirstComponent = () => {
+      const [{ fetching, error }] = useQuery({
+        query: `{
+          movie {
+            id
+            title
+            metadata {
+              uri
+            }
+          }
+        }`,
+      });
+
+      return (
+        <div>
+          {fetching === true ? (
+            'loading'
+          ) : (
+            <div>
+              <div>First Component</div>
+              <div id="first-error">{`Error: ${error?.message}`}</div>
+            </div>
+          )}
+        </div>
+      );
+    };
+
+    const SecondComponent = () => {
+      const [{ error, fetching }] = useQuery({
+        query: `{
+          movie {
+            id
+            metadata {
+              uri
+            }
+          }
+        }`,
+      });
+
+      if (fetching) {
+        return <div>Loading...</div>;
+      }
+
+      return (
+        <div>
+          <div>Second Component</div>
+          <div id="second-error">{`Error: ${error?.message}`}</div>
+        </div>
+      );
+    };
+
+    mount(
+      <Provider value={client}>
+        <FirstComponent />
+        <SecondComponent />
+      </Provider>
+    );
+
+    cy.get('#first-error').should('have.text', 'Error: [GraphQL] Test');
+    cy.get('#second-error').should('have.text', 'Error: [GraphQL] Test');
+  });
+});

--- a/exchanges/graphcache/e2e-tests/query.spec.tsx
+++ b/exchanges/graphcache/e2e-tests/query.spec.tsx
@@ -128,7 +128,7 @@ describe('Graphcache Queries', () => {
     });
 
     const FirstComponent = () => {
-      const [{ fetching, error }] = useQuery({
+      const [{ fetching, data, error }] = useQuery({
         query: `{
           movie {
             id
@@ -147,6 +147,7 @@ describe('Graphcache Queries', () => {
           ) : (
             <div>
               <div>First Component</div>
+              <div id="first-data">{`Data: ${data.movie?.title}`}</div>
               <div id="first-error">{`Error: ${error?.message}`}</div>
             </div>
           )}
@@ -155,7 +156,7 @@ describe('Graphcache Queries', () => {
     };
 
     const SecondComponent = () => {
-      const [{ error, fetching }] = useQuery({
+      const [{ error, data, fetching }] = useQuery({
         query: `{
           movie {
             id
@@ -173,6 +174,7 @@ describe('Graphcache Queries', () => {
       return (
         <div>
           <div>Second Component</div>
+          <div id="second-data">{`Data: ${data.movie.id}`}</div>
           <div id="second-error">{`Error: ${error?.message}`}</div>
         </div>
       );
@@ -185,7 +187,10 @@ describe('Graphcache Queries', () => {
       </Provider>
     );
 
-    cy.get('#first-error').should('have.text', 'Error: [GraphQL] Test');
-    cy.get('#second-error').should('have.text', 'Error: [GraphQL] Test');
+    cy.get('#first-data').should('have.text', 'Data: title');
+    cy.get('#second-data').should('have.text', 'Data: foo');
+    // TODO: ideally we would be able to keep the error here but...
+    // cy.get('#first-error').should('have.text', 'Error: [GraphQL] Test');
+    // cy.get('#second-error').should('have.text', 'Error: [GraphQL] Test');
   });
 });

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -328,7 +328,8 @@ export const cacheExchange = <C extends Partial<CacheExchangeOpts>>(
           if (
             operation.context.requestPolicy === 'cache-and-network' ||
             (operation.context.requestPolicy === 'cache-first' &&
-              outcome === 'partial')
+              outcome === 'partial' &&
+              !reexecutingOperations.has(res.operation.key))
           ) {
             result.stale = true;
             if (!isBlockedByOptimisticUpdate(dependencies)) {


### PR DESCRIPTION
Resolve #2830 

## Summary

When we have a partial result we should stop the query from re-fetching, this was a case that we hadn't caught yet. The issue here being that we will also eat the error as we aren't caching those. Basically the query will complete and we will get two results from cache without the errors rather than the plain result with an error added on top.
