### PR TITLE
fix(next-urql): Change import for init-urql-client to @urql/core to prevent it from using createContext

### DIFF
--- a/.changeset/beige-fishes-relate.md
+++ b/.changeset/beige-fishes-relate.md
@@ -1,0 +1,5 @@
+---
+'next-urql': patch
+---
+
+Change import for `createClient` to `@urql/core`, which helps Next not depend on `urql` and hence not cause `createContext` to be called when the import is treeshaken away.

--- a/packages/next-urql/src/init-urql-client.ts
+++ b/packages/next-urql/src/init-urql-client.ts
@@ -1,4 +1,4 @@
-import { createClient, Client, ClientOptions } from 'urql';
+import { Client, ClientOptions, createClient } from '@urql/core';
 
 let urqlClient: Client | null = null;
 


### PR DESCRIPTION
## Summary

Currently, `initUrqlClient` cannot be used in Nextjs server components because it uses `createContext`. Per [a discussion](https://github.com/urql-graphql/urql/discussions/2829#discussioncomment-4234974) with @JoviDeCroock the other day, the solution to this seems to be to import from @urql/core instead of urql.

## Set of changes
The only change is changing the import for `init-urql-client.ts` from urql to @urql/core. This should not be a breaking change.
