### PR TITLE
chore(workspace): Fix detection of non-ESM builds

### DIFF
--- a/scripts/rollup/settings.mjs
+++ b/scripts/rollup/settings.mjs
@@ -43,7 +43,7 @@ if (pkg.optionalDependencies)
 
 const prodDependencies = new Set([
   ...Object.keys(pkg.peerDependencies || {}),
-  ...Object.keys(pkg.dependencies),
+  ...Object.keys(pkg.dependencies || {}),
 ]);
 
 const externalPredicate = new RegExp(`^(${externalModules.join('|')})($|/)`);

--- a/scripts/rollup/settings.mjs
+++ b/scripts/rollup/settings.mjs
@@ -41,6 +41,11 @@ if (pkg.dependencies)
 if (pkg.optionalDependencies)
   externalModules.push(...Object.keys(pkg.optionalDependencies));
 
+const prodDependencies = new Set([
+  ...Object.keys(pkg.peerDependencies),
+  ...Object.keys(pkg.dependencies),
+]);
+
 const externalPredicate = new RegExp(`^(${externalModules.join('|')})($|/)`);
 
 export const isExternal = id => {
@@ -49,10 +54,10 @@ export const isExternal = id => {
   return externalPredicate.test(id);
 };
 
-export const hasReact = externalModules.includes('react');
-export const hasPreact = externalModules.includes('preact');
-export const hasSvelte = externalModules.includes('svelte');
-export const hasVue = externalModules.includes('vue');
+export const hasReact = prodDependencies.has('react');
+export const hasPreact = prodDependencies.has('preact');
+export const hasSvelte = prodDependencies.has('svelte');
+export const hasVue = prodDependencies.has('vue');
 export const mayReexport = hasReact || hasPreact || hasSvelte || hasVue;
 export const isCI = !!process.env.CIRCLECI;
 export const isAnalyze = !!process.env.ANALYZE;

--- a/scripts/rollup/settings.mjs
+++ b/scripts/rollup/settings.mjs
@@ -42,7 +42,7 @@ if (pkg.optionalDependencies)
   externalModules.push(...Object.keys(pkg.optionalDependencies));
 
 const prodDependencies = new Set([
-  ...Object.keys(pkg.peerDependencies),
+  ...Object.keys(pkg.peerDependencies || {}),
   ...Object.keys(pkg.dependencies),
 ]);
 


### PR DESCRIPTION
This is a tiny issue that was introduced when adding missing dependencies in `@urql/exchange-graphcache`. Our non-ESM build mode is activated when React is installed, however, instead, we shouldn't check `devDependencies` for that, since currently the E2E tests require us to have it installed in `@urql/exchange-graphcache`.