### PR TITLE
chore(workspace): Enable TypeScript's isolatedModules compiler option

### DIFF
--- a/exchanges/auth/src/index.ts
+++ b/exchanges/auth/src/index.ts
@@ -1,1 +1,2 @@
-export { authExchange, AuthConfig } from './authExchange';
+export { authExchange } from './authExchange';
+export type { AuthConfig } from './authExchange';

--- a/exchanges/context/src/index.ts
+++ b/exchanges/context/src/index.ts
@@ -1,1 +1,2 @@
-export { contextExchange, ContextExchangeArgs } from './context';
+export { contextExchange } from './context';
+export type { ContextExchangeArgs } from './context';

--- a/exchanges/execute/src/index.ts
+++ b/exchanges/execute/src/index.ts
@@ -1,1 +1,2 @@
-export { executeExchange, ExecuteExchangeArgs } from './execute';
+export { executeExchange } from './execute';
+export type { ExecuteExchangeArgs } from './execute';

--- a/exchanges/retry/src/index.ts
+++ b/exchanges/retry/src/index.ts
@@ -1,1 +1,2 @@
-export { retryExchange, RetryExchangeOptions } from './retryExchange';
+export { retryExchange } from './retryExchange';
+export type { RetryExchangeOptions } from './retryExchange';

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,4 +1,4 @@
-import { GraphQLError, DocumentNode } from 'graphql';
+import type { GraphQLError, DocumentNode } from 'graphql';
 import { Source } from 'wonka';
 import { Client } from './client';
 import { CombinedError } from './utils/error';

--- a/packages/vue-urql/src/index.ts
+++ b/packages/vue-urql/src/index.ts
@@ -3,15 +3,13 @@ export * from '@urql/core';
 export * from './useClientHandle';
 export { install, provideClient } from './useClient';
 
-export {
-  useQuery,
-  UseQueryArgs,
-  UseQueryResponse,
-  UseQueryState,
-} from './useQuery';
+export { useQuery } from './useQuery';
 
-export {
-  useSubscription,
+export type { UseQueryArgs, UseQueryResponse, UseQueryState } from './useQuery';
+
+export { useSubscription } from './useSubscription';
+
+export type {
   UseSubscriptionArgs,
   UseSubscriptionResponse,
   UseSubscriptionState,
@@ -19,11 +17,9 @@ export {
   SubscriptionHandler,
 } from './useSubscription';
 
-export {
-  useMutation,
-  UseMutationResponse,
-  UseMutationState,
-} from './useMutation';
+export { useMutation } from './useMutation';
+
+export type { UseMutationResponse, UseMutationState } from './useMutation';
 
 import { install } from './useClient';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
       "@urql/*": ["packages/*-urql/src", "packages/*/src"]
     },
     "esModuleInterop": true,
+    "isolatedModules": true,
     "forceConsistentCasingInFileNames": true,
     "noUnusedLocals": true,
     "noEmit": true,


### PR DESCRIPTION
## Summary

This is simply a small change to give ourselves more options when bundling in the future and avoid accidental issues with unresolveable modules.

## Set of changes

- Enable `isolatedModules: true` in root `tsconfig.json`
- Refactor various exports to use isolated modules syntax
