### PR TITLE
fix(graphcache): Fix deadlocked layers between deferred and optimistic layers

### DIFF
--- a/.changeset/poor-items-shake.md
+++ b/.changeset/poor-items-shake.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix a deadlock condition in Graphcache's layers, which is caused by subscriptions (or other deferred layers) starting before one-off mutation layers. This causes the mutation to not be completed, which keeps its data preferred above the deferred layer. That in turn means that layers stop squashing, which causes new results to be missing indefinitely, when they overlap.

--- a/exchanges/graphcache/src/cacheExchange.test.ts
+++ b/exchanges/graphcache/src/cacheExchange.test.ts
@@ -1811,12 +1811,6 @@ describe('commutativity', () => {
       variables: undefined,
     });
 
-    const queryOpB = client.createRequestOperation('query', {
-      key: 3,
-      query,
-      variables: undefined,
-    });
-
     expect(data).toBe(undefined);
 
     nextOp(queryOpA);
@@ -1838,23 +1832,6 @@ describe('commutativity', () => {
     nextOp(mutationOp);
     expect(reexec).toHaveBeenCalledTimes(1);
     expect(data).toHaveProperty('node.name', 'optimistic');
-
-    // NOTE: We purposefully skip the following:
-    // nextOp(queryOpB);
-
-    nextRes({
-      operation: queryOpB,
-      data: {
-        __typename: 'Query',
-        node: {
-          __typename: 'Node',
-          id: 'node',
-          name: 'query b',
-        },
-      },
-    });
-
-    expect(data).toHaveProperty('node.name', 'query b');
   });
 
   it('applies mutation results on top of commutative queries', () => {

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -213,11 +213,8 @@ export const cacheExchange = <C extends Partial<CacheExchangeOpts>>(
       optimisticKeysToDependencies.delete(operation.key);
     }
 
-    reserveLayer(
-      store.data,
-      operation.key,
-      operation.kind === 'subscription' || result.hasNext
-    );
+    if (operation.kind === 'subscription' || result.hasNext)
+      reserveLayer(store.data, operation.key, true);
 
     let queryDependencies: void | Dependencies;
     let data: Data | null = result.data;

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -161,11 +161,9 @@ export const clearDataState = () => {
     while (
       --i >= 0 &&
       data.refLock.has(data.optimisticOrder[i]) &&
-      data.commutativeKeys.has(data.optimisticOrder[i]) &&
-      !data.deferredKeys.has(data.optimisticOrder[i])
-    ) {
+      data.commutativeKeys.has(data.optimisticOrder[i])
+    )
       squashLayer(data.optimisticOrder[i]);
-    }
   }
 
   currentOwnership = null;
@@ -535,20 +533,17 @@ export const reserveLayer = (
 
   let index = data.optimisticOrder.indexOf(layerKey);
   if (index > -1) {
-    if (!data.commutativeKeys.has(layerKey) && !hasNext) {
-      data.optimisticOrder.splice(index, 1);
-      // Protect optimistic layers from being turned into non-optimistic layers
-      // while preserving optimistic data
+    data.optimisticOrder.splice(index, 1);
+    // Protect optimistic layers from being turned into non-optimistic layers
+    // while preserving optimistic data
+    if (!data.commutativeKeys.has(layerKey) && !hasNext)
       clearLayer(data, layerKey);
-    } else {
-      return;
-    }
   }
 
   // If the layer has future results then we'll move it past any layer that's
   // still empty, so currently pending operations will take precedence over it
   for (
-    index = 0;
+    index = index > -1 ? index : 0;
     hasNext &&
     index < data.optimisticOrder.length &&
     !data.deferredKeys.has(data.optimisticOrder[index]) &&

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -525,33 +525,34 @@ export const reserveLayer = (
   layerKey: number,
   hasNext?: boolean
 ) => {
+  // Find the current index for the layer, and remove it from
+  // the order if it exists already
+  let index = data.optimisticOrder.indexOf(layerKey);
+  if (index > -1) data.optimisticOrder.splice(index, 1);
+
   if (hasNext) {
     data.deferredKeys.add(layerKey);
+    // If the layer has future results then we'll move it past any layer that's
+    // still empty, so currently pending operations will take precedence over it
+    for (
+      index = index > -1 ? index : 0;
+      index < data.optimisticOrder.length &&
+      !data.deferredKeys.has(data.optimisticOrder[index]) &&
+      (!data.refLock.has(data.optimisticOrder[index]) ||
+        !data.commutativeKeys.has(data.optimisticOrder[index]));
+      index++
+    );
   } else {
     data.deferredKeys.delete(layerKey);
-  }
-
-  let index = data.optimisticOrder.indexOf(layerKey);
-  if (index > -1) {
-    data.optimisticOrder.splice(index, 1);
     // Protect optimistic layers from being turned into non-optimistic layers
     // while preserving optimistic data
-    if (!data.commutativeKeys.has(layerKey) && !hasNext)
+    if (index > -1 && !data.commutativeKeys.has(layerKey))
       clearLayer(data, layerKey);
+    index = 0;
   }
 
-  // If the layer has future results then we'll move it past any layer that's
-  // still empty, so currently pending operations will take precedence over it
-  for (
-    index = index > -1 ? index : 0;
-    hasNext &&
-    index < data.optimisticOrder.length &&
-    !data.deferredKeys.has(data.optimisticOrder[index]) &&
-    (!data.refLock.has(data.optimisticOrder[index]) ||
-      !data.commutativeKeys.has(data.optimisticOrder[index]));
-    index++
-  );
-
+  // Register the layer with the deferred or "top" index and
+  // mark it as commutative
   data.optimisticOrder.splice(index, 0, layerKey);
   data.commutativeKeys.add(layerKey);
 };


### PR DESCRIPTION
Resolve #2853

## Summary

This fixes a deadlock that could occur in the layers of Graphcache, when a deferred layer (subscriptions or otherwise `hasNext` layers) would be moved past previously optimistic layers (like mutations). In such cases, it would become impossible for preceding layers (i.e. mutations) to ever squash and move "out of the way" causing a deadlock that'd make it impossible for the deferred layer's data to show up when the two layers had overlaps.

Instead, we now will try to clear out deferred layers more aggressively. This means that we will squash its data even when it's deferred, when data is written.

Furthermore, we then move the layer from its current position (or recreate it) when it's re-registered, i.e. when a new message/update comes in for the deferred layer.

This should keep the deferred layers data in the cache but still bump it as needed.

## Set of changes

- Allow deferred layers to be squashed
- Allow layers to only move past empty ones from its current position in the `optimisticOrder` list
