### PR TITLE
fix(graphcache): Fix blocking of legitimate reexecutions after teardowns

### DIFF
--- a/.changeset/odd-rockets-behave.md
+++ b/.changeset/odd-rockets-behave.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix operation being blocked for looping due to it not cancelling the looping protection when a `teardown` is received. This bug could be triggered when a shared query operation triggers again and causes a cache miss (e.g. due to an error). The re-execution of the operation would then be blocked as Graphcache considered it a "reexecution loop" rather than a legitimate execution triggered by the UI. (See https://github.com/urql-graphql/urql/pull/2737 for more information)

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -111,7 +111,6 @@ export const cacheExchange = <C extends Partial<CacheExchangeOpts>>(
 
   // This registers queries with the data layer to ensure commutativity
   const prepareForwardedOperation = (operation: Operation) => {
-    operation.context.bakka + {};
     if (operation.kind === 'query') {
       // Pre-reserve the position of the result layer
       reserveLayer(store.data, operation.key);
@@ -119,6 +118,7 @@ export const cacheExchange = <C extends Partial<CacheExchangeOpts>>(
       // Delete reference to operation if any exists to release it
       operations.delete(operation.key);
       results.delete(operation.key);
+      reexecutingOperations.delete(operation.key);
       // Mark operation layer as done
       noopDataState(store.data, operation.key);
     } else if (


### PR DESCRIPTION
Resolve #2835

## Summary

This fixes Graphcache blocking legitimate reexecutions triggerd by the UI. These reexecutions could be triggered due to the previously introduced looping protection #2737.

When an operation is torn down and reactivated without any other network request inbetween, then Graphcache wouldn't clean up the operations that'd be blocked from refetching. This meant that it'd erroneously block a legitimate operation triggered by the UI.

The protection is meant to only trigger requests that'd potentially infinitely trigger requests, i.e. non-`network-only` operations triggered by cache misses.

This has been addressed by adding a missing clean up call in reaction to teardowns.

## Set of changes

- Add missing `reexecutingOperations` clean up to `teardown` handler
- Remove typings/build testing line that we added to test a Rollup+TS build issue