### PR TITLE
feat(core): Replace fetch source implementation with async generator

### DIFF
--- a/.changeset/real-donkeys-act.md
+++ b/.changeset/real-donkeys-act.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Replace fetch source implementation with async generator implementation, based on Wonka's `fromAsyncIterable`. This will bump `wonka` to `^6.1.1`. To prevent duplication of `wonka`, check whether you have two versions installed after upgrading.

--- a/exchanges/multipart-fetch/src/multipartFetchExchange.test.ts
+++ b/exchanges/multipart-fetch/src/multipartFetchExchange.test.ts
@@ -1,5 +1,6 @@
-import { Client, OperationResult, makeOperation } from '@urql/core';
-import { empty, fromValue, pipe, Source, subscribe, toPromise } from 'wonka';
+import { Client, OperationResult } from '@urql/core';
+import { empty, fromValue, pipe, Source, toPromise } from 'wonka';
+
 import {
   vi,
   expect,
@@ -22,9 +23,6 @@ import {
 
 const fetch = (global as any).fetch as Mock;
 const abort = vi.fn();
-
-const abortError = new Error();
-abortError.name = 'AbortError';
 
 beforeAll(() => {
   (global as any).AbortController = function AbortController() {
@@ -177,54 +175,5 @@ describe('on error', () => {
     );
 
     expect(data.data).toEqual(JSON.parse(response).data);
-  });
-});
-
-describe('on teardown', () => {
-  const fail = () => {
-    expect(true).toEqual(false);
-  };
-
-  it('does not start the outgoing request on immediate teardowns', () => {
-    fetch.mockRejectedValueOnce(abortError);
-
-    const { unsubscribe } = pipe(
-      fromValue(queryOperation),
-      multipartFetchExchange(exchangeArgs),
-      subscribe(fail)
-    );
-
-    unsubscribe();
-    expect(fetch).toHaveBeenCalledTimes(0);
-    expect(abort).toHaveBeenCalledTimes(1);
-  });
-
-  it('aborts the outgoing request', async () => {
-    fetch.mockRejectedValueOnce(abortError);
-
-    const { unsubscribe } = pipe(
-      fromValue(queryOperation),
-      multipartFetchExchange(exchangeArgs),
-      subscribe(fail)
-    );
-
-    await Promise.resolve();
-
-    unsubscribe();
-    expect(fetch).toHaveBeenCalledTimes(1);
-    expect(abort).toHaveBeenCalledTimes(1);
-  });
-
-  it('does not call the query', () => {
-    pipe(
-      fromValue(
-        makeOperation('teardown', queryOperation, queryOperation.context)
-      ),
-      multipartFetchExchange(exchangeArgs),
-      subscribe(fail)
-    );
-
-    expect(fetch).toHaveBeenCalledTimes(0);
-    expect(abort).toHaveBeenCalledTimes(0);
   });
 });

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
       "react-dom": "^17.0.2",
       "react-is": "^17.0.2",
       "styled-components": "^5.2.3",
-      "wonka": "^6.0.0"
+      "wonka": "^6.1.1"
     }
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
       "react-dom": "^17.0.2",
       "react-is": "^17.0.2",
       "styled-components": "^5.2.3",
-      "wonka": "^6.1.1"
+      "wonka": "^6.1.2"
     }
   },
   "devDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -59,7 +59,7 @@
     "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
   },
   "dependencies": {
-    "wonka": "^6.0.0"
+    "wonka": "^6.1.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -59,7 +59,7 @@
     "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
   },
   "dependencies": {
-    "wonka": "^6.1.1"
+    "wonka": "^6.1.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/src/exchanges/fetch.test.ts
+++ b/packages/core/src/exchanges/fetch.test.ts
@@ -143,8 +143,9 @@ describe('on teardown', () => {
   const fail = () => {
     expect(true).toEqual(false);
   };
+
   it('does not start the outgoing request on immediate teardowns', () => {
-    fetch.mockRejectedValueOnce(abortError);
+    fetch.mockResolvedValue(new Response('text', { status: 200 }));
 
     const { unsubscribe } = pipe(
       fromValue(queryOperation),
@@ -154,11 +155,11 @@ describe('on teardown', () => {
 
     unsubscribe();
     expect(fetch).toHaveBeenCalledTimes(0);
-    expect(abort).toHaveBeenCalledTimes(1);
+    expect(abort).toHaveBeenCalledTimes(0);
   });
 
   it('aborts the outgoing request', async () => {
-    fetch.mockRejectedValueOnce(abortError);
+    fetch.mockResolvedValue(new Response('text', { status: 200 }));
 
     const { unsubscribe } = pipe(
       fromValue(queryOperation),
@@ -169,11 +170,16 @@ describe('on teardown', () => {
     await Promise.resolve();
 
     unsubscribe();
+
+    // NOTE: We can only observe the async iterator's final run after a macro tick
+    await new Promise(resolve => setTimeout(resolve));
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(abort).toHaveBeenCalledTimes(1);
   });
 
   it('does not call the query', () => {
+    fetch.mockResolvedValue(new Response('text', { status: 200 }));
+
     pipe(
       fromValue(
         makeOperation('teardown', queryOperation, queryOperation.context)

--- a/packages/core/src/internal/fetchSource.ts
+++ b/packages/core/src/internal/fetchSource.ts
@@ -56,8 +56,8 @@ async function* fetchOperation(
     let iterator: AsyncIterableIterator<ChunkData>;
     if (response[Symbol.asyncIterator]) {
       iterator = response[Symbol.asyncIterator]();
-    } else if (response.body) {
-      const reader = response.body.getReader();
+    } else {
+      const reader = response.body!.getReader();
       iterator = {
         next() {
           return reader.read() as Promise<IteratorResult<ChunkData>>;
@@ -66,8 +66,6 @@ async function* fetchOperation(
           return iterator;
         },
       };
-    } else {
-      throw new TypeError('Streaming requests unsupported');
     }
 
     let buffer = '';
@@ -129,11 +127,10 @@ async function* fetchOperation(
 
     yield makeErrorResult(
       operation,
-      statusNotOk
-        ? response!.statusText
-          ? new Error(response!.statusText)
-          : error
-        : error,
+      (statusNotOk &&
+        response!.statusText &&
+        new Error(response!.statusText)) ||
+        error,
       response!
     );
   } finally {

--- a/packages/core/src/internal/fetchSource.ts
+++ b/packages/core/src/internal/fetchSource.ts
@@ -1,4 +1,4 @@
-import { Source, make } from 'wonka';
+import { Source, fromAsyncIterable } from 'wonka';
 import { Operation, OperationResult } from '../types';
 import { makeResult, makeErrorResult, mergeResultPatch } from '../utils';
 
@@ -6,7 +6,7 @@ const decoder = typeof TextDecoder !== 'undefined' ? new TextDecoder() : null;
 const jsonHeaderRe = /content-type:[^\r\n]*application\/json/i;
 const boundaryHeaderRe = /boundary="?([^=";]+)"?/i;
 
-type ChunkData = { done: false; value: Buffer | Uint8Array } | { done: true };
+type ChunkData = Buffer | Uint8Array;
 
 // NOTE: We're avoiding referencing the `Buffer` global here to prevent
 // auto-polyfilling in Webpack
@@ -15,168 +15,143 @@ const toString = (input: Buffer | ArrayBuffer): string =>
     ? (input as Buffer).toString()
     : decoder!.decode(input as ArrayBuffer);
 
-export const makeFetchSource = (
+async function* fetchOperation(
   operation: Operation,
   url: string,
   fetchOptions: RequestInit
-): Source<OperationResult> => {
+) {
   const maxStatus = fetchOptions.redirect === 'manual' ? 400 : 300;
   const fetcher = operation.context.fetch;
 
-  return make<OperationResult>(({ next, complete }) => {
-    const abortController =
-      typeof AbortController !== 'undefined' ? new AbortController() : null;
-    if (abortController) {
-      fetchOptions.signal = abortController.signal;
+  let abortController: AbortController | void;
+  let response: Response;
+  let hasResults = false;
+  let statusNotOk = false;
+
+  try {
+    if (typeof AbortController !== 'undefined') {
+      fetchOptions.signal = (abortController = new AbortController()).signal;
     }
 
-    let hasResults = false;
-    // DERIVATIVE: Copyright (c) 2021 Marais Rossouw <hi@marais.io>
-    // See: https://github.com/maraisr/meros/blob/219fe95/src/browser.ts
-    const executeIncrementalFetch = (
-      onResult: (result: OperationResult) => void,
-      operation: Operation,
-      response: Response
-    ): Promise<void> => {
-      // NOTE: Guarding against fetch polyfills here
-      const contentType =
-        (response.headers && response.headers.get('Content-Type')) || '';
-      if (/text\//i.test(contentType)) {
-        return response.text().then(text => {
-          onResult(makeErrorResult(operation, new Error(text), response));
-        });
-      } else if (!/multipart\/mixed/i.test(contentType)) {
-        return response.text().then(payload => {
-          onResult(makeResult(operation, JSON.parse(payload), response));
-        });
-      }
+    response = await (fetcher || fetch)(url, fetchOptions);
+    statusNotOk = response.status < 200 || response.status >= maxStatus;
 
-      let boundary = '---';
-      const boundaryHeader = contentType.match(boundaryHeaderRe);
-      if (boundaryHeader) boundary = '--' + boundaryHeader[1];
+    const contentType =
+      (response.headers && response.headers.get('Content-Type')) || '';
+    if (/text\//i.test(contentType)) {
+      const text = await response.text();
+      return yield makeErrorResult(operation, new Error(text), response);
+    } else if (!/multipart\/mixed/i.test(contentType)) {
+      const text = await response.text();
+      return yield makeResult(operation, JSON.parse(text), response);
+    }
 
-      let read: () => Promise<ChunkData>;
-      let cancel = () => {
-        /*noop*/
+    let boundary = '---';
+    const boundaryHeader = contentType.match(boundaryHeaderRe);
+    if (boundaryHeader) boundary = '--' + boundaryHeader[1];
+
+    let iterator: AsyncIterableIterator<ChunkData>;
+    if (response[Symbol.asyncIterator]) {
+      iterator = response[Symbol.asyncIterator]();
+    } else if (response.body) {
+      const reader = response.body.getReader();
+      iterator = {
+        next() {
+          return reader.read() as Promise<IteratorResult<ChunkData>>;
+        },
+        async return() {
+          await reader.cancel();
+          return { done: true } as IteratorReturnResult<any>;
+        },
+        [Symbol.asyncIterator]() {
+          return iterator;
+        },
       };
-      if (response[Symbol.asyncIterator]) {
-        const iterator = response[Symbol.asyncIterator]();
-        read = iterator.next.bind(iterator);
-      } else if ('body' in response && response.body) {
-        const reader = response.body.getReader();
-        cancel = () => reader.cancel();
-        read = () => reader.read();
-      } else {
-        throw new TypeError('Streaming requests unsupported');
-      }
+    } else {
+      throw new TypeError('Streaming requests unsupported');
+    }
 
+    try {
       let buffer = '';
       let isPreamble = true;
       let nextResult: OperationResult | null = null;
       let prevResult: OperationResult | null = null;
+      for await (const data of iterator) {
+        hasResults = true;
 
-      function next(data: ChunkData): Promise<void> | void {
-        if (!data.done) {
-          const chunk = toString(data.value);
-          let boundaryIndex = chunk.indexOf(boundary);
-          if (boundaryIndex > -1) {
-            boundaryIndex += buffer.length;
+        const chunk = toString(data);
+        let boundaryIndex = chunk.indexOf(boundary);
+        if (boundaryIndex > -1) {
+          boundaryIndex += buffer.length;
+        } else {
+          boundaryIndex = buffer.indexOf(boundary);
+        }
+
+        buffer += chunk;
+        while (boundaryIndex > -1) {
+          const current = buffer.slice(0, boundaryIndex);
+          const next = buffer.slice(boundaryIndex + boundary.length);
+
+          if (isPreamble) {
+            isPreamble = false;
           } else {
-            boundaryIndex = buffer.indexOf(boundary);
-          }
+            const headersEnd = current.indexOf('\r\n\r\n') + 4;
+            const headers = current.slice(0, headersEnd);
+            const body = current.slice(headersEnd, current.lastIndexOf('\r\n'));
 
-          buffer += chunk;
-          while (boundaryIndex > -1) {
-            const current = buffer.slice(0, boundaryIndex);
-            const next = buffer.slice(boundaryIndex + boundary.length);
-
-            if (isPreamble) {
-              isPreamble = false;
-            } else {
-              const headersEnd = current.indexOf('\r\n\r\n') + 4;
-              const headers = current.slice(0, headersEnd);
-              const body = current.slice(
-                headersEnd,
-                current.lastIndexOf('\r\n')
-              );
-
-              let payload: any;
-              if (jsonHeaderRe.test(headers)) {
-                try {
-                  payload = JSON.parse(body);
-                  nextResult = prevResult = prevResult
-                    ? mergeResultPatch(prevResult, payload, response)
-                    : makeResult(operation, payload, response);
-                } catch (_error) {}
-              }
-
-              if (next.slice(0, 2) === '--' || (payload && !payload.hasNext)) {
-                if (!prevResult)
-                  return onResult(makeResult(operation, {}, response));
-                break;
-              }
+            let payload: any;
+            if (jsonHeaderRe.test(headers)) {
+              try {
+                payload = JSON.parse(body);
+                nextResult = prevResult = prevResult
+                  ? mergeResultPatch(prevResult, payload, response)
+                  : makeResult(operation, payload, response);
+              } catch (_error) {}
             }
 
-            buffer = next;
-            boundaryIndex = buffer.indexOf(boundary);
+            if (next.slice(0, 2) === '--' || (payload && !payload.hasNext)) {
+              if (!prevResult) yield makeResult(operation, {}, response);
+              break;
+            }
           }
-        } else {
-          hasResults = true;
+
+          buffer = next;
+          boundaryIndex = buffer.indexOf(boundary);
         }
 
         if (nextResult) {
-          onResult(nextResult);
+          yield nextResult;
           nextResult = null;
         }
-
-        if (!data.done && (!prevResult || prevResult.hasNext)) {
-          return read().then(next);
-        }
       }
+    } finally {
+      iterator.return?.();
+    }
+  } catch (error: any) {
+    if (hasResults) {
+      throw error;
+    }
 
-      return read().then(next).finally(cancel);
-    };
+    yield makeErrorResult(
+      operation,
+      statusNotOk
+        ? response!.statusText
+          ? new Error(response!.statusText)
+          : error
+        : error,
+      response!
+    );
+  } finally {
+    if (abortController) {
+      abortController.abort();
+    }
+  }
+}
 
-    let ended = false;
-    let statusNotOk = false;
-    let response: Response;
-
-    Promise.resolve()
-      .then(() => {
-        if (ended) return;
-        return (fetcher || fetch)(url, fetchOptions);
-      })
-      .then((_response: Response | void) => {
-        if (!_response) return;
-        response = _response;
-        statusNotOk = response.status < 200 || response.status >= maxStatus;
-        return executeIncrementalFetch(next, operation, response);
-      })
-      .then(complete)
-      .catch((error: Error) => {
-        if (hasResults) {
-          throw error;
-        }
-
-        const result = makeErrorResult(
-          operation,
-          statusNotOk
-            ? response.statusText
-              ? new Error(response.statusText)
-              : error
-            : error,
-          response
-        );
-
-        next(result);
-        complete();
-      });
-
-    return () => {
-      ended = true;
-      if (abortController) {
-        abortController.abort();
-      }
-    };
-  });
-};
+export function makeFetchSource(
+  operation: Operation,
+  url: string,
+  fetchOptions: RequestInit
+): Source<OperationResult> {
+  return fromAsyncIterable(fetchOperation(operation, url, fetchOptions));
+}

--- a/packages/core/src/internal/fetchSource.ts
+++ b/packages/core/src/internal/fetchSource.ts
@@ -20,9 +20,6 @@ async function* fetchOperation(
   url: string,
   fetchOptions: RequestInit
 ) {
-  const maxStatus = fetchOptions.redirect === 'manual' ? 400 : 300;
-  const fetcher = operation.context.fetch;
-
   let abortController: AbortController | void;
   let response: Response;
   let hasResults = false;
@@ -37,8 +34,10 @@ async function* fetchOperation(
     // if a teardown comes in immediately
     await Promise.resolve();
 
-    response = await (fetcher || fetch)(url, fetchOptions);
-    statusNotOk = response.status < 200 || response.status >= maxStatus;
+    response = await (operation.context.fetch || fetch)(url, fetchOptions);
+    statusNotOk =
+      response.status < 200 ||
+      response.status >= (fetchOptions.redirect === 'manual' ? 400 : 300);
 
     const contentType =
       (response.headers && response.headers.get('Content-Type')) || '';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ overrides:
   react-dom: ^17.0.2
   react-is: ^17.0.2
   styled-components: ^5.2.3
-  wonka: ^6.1.1
+  wonka: ^6.1.2
 
 importers:
 
@@ -120,10 +120,10 @@ importers:
     specifiers:
       '@urql/core': '>=3.0.0'
       graphql: ^16.0.0
-      wonka: ^6.1.1
+      wonka: ^6.1.2
     dependencies:
       '@urql/core': link:../../packages/core
-      wonka: 6.1.1
+      wonka: 6.1.2
     devDependencies:
       graphql: 16.0.1
 
@@ -131,10 +131,10 @@ importers:
     specifiers:
       '@urql/core': '>=2.3.6'
       graphql: ^16.0.0
-      wonka: ^6.1.1
+      wonka: ^6.1.2
     dependencies:
       '@urql/core': link:../../packages/core
-      wonka: 6.1.1
+      wonka: 6.1.2
     devDependencies:
       graphql: 16.0.1
 
@@ -142,10 +142,10 @@ importers:
     specifiers:
       '@urql/core': '>=3.0.0'
       graphql: ^16.0.0
-      wonka: ^6.1.1
+      wonka: ^6.1.2
     dependencies:
       '@urql/core': link:../../packages/core
-      wonka: 6.1.1
+      wonka: 6.1.2
     devDependencies:
       graphql: 16.0.1
 
@@ -160,10 +160,10 @@ importers:
       react: ^17.0.2
       react-dom: ^17.0.2
       urql: '*'
-      wonka: ^6.1.1
+      wonka: ^6.1.2
     dependencies:
       '@urql/core': link:../../packages/core
-      wonka: 6.1.1
+      wonka: 6.1.2
     devDependencies:
       '@cypress/react': 7.0.1_ddmelm2ieimfs7lfnlxmtlhrry
       '@urql/exchange-execute': link:../execute
@@ -179,11 +179,11 @@ importers:
       '@urql/core': '>=3.0.0'
       extract-files: ^11.0.0
       graphql: ^16.0.0
-      wonka: ^6.1.1
+      wonka: ^6.1.2
     dependencies:
       '@urql/core': link:../../packages/core
       extract-files: 11.0.0
-      wonka: 6.1.1
+      wonka: 6.1.2
     devDependencies:
       graphql: 16.0.1
 
@@ -191,10 +191,10 @@ importers:
     specifiers:
       '@urql/core': '>=3.0.0'
       graphql: ^16.0.0
-      wonka: ^6.1.1
+      wonka: ^6.1.2
     dependencies:
       '@urql/core': link:../../packages/core
-      wonka: 6.1.1
+      wonka: 6.1.2
     devDependencies:
       graphql: 16.0.1
 
@@ -202,10 +202,10 @@ importers:
     specifiers:
       '@urql/core': '>=3.0.0'
       graphql: ^16.0.0
-      wonka: ^6.1.1
+      wonka: ^6.1.2
     dependencies:
       '@urql/core': link:../../packages/core
-      wonka: 6.1.1
+      wonka: 6.1.2
     devDependencies:
       graphql: 16.0.1
 
@@ -214,10 +214,10 @@ importers:
       '@types/react': ^17.0.39
       '@urql/core': '>=3.0.0'
       graphql: ^16.0.0
-      wonka: ^6.1.1
+      wonka: ^6.1.2
     dependencies:
       '@urql/core': link:../../packages/core
-      wonka: 6.1.1
+      wonka: 6.1.2
     devDependencies:
       '@types/react': 17.0.52
       graphql: 16.0.1
@@ -226,10 +226,10 @@ importers:
     specifiers:
       '@urql/core': '>=3.0.0'
       graphql: ^16.0.0
-      wonka: ^6.1.1
+      wonka: ^6.1.2
     dependencies:
       '@urql/core': link:../../packages/core
-      wonka: 6.1.1
+      wonka: 6.1.2
     devDependencies:
       graphql: 16.0.1
 
@@ -237,19 +237,19 @@ importers:
     specifiers:
       '@urql/core': '>=3.0.0'
       graphql: ^16.0.0
-      wonka: ^6.1.1
+      wonka: ^6.1.2
     dependencies:
       '@urql/core': link:../../packages/core
-      wonka: 6.1.1
+      wonka: 6.1.2
     devDependencies:
       graphql: 16.0.1
 
   packages/core:
     specifiers:
       graphql: ^16.0.0
-      wonka: ^6.1.1
+      wonka: ^6.1.2
     dependencies:
-      wonka: 6.1.1
+      wonka: 6.1.2
     devDependencies:
       graphql: 16.0.1
 
@@ -296,10 +296,10 @@ importers:
       '@urql/core': ^3.0.3
       graphql: ^16.0.0
       preact: ^10.5.5
-      wonka: ^6.1.1
+      wonka: ^6.1.2
     dependencies:
       '@urql/core': link:../core
-      wonka: 6.1.1
+      wonka: 6.1.2
     devDependencies:
       '@testing-library/preact': 2.0.1_preact@10.5.13
       graphql: 16.0.1
@@ -322,10 +322,10 @@ importers:
       react-ssr-prepass: ^1.1.2
       react-test-renderer: ^17.0.1
       vite: ^3.0.0
-      wonka: ^6.1.1
+      wonka: ^6.1.2
     dependencies:
       '@urql/core': link:../core
-      wonka: 6.1.1
+      wonka: 6.1.2
     devDependencies:
       '@cypress/react': 7.0.1_afg4ncukyuyevrurg5xxicvqy4
       '@cypress/vite-dev-server': 4.0.1
@@ -443,10 +443,10 @@ importers:
       typescript: '>=4.7.3'
       urql: '>=3.0.0'
       webpack: '>=4.4.6'
-      wonka: ^6.1.1
+      wonka: ^6.1.2
     dependencies:
       '@urql/core': link:../core
-      wonka: 6.1.1
+      wonka: 6.1.2
     optionalDependencies:
       '@storybook/addons': 6.2.9_sfoxds7t5ydpegc3knd667wn6m
       '@urql/devtools': 2.0.3_6datu6bk5t3os3oamu6of3ptzi
@@ -470,10 +470,10 @@ importers:
       '@urql/core': ^3.0.0
       graphql: ^16.0.0
       svelte: ^3.20.0
-      wonka: ^6.1.1
+      wonka: ^6.1.2
     dependencies:
       '@urql/core': link:../core
-      wonka: 6.1.1
+      wonka: 6.1.2
     devDependencies:
       graphql: 16.0.1
       svelte: 3.37.0
@@ -483,10 +483,10 @@ importers:
       '@urql/core': ^3.0.0
       graphql: ^16.0.0
       vue: ^3.0.11
-      wonka: ^6.1.1
+      wonka: ^6.1.2
     dependencies:
       '@urql/core': link:../core
-      wonka: 6.1.1
+      wonka: 6.1.2
     devDependencies:
       graphql: 16.0.1
       vue: 3.0.11
@@ -3684,8 +3684,8 @@ packages:
       '@types/yargs-parser': 20.2.0
     dev: true
 
-  /@types/yauzl/2.9.2:
-    resolution: {integrity: sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==}
+  /@types/yauzl/2.10.0:
+    resolution: {integrity: sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==}
     requiresBuild: true
     dependencies:
       '@types/node': 18.11.9
@@ -3830,7 +3830,7 @@ packages:
     dependencies:
       '@urql/core': link:packages/core
       graphql: 16.0.1
-      wonka: 6.1.1
+      wonka: 6.1.2
     dev: false
     optional: true
 
@@ -8018,7 +8018,7 @@ packages:
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
-      '@types/yauzl': 2.9.2
+      '@types/yauzl': 2.10.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -16820,8 +16820,8 @@ packages:
       execa: 1.0.0
     dev: true
 
-  /wonka/6.1.1:
-    resolution: {integrity: sha512-shBtyZ0KFvUadtnDGlTRA4mF4pgcRoyZKikdputKhmShoXWcZDvlg6CUw6Jx9nTL7Ub8QUJoIarPpxdlosg9cw==}
+  /wonka/6.1.2:
+    resolution: {integrity: sha512-zNrXPMccg/7OEp9tSfFkMgTvhhowqasiSHdJ3eCZolXxVTV/aT6HUTofoZk9gwRbGoFey/Nss3JaZKUMKMbofg==}
     dev: false
 
   /word-wrap/1.2.3:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ overrides:
   react-dom: ^17.0.2
   react-is: ^17.0.2
   styled-components: ^5.2.3
-  wonka: ^6.0.0
+  wonka: ^6.1.1
 
 importers:
 
@@ -120,10 +120,10 @@ importers:
     specifiers:
       '@urql/core': '>=3.0.0'
       graphql: ^16.0.0
-      wonka: ^6.0.0
+      wonka: ^6.1.1
     dependencies:
       '@urql/core': link:../../packages/core
-      wonka: 6.0.0
+      wonka: 6.1.1
     devDependencies:
       graphql: 16.0.1
 
@@ -131,10 +131,10 @@ importers:
     specifiers:
       '@urql/core': '>=2.3.6'
       graphql: ^16.0.0
-      wonka: ^6.0.0
+      wonka: ^6.1.1
     dependencies:
       '@urql/core': link:../../packages/core
-      wonka: 6.0.0
+      wonka: 6.1.1
     devDependencies:
       graphql: 16.0.1
 
@@ -142,10 +142,10 @@ importers:
     specifiers:
       '@urql/core': '>=3.0.0'
       graphql: ^16.0.0
-      wonka: ^6.0.0
+      wonka: ^6.1.1
     dependencies:
       '@urql/core': link:../../packages/core
-      wonka: 6.0.0
+      wonka: 6.1.1
     devDependencies:
       graphql: 16.0.1
 
@@ -160,10 +160,10 @@ importers:
       react: ^17.0.2
       react-dom: ^17.0.2
       urql: '*'
-      wonka: ^6.0.0
+      wonka: ^6.1.1
     dependencies:
       '@urql/core': link:../../packages/core
-      wonka: 6.0.0
+      wonka: 6.1.1
     devDependencies:
       '@cypress/react': 7.0.1_ddmelm2ieimfs7lfnlxmtlhrry
       '@urql/exchange-execute': link:../execute
@@ -179,11 +179,11 @@ importers:
       '@urql/core': '>=3.0.0'
       extract-files: ^11.0.0
       graphql: ^16.0.0
-      wonka: ^6.0.0
+      wonka: ^6.1.1
     dependencies:
       '@urql/core': link:../../packages/core
       extract-files: 11.0.0
-      wonka: 6.0.0
+      wonka: 6.1.1
     devDependencies:
       graphql: 16.0.1
 
@@ -191,10 +191,10 @@ importers:
     specifiers:
       '@urql/core': '>=3.0.0'
       graphql: ^16.0.0
-      wonka: ^6.0.0
+      wonka: ^6.1.1
     dependencies:
       '@urql/core': link:../../packages/core
-      wonka: 6.0.0
+      wonka: 6.1.1
     devDependencies:
       graphql: 16.0.1
 
@@ -202,10 +202,10 @@ importers:
     specifiers:
       '@urql/core': '>=3.0.0'
       graphql: ^16.0.0
-      wonka: ^6.0.0
+      wonka: ^6.1.1
     dependencies:
       '@urql/core': link:../../packages/core
-      wonka: 6.0.0
+      wonka: 6.1.1
     devDependencies:
       graphql: 16.0.1
 
@@ -214,10 +214,10 @@ importers:
       '@types/react': ^17.0.39
       '@urql/core': '>=3.0.0'
       graphql: ^16.0.0
-      wonka: ^6.0.0
+      wonka: ^6.1.1
     dependencies:
       '@urql/core': link:../../packages/core
-      wonka: 6.0.0
+      wonka: 6.1.1
     devDependencies:
       '@types/react': 17.0.52
       graphql: 16.0.1
@@ -226,10 +226,10 @@ importers:
     specifiers:
       '@urql/core': '>=3.0.0'
       graphql: ^16.0.0
-      wonka: ^6.0.0
+      wonka: ^6.1.1
     dependencies:
       '@urql/core': link:../../packages/core
-      wonka: 6.0.0
+      wonka: 6.1.1
     devDependencies:
       graphql: 16.0.1
 
@@ -237,19 +237,19 @@ importers:
     specifiers:
       '@urql/core': '>=3.0.0'
       graphql: ^16.0.0
-      wonka: ^6.0.0
+      wonka: ^6.1.1
     dependencies:
       '@urql/core': link:../../packages/core
-      wonka: 6.0.0
+      wonka: 6.1.1
     devDependencies:
       graphql: 16.0.1
 
   packages/core:
     specifiers:
       graphql: ^16.0.0
-      wonka: ^6.0.0
+      wonka: ^6.1.1
     dependencies:
-      wonka: 6.0.0
+      wonka: 6.1.1
     devDependencies:
       graphql: 16.0.1
 
@@ -296,10 +296,10 @@ importers:
       '@urql/core': ^3.0.3
       graphql: ^16.0.0
       preact: ^10.5.5
-      wonka: ^6.0.0
+      wonka: ^6.1.1
     dependencies:
       '@urql/core': link:../core
-      wonka: 6.0.0
+      wonka: 6.1.1
     devDependencies:
       '@testing-library/preact': 2.0.1_preact@10.5.13
       graphql: 16.0.1
@@ -322,10 +322,10 @@ importers:
       react-ssr-prepass: ^1.1.2
       react-test-renderer: ^17.0.1
       vite: ^3.0.0
-      wonka: ^6.0.0
+      wonka: ^6.1.1
     dependencies:
       '@urql/core': link:../core
-      wonka: 6.0.0
+      wonka: 6.1.1
     devDependencies:
       '@cypress/react': 7.0.1_afg4ncukyuyevrurg5xxicvqy4
       '@cypress/vite-dev-server': 4.0.1
@@ -443,10 +443,10 @@ importers:
       typescript: '>=4.7.3'
       urql: '>=3.0.0'
       webpack: '>=4.4.6'
-      wonka: ^6.0.0
+      wonka: ^6.1.1
     dependencies:
       '@urql/core': link:../core
-      wonka: 6.0.0
+      wonka: 6.1.1
     optionalDependencies:
       '@storybook/addons': 6.2.9_sfoxds7t5ydpegc3knd667wn6m
       '@urql/devtools': 2.0.3_6datu6bk5t3os3oamu6of3ptzi
@@ -470,10 +470,10 @@ importers:
       '@urql/core': ^3.0.0
       graphql: ^16.0.0
       svelte: ^3.20.0
-      wonka: ^6.0.0
+      wonka: ^6.1.1
     dependencies:
       '@urql/core': link:../core
-      wonka: 6.0.0
+      wonka: 6.1.1
     devDependencies:
       graphql: 16.0.1
       svelte: 3.37.0
@@ -483,10 +483,10 @@ importers:
       '@urql/core': ^3.0.0
       graphql: ^16.0.0
       vue: ^3.0.11
-      wonka: ^6.0.0
+      wonka: ^6.1.1
     dependencies:
       '@urql/core': link:../core
-      wonka: 6.0.0
+      wonka: 6.1.1
     devDependencies:
       graphql: 16.0.1
       vue: 3.0.11
@@ -3830,7 +3830,7 @@ packages:
     dependencies:
       '@urql/core': link:packages/core
       graphql: 16.0.1
-      wonka: 6.0.0
+      wonka: 6.1.1
     dev: false
     optional: true
 
@@ -16820,8 +16820,8 @@ packages:
       execa: 1.0.0
     dev: true
 
-  /wonka/6.0.0:
-    resolution: {integrity: sha512-TEiIOqkhQXbcmL1RrjxPCzTX15V5FSyJvZRSiTxvgTgrJMaOVKmzGTdRVh349CfaNo9dsIhWDyg1/GNq4NWrEg==}
+  /wonka/6.1.1:
+    resolution: {integrity: sha512-shBtyZ0KFvUadtnDGlTRA4mF4pgcRoyZKikdputKhmShoXWcZDvlg6CUw6Jx9nTL7Ub8QUJoIarPpxdlosg9cw==}
     dev: false
 
   /word-wrap/1.2.3:


### PR DESCRIPTION
Resolves #2355

## Summary

Our previous implementation of `makeFetchSource`, although not entering the branch, retained refrences to any `Response` in Node.js via the incremental fetch logic.

More incidentally than not, we already had an alternative implementaiton of `makeFetchSource` around from when the last major version bumped our ECMA-support requirements. This means that we have an alternative implementation of `makeFetchSource` we can now apply, based on async generators.

This will bump the minimum range of `wonka` to `^6.1.1`.

## Set of changes

- Bump to `wonka@^6.1.1`
- Replace `makeFetchSource` implementation with async generator implementation
