### PR TITLE
fix(docs): correct TS `useQuery` example

### DIFF
--- a/docs/basics/typescript-integration.md
+++ b/docs/basics/typescript-integration.md
@@ -140,7 +140,7 @@ const allFilmsWithVariablesQueryDocument = graphql(/* GraphQL */ `
 
 function App() {
   // `data` is typed!
-  const { data } = useQuery(allFilmsWithVariablesQueryDocument, { variables: { first: 10 } });
+  const [{ data }] = useQuery(allFilmsWithVariablesQueryDocument, { variables: { first: 10 } });
   return (
     <div className="App">
       {data && (


### PR DESCRIPTION
Resolves #2883

## Summary

Corrects to our array destructuring syntax
