### PR TITLE
fix(core): Fix regression causing stringifyDocument to not reprint after formatDocument

### DIFF
--- a/.changeset/large-eggs-cough.md
+++ b/.changeset/large-eggs-cough.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Fix regression in `@urql/core`'s `stringifyDocument` that caused some formatted documents to not be reprinted.

--- a/packages/core/src/utils/request.test.ts
+++ b/packages/core/src/utils/request.test.ts
@@ -92,8 +92,31 @@ describe('stringifyDocument ', () => {
     expect(stringifyDocument(formatted)).toBe(print(formatted));
   });
 
-  it('should reprint gql documents', () => {
+  it('should reprint request documents', () => {
     const request = createRequest(`query { test { field } }`, {});
+    const formatted = formatDocument(request.query);
+    expect(print(formatted)).toMatchInlineSnapshot(`
+      "{
+        test {
+          field
+          __typename
+        }
+      }"
+    `);
+    expect(stringifyDocument(formatted)).toBe(print(formatted));
+  });
+
+  it.only('should reprint gql documents', () => {
+    const request = createRequest(
+      gql`
+        query {
+          test {
+            field
+          }
+        }
+      `,
+      {}
+    );
     const formatted = formatDocument(request.query);
     expect(print(formatted)).toMatchInlineSnapshot(`
       "{

--- a/packages/core/src/utils/request.test.ts
+++ b/packages/core/src/utils/request.test.ts
@@ -92,6 +92,20 @@ describe('stringifyDocument ', () => {
     expect(stringifyDocument(formatted)).toBe(print(formatted));
   });
 
+  it('should reprint gql documents', () => {
+    const request = createRequest(`query { test { field } }`, {});
+    const formatted = formatDocument(request.query);
+    expect(print(formatted)).toMatchInlineSnapshot(`
+      "{
+        test {
+          field
+          __typename
+        }
+      }"
+    `);
+    expect(stringifyDocument(formatted)).toBe(print(formatted));
+  });
+
   it('should remove comments', () => {
     const doc = `
       { #query
@@ -131,7 +145,7 @@ describe('stringifyDocument ', () => {
     expect(stringifyDocument(createRequest(doc, undefined).query))
       .toMatchInlineSnapshot(`
         "{
-          field(arg: 
+          field(arg:
 
         \\"test #1\\")
         }"
@@ -152,7 +166,7 @@ describe('stringifyDocument ', () => {
     expect(stringifyDocument(createRequest(doc, undefined).query))
       .toMatchInlineSnapshot(`
         "{
-          field(arg: 
+          field(arg:
 
         \\"\\"\\"
           hello

--- a/packages/core/src/utils/request.test.ts
+++ b/packages/core/src/utils/request.test.ts
@@ -106,7 +106,7 @@ describe('stringifyDocument ', () => {
     expect(stringifyDocument(formatted)).toBe(print(formatted));
   });
 
-  it.only('should reprint gql documents', () => {
+  it('should reprint gql documents', () => {
     const request = createRequest(
       gql`
         query {
@@ -168,7 +168,7 @@ describe('stringifyDocument ', () => {
     expect(stringifyDocument(createRequest(doc, undefined).query))
       .toMatchInlineSnapshot(`
         "{
-          field(arg:
+          field(arg: 
 
         \\"test #1\\")
         }"
@@ -189,7 +189,7 @@ describe('stringifyDocument ', () => {
     expect(stringifyDocument(createRequest(doc, undefined).query))
       .toMatchInlineSnapshot(`
         "{
-          field(arg:
+          field(arg: 
 
         \\"\\"\\"
           hello

--- a/packages/core/src/utils/request.test.ts
+++ b/packages/core/src/utils/request.test.ts
@@ -169,7 +169,6 @@ describe('stringifyDocument ', () => {
       .toMatchInlineSnapshot(`
         "{
           field(arg: 
-
         \\"test #1\\")
         }"
       `);
@@ -190,7 +189,6 @@ describe('stringifyDocument ', () => {
       .toMatchInlineSnapshot(`
         "{
           field(arg: 
-
         \\"\\"\\"
           hello
           #hello

--- a/packages/core/src/utils/typenames.ts
+++ b/packages/core/src/utils/typenames.ts
@@ -4,6 +4,7 @@ import {
   InlineFragmentNode,
   Kind,
   visit,
+  print,
 } from 'graphql';
 
 import { KeyedDocumentNode, keyDocument } from './request';
@@ -83,6 +84,11 @@ export const formatDocument = <T extends DocumentNode>(node: T): T => {
     });
 
     formattedDocs.set(query.__key, result);
+    if (typeof node !== 'string' && node.loc?.source.name === 'gql') {
+      const printed = print(result);
+      node.loc.source.body = printed;
+      (node.loc as any).end = printed.length;
+    }
   }
 
   return (result as unknown) as T;

--- a/packages/core/src/utils/typenames.ts
+++ b/packages/core/src/utils/typenames.ts
@@ -4,7 +4,6 @@ import {
   InlineFragmentNode,
   Kind,
   visit,
-  print,
 } from 'graphql';
 
 import { KeyedDocumentNode, keyDocument } from './request';
@@ -84,11 +83,6 @@ export const formatDocument = <T extends DocumentNode>(node: T): T => {
     });
 
     formattedDocs.set(query.__key, result);
-    if (typeof node !== 'string' && node.loc?.source.name === 'gql') {
-      const printed = print(result);
-      node.loc.source.body = printed;
-      (node.loc as any).end = printed.length;
-    }
   }
 
   return (result as unknown) as T;

--- a/packages/svelte-urql/src/mutationStore.test.ts
+++ b/packages/svelte-urql/src/mutationStore.test.ts
@@ -1,3 +1,4 @@
+import { print } from 'graphql';
 import { createClient } from '@urql/core';
 import { get } from 'svelte/store';
 import { vi, expect, it, describe } from 'vitest';
@@ -28,11 +29,10 @@ describe('mutationStore', () => {
     expect(get(store).operation.context.url).toBe('https://example.com');
     expect(get(store).operation.variables).toBe(variables);
 
-    expect(get(store).operation.query.loc?.source.body).toMatchInlineSnapshot(`
+    expect(print(get(store).operation.query)).toMatchInlineSnapshot(`
       "mutation ($input: Example!) {
         doExample(input: $input) {
           id
-          __typename
         }
       }"
     `);

--- a/packages/svelte-urql/src/mutationStore.test.ts
+++ b/packages/svelte-urql/src/mutationStore.test.ts
@@ -32,6 +32,7 @@ describe('mutationStore', () => {
       "mutation ($input: Example!) {
         doExample(input: $input) {
           id
+          __typename
         }
       }"
     `);


### PR DESCRIPTION
## Summary

Related to #2869 reproduces the issue.

[this](https://github.com/urql-graphql/urql/blob/main/packages/core/src/utils/request.ts#L43-L53) looks to be the problem, when we use `createRequest` we fill in `gql` as the source name and don't update the printed string when looping over it with `formatDocument`. When we use `gql` the name will be `graphql request` hence not hitting this clause.

The thing concerning me here is if people would be implementing local-only exchanges whether that would mess with i.e. them removing a field when seeing `@local`
