### PR TITLE
fix(workspace): set cache dir correctly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           path: |
             ~/.cache/Cypress
-            ${{ steps.pnpm-store.outputs.dir }}
+            ${{ steps.pnpm-store.outputs.pnpm_cache_dir }}
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-
@@ -85,7 +85,7 @@ jobs:
         with:
           path: |
             ~/.cache/Cypress
-            ${{ steps.pnpm-store.outputs.dir }}
+            ${{ steps.pnpm-store.outputs.pnpm_cache_dir }}
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-
@@ -134,7 +134,7 @@ jobs:
         with:
           path: |
             ~/.cache/Cypress
-            ${{ steps.pnpm-store.outputs.dir }}
+            ${{ steps.pnpm-store.outputs.pnpm_cache_dir }}
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-
@@ -189,7 +189,7 @@ jobs:
         with:
           path: |
             ~/.cache/Cypress
-            ${{ steps.pnpm-store.outputs.dir }}
+            ${{ steps.pnpm-store.outputs.pnpm_cache_dir }}
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           path: |
             ~/.cache/Cypress
-            ${{ steps.pnpm-store.outputs.dir }}
+            ${{ steps.pnpm-store.outputs.pnpm_cache_dir }}
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           path: |
             ~/.cache/Cypress
-            ${{ steps.pnpm-store.outputs.dir }}
+            ${{ steps.pnpm-store.outputs.pnpm_cache_dir }}
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-


### PR DESCRIPTION
## Summary

We set the output to `pnpm_cache_dir` but were erroneously referencing `dir`
