### PR TITLE
feat(core): Reuse stringifyDocument and cached prints across @urql/core

### DIFF
--- a/.changeset/quiet-mugs-travel.md
+++ b/.changeset/quiet-mugs-travel.md
@@ -1,0 +1,8 @@
+---
+'@urql/core': patch
+---
+
+Reuse output of `stringifyDocument` in place of repeated `print`. This will mean that we now prevent calling `print` repeatedly for identical operations and are instead only reusing the result once.
+
+This change has a subtle consequence of our internals. Operation keys will change due to this
+refactor and we will no longer sanitise strip newlines from queries that `@urql/core` has printed.

--- a/exchanges/multipart-fetch/src/__snapshots__/multipartFetchExchange.test.ts.snap
+++ b/exchanges/multipart-fetch/src/__snapshots__/multipartFetchExchange.test.ts.snap
@@ -16,7 +16,7 @@ exports[`on error > returns error data 1`] = `
     "key": 2,
     "kind": "query",
     "query": {
-      "__key": 3521976120,
+      "__key": -2395444236,
       "definitions": [
         {
           "directives": [],
@@ -119,10 +119,15 @@ exports[`on error > returns error data 1`] = `
       ],
       "kind": "Document",
       "loc": {
-        "end": 86,
+        "end": 92,
         "source": {
-          "body": "# getUser
-query getUser($name: String) { user(name: $name) { id firstName lastName } }",
+          "body": "query getUser($name: String) {
+  user(name: $name) {
+    id
+    firstName
+    lastName
+  }
+}",
           "locationOffset": {
             "column": 1,
             "line": 1,
@@ -165,7 +170,7 @@ exports[`on error > returns error data with status 400 and manual redirect mode 
     "key": 2,
     "kind": "query",
     "query": {
-      "__key": 3521976120,
+      "__key": -2395444236,
       "definitions": [
         {
           "directives": [],
@@ -268,10 +273,15 @@ exports[`on error > returns error data with status 400 and manual redirect mode 
       ],
       "kind": "Document",
       "loc": {
-        "end": 86,
+        "end": 92,
         "source": {
-          "body": "# getUser
-query getUser($name: String) { user(name: $name) { id firstName lastName } }",
+          "body": "query getUser($name: String) {
+  user(name: $name) {
+    id
+    firstName
+    lastName
+  }
+}",
           "locationOffset": {
             "column": 1,
             "line": 1,
@@ -317,7 +327,7 @@ exports[`on success > returns response data 1`] = `
     "key": 2,
     "kind": "query",
     "query": {
-      "__key": 3521976120,
+      "__key": -2395444236,
       "definitions": [
         {
           "directives": [],
@@ -420,10 +430,15 @@ exports[`on success > returns response data 1`] = `
       ],
       "kind": "Document",
       "loc": {
-        "end": 86,
+        "end": 92,
         "source": {
-          "body": "# getUser
-query getUser($name: String) { user(name: $name) { id firstName lastName } }",
+          "body": "query getUser($name: String) {
+  user(name: $name) {
+    id
+    firstName
+    lastName
+  }
+}",
           "locationOffset": {
             "column": 1,
             "line": 1,
@@ -471,7 +486,7 @@ exports[`on success > uses a file when given 1`] = `
     "key": 3,
     "kind": "mutation",
     "query": {
-      "__key": 4034972436,
+      "__key": 8029062428,
       "definitions": [
         {
           "directives": [],
@@ -552,10 +567,13 @@ exports[`on success > uses a file when given 1`] = `
       ],
       "kind": "Document",
       "loc": {
-        "end": 125,
+        "end": 110,
         "source": {
-          "body": "# uploadProfilePicture
-mutation uploadProfilePicture($picture: File) { uploadProfilePicture(picture: $picture) { location } }",
+          "body": "mutation uploadProfilePicture($picture: File) {
+  uploadProfilePicture(picture: $picture) {
+    location
+  }
+}",
           "locationOffset": {
             "column": 1,
             "line": 1,
@@ -609,7 +627,7 @@ exports[`on success > uses multiple files when given 1`] = `
     "key": 3,
     "kind": "mutation",
     "query": {
-      "__key": 2033658603,
+      "__key": -6039055341,
       "definitions": [
         {
           "directives": [],
@@ -693,10 +711,13 @@ exports[`on success > uses multiple files when given 1`] = `
       ],
       "kind": "Document",
       "loc": {
-        "end": 132,
+        "end": 116,
         "source": {
-          "body": "# uploadProfilePictures
-mutation uploadProfilePictures($pictures: [File]) { uploadProfilePicture(pictures: $pictures) { location } }",
+          "body": "mutation uploadProfilePictures($pictures: [File]) {
+  uploadProfilePicture(pictures: $pictures) {
+    location
+  }
+}",
           "locationOffset": {
             "column": 1,
             "line": 1,

--- a/packages/core/src/exchanges/__snapshots__/fetch.test.ts.snap
+++ b/packages/core/src/exchanges/__snapshots__/fetch.test.ts.snap
@@ -16,7 +16,7 @@ exports[`on error > returns error data 1`] = `
     "key": 2,
     "kind": "query",
     "query": {
-      "__key": 3521976120,
+      "__key": -2395444236,
       "definitions": [
         {
           "directives": [],
@@ -119,10 +119,15 @@ exports[`on error > returns error data 1`] = `
       ],
       "kind": "Document",
       "loc": {
-        "end": 86,
+        "end": 92,
         "source": {
-          "body": "# getUser
-query getUser($name: String) { user(name: $name) { id firstName lastName } }",
+          "body": "query getUser($name: String) {
+  user(name: $name) {
+    id
+    firstName
+    lastName
+  }
+}",
           "locationOffset": {
             "column": 1,
             "line": 1,
@@ -165,7 +170,7 @@ exports[`on error > returns error data with status 400 and manual redirect mode 
     "key": 2,
     "kind": "query",
     "query": {
-      "__key": 3521976120,
+      "__key": -2395444236,
       "definitions": [
         {
           "directives": [],
@@ -268,10 +273,15 @@ exports[`on error > returns error data with status 400 and manual redirect mode 
       ],
       "kind": "Document",
       "loc": {
-        "end": 86,
+        "end": 92,
         "source": {
-          "body": "# getUser
-query getUser($name: String) { user(name: $name) { id firstName lastName } }",
+          "body": "query getUser($name: String) {
+  user(name: $name) {
+    id
+    firstName
+    lastName
+  }
+}",
           "locationOffset": {
             "column": 1,
             "line": 1,
@@ -317,7 +327,7 @@ exports[`on success > returns response data 1`] = `
     "key": 2,
     "kind": "query",
     "query": {
-      "__key": 3521976120,
+      "__key": -2395444236,
       "definitions": [
         {
           "directives": [],
@@ -420,10 +430,15 @@ exports[`on success > returns response data 1`] = `
       ],
       "kind": "Document",
       "loc": {
-        "end": 86,
+        "end": 92,
         "source": {
-          "body": "# getUser
-query getUser($name: String) { user(name: $name) { id firstName lastName } }",
+          "body": "query getUser($name: String) {
+  user(name: $name) {
+    id
+    firstName
+    lastName
+  }
+}",
           "locationOffset": {
             "column": 1,
             "line": 1,

--- a/packages/core/src/exchanges/__snapshots__/subscription.test.ts.snap
+++ b/packages/core/src/exchanges/__snapshots__/subscription.test.ts.snap
@@ -17,7 +17,7 @@ exports[`should return response data from forwardSubscription observable 1`] = `
     "key": 4,
     "kind": "subscription",
     "query": {
-      "__key": 2088253569,
+      "__key": 7623921801,
       "definitions": [
         {
           "directives": [],
@@ -98,10 +98,13 @@ exports[`should return response data from forwardSubscription observable 1`] = `
       ],
       "kind": "Document",
       "loc": {
-        "end": 92,
+        "end": 82,
         "source": {
-          "body": "# subscribeToUser
-subscription subscribeToUser($user: String) { user(user: $user) { name } }",
+          "body": "subscription subscribeToUser($user: String) {
+  user(user: $user) {
+    name
+  }
+}",
           "locationOffset": {
             "column": 1,
             "line": 1,

--- a/packages/core/src/exchanges/subscription.test.ts
+++ b/packages/core/src/exchanges/subscription.test.ts
@@ -1,5 +1,5 @@
-import { print } from 'graphql';
 import { vi, expect, it } from 'vitest';
+
 import {
   empty,
   publish,
@@ -12,6 +12,7 @@ import {
 
 import { Client } from '../client';
 import { subscriptionOperation, subscriptionResult } from '../test-utils';
+import { stringifyDocument } from '../utils';
 import { OperationResult } from '../types';
 import { subscriptionExchange, SubscriptionForwarder } from './subscription';
 
@@ -24,7 +25,9 @@ it('should return response data from forwardSubscription observable', async () =
 
   const unsubscribe = vi.fn();
   const forwardSubscription: SubscriptionForwarder = operation => {
-    expect(operation.query).toBe(print(subscriptionOperation.query));
+    expect(operation.query).toBe(
+      stringifyDocument(subscriptionOperation.query)
+    );
     expect(operation.variables).toBe(subscriptionOperation.variables);
     expect(operation.context).toEqual(subscriptionOperation.context);
 

--- a/packages/core/src/exchanges/subscription.ts
+++ b/packages/core/src/exchanges/subscription.ts
@@ -1,5 +1,3 @@
-import { print } from 'graphql';
-
 import {
   filter,
   make,
@@ -12,7 +10,12 @@ import {
   takeUntil,
 } from 'wonka';
 
-import { makeResult, makeErrorResult, makeOperation } from '../utils';
+import {
+  stringifyDocument,
+  makeResult,
+  makeErrorResult,
+  makeOperation,
+} from '../utils';
 
 import {
   Exchange,
@@ -70,7 +73,7 @@ export const subscriptionExchange = ({
     // This excludes the query's name as a field although subscription-transport-ws does accept it since it's optional
     const observableish = forwardSubscription({
       key: operation.key.toString(36),
-      query: print(operation.query),
+      query: stringifyDocument(operation.query),
       variables: operation.variables!,
       context: { ...operation.context },
     });

--- a/packages/core/src/gql.test.ts
+++ b/packages/core/src/gql.test.ts
@@ -23,10 +23,10 @@ it('parses GraphQL Documents', () => {
     parse('{ gql testing }', { noLocation: true }).definitions
   );
 
-  expect(doc).toBe(keyDocument('{ gql testing }'));
+  expect(doc).toBe(keyDocument('{\n  gql\n  testing\n}'));
   expect(doc.loc).toEqual({
     start: 0,
-    end: 15,
+    end: 19,
     source: expect.anything(),
   });
 });

--- a/packages/core/src/internal/__snapshots__/fetchSource.test.ts.snap
+++ b/packages/core/src/internal/__snapshots__/fetchSource.test.ts.snap
@@ -16,7 +16,7 @@ exports[`on error > ignores the error when a result is available 1`] = `
     "key": 2,
     "kind": "query",
     "query": {
-      "__key": 3521976120,
+      "__key": -2395444236,
       "definitions": [
         {
           "directives": [],
@@ -119,10 +119,15 @@ exports[`on error > ignores the error when a result is available 1`] = `
       ],
       "kind": "Document",
       "loc": {
-        "end": 86,
+        "end": 92,
         "source": {
-          "body": "# getUser
-query getUser($name: String) { user(name: $name) { id firstName lastName } }",
+          "body": "query getUser($name: String) {
+  user(name: $name) {
+    id
+    firstName
+    lastName
+  }
+}",
           "locationOffset": {
             "column": 1,
             "line": 1,
@@ -155,7 +160,7 @@ exports[`on error > returns error data 1`] = `
     "key": 2,
     "kind": "query",
     "query": {
-      "__key": 3521976120,
+      "__key": -2395444236,
       "definitions": [
         {
           "directives": [],
@@ -258,10 +263,15 @@ exports[`on error > returns error data 1`] = `
       ],
       "kind": "Document",
       "loc": {
-        "end": 86,
+        "end": 92,
         "source": {
-          "body": "# getUser
-query getUser($name: String) { user(name: $name) { id firstName lastName } }",
+          "body": "query getUser($name: String) {
+  user(name: $name) {
+    id
+    firstName
+    lastName
+  }
+}",
           "locationOffset": {
             "column": 1,
             "line": 1,
@@ -294,7 +304,7 @@ exports[`on error > returns error data with status 400 and manual redirect mode 
     "key": 2,
     "kind": "query",
     "query": {
-      "__key": 3521976120,
+      "__key": -2395444236,
       "definitions": [
         {
           "directives": [],
@@ -397,10 +407,15 @@ exports[`on error > returns error data with status 400 and manual redirect mode 
       ],
       "kind": "Document",
       "loc": {
-        "end": 86,
+        "end": 92,
         "source": {
-          "body": "# getUser
-query getUser($name: String) { user(name: $name) { id firstName lastName } }",
+          "body": "query getUser($name: String) {
+  user(name: $name) {
+    id
+    firstName
+    lastName
+  }
+}",
           "locationOffset": {
             "column": 1,
             "line": 1,
@@ -438,7 +453,7 @@ exports[`on success > returns response data 1`] = `
     "key": 2,
     "kind": "query",
     "query": {
-      "__key": 3521976120,
+      "__key": -2395444236,
       "definitions": [
         {
           "directives": [],
@@ -541,10 +556,15 @@ exports[`on success > returns response data 1`] = `
       ],
       "kind": "Document",
       "loc": {
-        "end": 86,
+        "end": 92,
         "source": {
-          "body": "# getUser
-query getUser($name: String) { user(name: $name) { id firstName lastName } }",
+          "body": "query getUser($name: String) {
+  user(name: $name) {
+    id
+    firstName
+    lastName
+  }
+}",
           "locationOffset": {
             "column": 1,
             "line": 1,
@@ -611,7 +631,7 @@ exports[`on success > uses the mock fetch if given 1`] = `
     "key": 2,
     "kind": "query",
     "query": {
-      "__key": 3521976120,
+      "__key": -2395444236,
       "definitions": [
         {
           "directives": [],
@@ -714,10 +734,15 @@ exports[`on success > uses the mock fetch if given 1`] = `
       ],
       "kind": "Document",
       "loc": {
-        "end": 86,
+        "end": 92,
         "source": {
-          "body": "# getUser
-query getUser($name: String) { user(name: $name) { id firstName lastName } }",
+          "body": "query getUser($name: String) {
+  user(name: $name) {
+    id
+    firstName
+    lastName
+  }
+}",
           "locationOffset": {
             "column": 1,
             "line": 1,

--- a/packages/core/src/internal/fetchOptions.ts
+++ b/packages/core/src/internal/fetchOptions.ts
@@ -1,5 +1,8 @@
-import { print } from 'graphql';
-import { getOperationName, stringifyVariables } from '../utils';
+import {
+  stringifyDocument,
+  getOperationName,
+  stringifyVariables,
+} from '../utils';
 import { AnyVariables, GraphQLRequest, Operation } from '../types';
 
 export interface FetchBody {
@@ -14,7 +17,7 @@ export function makeFetchBody<
   Variables extends AnyVariables = AnyVariables
 >(request: Omit<GraphQLRequest<Data, Variables>, 'key'>): FetchBody {
   return {
-    query: print(request.query),
+    query: stringifyDocument(request.query),
     operationName: getOperationName(request.query),
     variables: request.variables || undefined,
     extensions: undefined,
@@ -32,8 +35,7 @@ export const makeFetchURL = (
   const url = new URL(operation.context.url);
   const search = url.searchParams;
   if (body.operationName) search.set('operationName', body.operationName);
-  if (body.query)
-    search.set('query', body.query.replace(/#[^\n\r]+/g, ' ').trim());
+  if (body.query) search.set('query', body.query);
   if (body.variables)
     search.set('variables', stringifyVariables(body.variables));
   if (body.extensions)

--- a/packages/core/src/utils/hash.test.ts
+++ b/packages/core/src/utils/hash.test.ts
@@ -1,0 +1,14 @@
+import { HashValue, phash } from './hash';
+import { expect, it } from 'vitest';
+
+it('hashes given strings', () => {
+  expect(phash('hello')).toMatchInlineSnapshot('261238937');
+});
+
+it('hashes given strings and seeds', () => {
+  let hash: HashValue;
+  expect((hash = phash('hello'))).toMatchInlineSnapshot('261238937');
+  expect((hash = phash('world', hash))).toMatchInlineSnapshot('-152191');
+  expect((hash = phash('!', hash))).toMatchInlineSnapshot('-5022270');
+  expect(typeof hash).toBe('number');
+});

--- a/packages/core/src/utils/hash.ts
+++ b/packages/core/src/utils/hash.ts
@@ -1,11 +1,11 @@
+export type HashValue = number & { readonly _opaque: unique symbol };
+
 // When we have separate strings it's useful to run a progressive
 // version of djb2 where we pretend that we're still looping over
 // the same string
-export const phash = (h: number, x: string): number => {
+export const phash = (x: string, seed?: HashValue): HashValue => {
+  let h = typeof seed === 'number' ? seed | 0 : 5381;
   for (let i = 0, l = x.length | 0; i < l; i++)
     h = (h << 5) + h + x.charCodeAt(i);
-  return h | 0;
+  return h as HashValue;
 };
-
-// This is a djb2 hashing function
-export const hash = (x: string): number => phash(5381 | 0, x) >>> 0;

--- a/packages/core/src/utils/request.test.ts
+++ b/packages/core/src/utils/request.test.ts
@@ -3,80 +3,95 @@ import { expect, it, describe } from 'vitest';
 import { parse, print } from 'graphql';
 import { gql } from '../gql';
 import { createRequest, stringifyDocument } from './request';
+import { formatDocument } from './typenames';
 
-it('should hash identical queries identically', () => {
-  const reqA = createRequest('{ test }', undefined);
-  const reqB = createRequest('{ test }', undefined);
-  expect(reqA.key).toBe(reqB.key);
-});
-
-it('should hash identical DocumentNodes identically', () => {
-  const reqA = createRequest(parse('{ testB }'), undefined);
-  const reqB = createRequest(parse('{ testB }'), undefined);
-  expect(reqA.key).toBe(reqB.key);
-  expect(reqA.query).toBe(reqB.query);
-});
-
-it('should use the hash from a key if available', () => {
-  const doc = parse('{ testC }');
-  (doc as any).__key = 1234;
-  const req = createRequest(doc, undefined);
-  expect(req.key).toBe(1234);
-});
-
-it('should hash DocumentNodes and strings identically', () => {
-  const docA = parse('{ field }');
-  const docB = print(docA);
-  const reqA = createRequest(docA, undefined);
-  const reqB = createRequest(docB, undefined);
-  expect(reqA.key).toBe(reqB.key);
-  expect(reqA.query).toBe(reqB.query);
-});
-
-it('should hash graphql-tag documents correctly', () => {
-  const doc = gql`
-    {
-      testD
-    }
-  `;
-  createRequest(doc, undefined);
-  expect((doc as any).__key).not.toBe(undefined);
-});
-
-it('should return a valid query object', () => {
-  const doc = gql`
-    {
-      testE
-    }
-  `;
-  const val = createRequest(doc, undefined);
-
-  expect(val).toMatchObject({
-    key: expect.any(Number),
-    query: expect.any(Object),
-    variables: {},
+describe('createRequest', () => {
+  it('should hash identical queries identically', () => {
+    const reqA = createRequest('{ test }', undefined);
+    const reqB = createRequest('{ test }', undefined);
+    expect(reqA.key).toBe(reqB.key);
   });
-});
 
-it('should return a valid query object with variables', () => {
-  const doc = print(
-    gql`
+  it('should hash identical queries identically', () => {
+    const reqA = createRequest('{ test }', undefined);
+    const reqB = createRequest('{ test }', undefined);
+    expect(reqA.key).toBe(reqB.key);
+  });
+
+  it('should hash identical DocumentNodes identically', () => {
+    const reqA = createRequest(parse('{ testB }'), undefined);
+    const reqB = createRequest(parse('{ testB }'), undefined);
+    expect(reqA.key).toBe(reqB.key);
+    expect(reqA.query).toBe(reqB.query);
+  });
+
+  it('should use the hash from a key if available', () => {
+    const doc = parse('{ testC }');
+    (doc as any).__key = 1234;
+    const req = createRequest(doc, undefined);
+    expect(req.key).toBe(1234);
+  });
+
+  it('should hash DocumentNodes and strings identically', () => {
+    const docA = parse('{ field }');
+    const docB = print(docA);
+    const reqA = createRequest(docA, undefined);
+    const reqB = createRequest(docB, undefined);
+    expect(reqA.key).toBe(reqB.key);
+    expect(reqA.query).toBe(reqB.query);
+  });
+
+  it('should hash graphql-tag documents correctly', () => {
+    const doc = gql`
       {
-        testF
+        testD
       }
-    `
-  );
-  const val = createRequest(doc, { test: 5 });
+    `;
+    createRequest(doc, undefined);
+    expect((doc as any).__key).not.toBe(undefined);
+  });
 
-  expect(print(val.query)).toBe(doc);
-  expect(val).toMatchObject({
-    key: expect.any(Number),
-    query: expect.any(Object),
-    variables: { test: 5 },
+  it('should return a valid query object', () => {
+    const doc = gql`
+      {
+        testE
+      }
+    `;
+    const val = createRequest(doc, undefined);
+
+    expect(val).toMatchObject({
+      key: expect.any(Number),
+      query: expect.any(Object),
+      variables: {},
+    });
+  });
+
+  it('should return a valid query object with variables', () => {
+    const doc = print(
+      gql`
+        {
+          testF
+        }
+      `
+    );
+    const val = createRequest(doc, { test: 5 });
+
+    expect(print(val.query)).toBe(doc);
+    expect(val).toMatchObject({
+      key: expect.any(Number),
+      query: expect.any(Object),
+      variables: { test: 5 },
+    });
   });
 });
 
-describe('stringifyDocument (internal API)', () => {
+describe('stringifyDocument ', () => {
+  it('should reprint formatted documents', () => {
+    const doc = parse('{ test { field } }');
+    const formatted = formatDocument(doc);
+    expect(stringifyDocument(formatted)).toBe(print(formatted));
+  });
+
   it('should remove comments', () => {
     const doc = `
       { #query

--- a/packages/core/src/utils/request.test.ts
+++ b/packages/core/src/utils/request.test.ts
@@ -115,12 +115,12 @@ describe('stringifyDocument (internal API)', () => {
     `;
     expect(stringifyDocument(createRequest(doc, undefined).query))
       .toMatchInlineSnapshot(`
-      "{
-        field(arg:
+        "{
+          field(arg: 
 
-      \\"test #1\\")
-      }"
-    `);
+        \\"test #1\\")
+        }"
+      `);
   });
 
   it('should not sanitize within block strings', () => {
@@ -136,14 +136,14 @@ describe('stringifyDocument (internal API)', () => {
     `;
     expect(stringifyDocument(createRequest(doc, undefined).query))
       .toMatchInlineSnapshot(`
-      "{
-        field(arg:
+        "{
+          field(arg: 
 
-      \\"\\"\\"
-        hello
-        #hello
-        \\"\\"\\")
-      }"
-    `);
+        \\"\\"\\"
+          hello
+          #hello
+          \\"\\"\\")
+        }"
+      `);
   });
 });

--- a/packages/core/src/utils/request.ts
+++ b/packages/core/src/utils/request.ts
@@ -19,6 +19,7 @@ export interface KeyedDocumentNode extends DocumentNode {
   __key: HashValue;
 }
 
+const SOURCE_NAME = 'gql';
 const GRAPHQL_STRING_RE = /("{3}[\s\S]*"{3}|"(?:\\.|[^"])*")/g;
 const REPLACE_CHAR_RE = /(#[^\n\r]+)?(?:\n|\r\n?|$)+/g;
 
@@ -32,9 +33,11 @@ export const stringifyDocument = (
   node: string | DefinitionNode | DocumentNode
 ): string => {
   const printed = sanitizeDocument(
-    typeof node !== 'string'
-      ? (node.loc && node.loc.source.body) || print(node)
-      : node
+    typeof node === 'string'
+      ? node
+      : node.loc && node.loc.source.name === SOURCE_NAME
+      ? node.loc.source.body
+      : print(node)
   );
 
   if (typeof node !== 'string' && !node.loc) {
@@ -43,7 +46,7 @@ export const stringifyDocument = (
       end: printed.length,
       source: {
         body: printed,
-        name: 'gql',
+        name: SOURCE_NAME,
         locationOffset: { line: 1, column: 1 },
       },
     } as Location;

--- a/packages/svelte-urql/src/mutationStore.test.ts
+++ b/packages/svelte-urql/src/mutationStore.test.ts
@@ -26,7 +26,14 @@ describe('mutationStore', () => {
   it('fills the store with correct values', () => {
     expect(get(store).operation.kind).toBe('mutation');
     expect(get(store).operation.context.url).toBe('https://example.com');
-    expect(get(store).operation.query.loc?.source.body).toBe(query);
     expect(get(store).operation.variables).toBe(variables);
+
+    expect(get(store).operation.query.loc?.source.body).toMatchInlineSnapshot(`
+      "mutation ($input: Example!) {
+        doExample(input: $input) {
+          id
+        }
+      }"
+    `);
   });
 });

--- a/packages/svelte-urql/src/queryStore.test.ts
+++ b/packages/svelte-urql/src/queryStore.test.ts
@@ -20,8 +20,13 @@ describe('queryStore', () => {
   it('fills the store with correct values', () => {
     expect(get(store).operation.kind).toBe('query');
     expect(get(store).operation.context.url).toBe('https://example.com');
-    expect(get(store).operation.query.loc?.source.body).toBe(query);
     expect(get(store).operation.variables).toBe(variables);
+
+    expect(get(store).operation.query.loc?.source.body).toMatchInlineSnapshot(`
+      "{
+        test
+      }"
+    `);
   });
 
   it('adds pause handles', () => {

--- a/packages/svelte-urql/src/subscriptionStore.test.ts
+++ b/packages/svelte-urql/src/subscriptionStore.test.ts
@@ -25,8 +25,15 @@ describe('subscriptionStore', () => {
   it('fills the store with correct values', () => {
     expect(get(store).operation.kind).toBe('subscription');
     expect(get(store).operation.context.url).toBe('https://example.com');
-    expect(get(store).operation.query.loc?.source.body).toBe(query);
     expect(get(store).operation.variables).toBe(variables);
+
+    expect(get(store).operation.query.loc?.source.body).toMatchInlineSnapshot(`
+      "subscription ($input: ExampleInput) {
+        exampleSubscribe(input: $input) {
+          data
+        }
+      }"
+    `);
   });
 
   it('adds pause handles', () => {


### PR DESCRIPTION
Resolves #2787

## Summary

This changes the internals of `@urql/core` to allow us to reuse `stringifyDocument` in `fetchOptions` and other places, to ensure that printing is memoised whenever possible — including for `formatDocument` outputs.

This means that we had to adjust our hashing slightly to account for the different outputs; that said, sanitisation will still be applied to `stringifyDocument` inputs. However, we will no longer reuse `loc.source` strings when they haven't been printed by `@urql/core`.

## Set of changes

- Replace `phash` hashing function and create opaque type for clarity
- Refactor `request.ts`' `stringifyDocument` and hashing
- Reuse `stringifyDocument` in `subscriptionExchange` and `fetchOptions`
- Update document sanitisation to only remove comments
- Update hashing to add the operation name only to the hash key, rather than the `stringifyDocument` output