### PR TITLE
refactor(populate): fields-based populate

### DIFF
--- a/exchanges/populate/src/helpers/node.ts
+++ b/exchanges/populate/src/helpers/node.ts
@@ -1,24 +1,15 @@
 import {
   NameNode,
-  SelectionNode,
-  SelectionSetNode,
   GraphQLOutputType,
   isWrappingType,
   GraphQLWrappingType,
   Kind,
 } from 'graphql';
 
-export type SelectionSet = ReadonlyArray<SelectionNode>;
 export type GraphQLFlatType = Exclude<GraphQLOutputType, GraphQLWrappingType>;
 
 /** Returns the name of a given node */
 export const getName = (node: { name: NameNode }): string => node.name.value;
-
-/** Returns the SelectionSet for a given inline or defined fragment node */
-export const getSelectionSet = (node: {
-  selectionSet?: SelectionSetNode;
-}): SelectionSet =>
-  node.selectionSet !== undefined ? node.selectionSet.selections : [];
 
 export const unwrapType = (
   type: null | undefined | GraphQLOutputType

--- a/exchanges/populate/src/populateExchange.test.ts
+++ b/exchanges/populate/src/populateExchange.test.ts
@@ -201,22 +201,15 @@ describe('on query -> mutation', () => {
       expect(print(response[1].query)).toMatchInlineSnapshot(`
         "mutation MyMutation {
           addTodo {
-            ...Todo_PopulateFragment_0
-            ...Todo_PopulateFragment_1
-          }
-        }
-
-        fragment Todo_PopulateFragment_0 on Todo {
-          id
-          text
-          creator {
+            __typename
             id
-            name
+            text
+            creator {
+              __typename
+              id
+              name
+            }
           }
-        }
-
-        fragment Todo_PopulateFragment_1 on Todo {
-          text
         }"
       `);
     });
@@ -285,44 +278,23 @@ describe('on (query w/ fragment) -> mutation', () => {
       expect(print(response[1].query)).toMatchInlineSnapshot(`
         "mutation MyMutation {
           addTodo {
-            ...Todo_PopulateFragment_0
             ...TodoFragment
+            __typename
+            id
+            text
+            creator {
+              __typename
+              id
+              name
+            }
           }
         }
 
         fragment TodoFragment on Todo {
           id
           text
-        }
-
-        fragment Todo_PopulateFragment_0 on Todo {
-          ...TodoFragment
-          creator {
-            ...CreatorFragment
-          }
-        }
-
-        fragment CreatorFragment on User {
-          id
-          name
         }"
       `);
-    });
-
-    it('includes user fragment', () => {
-      const response = pipe<Operation, any, Operation[]>(
-        fromArray([queryOp, mutationOp]),
-        populateExchange({ schema })(exchangeArgs),
-        toArray
-      );
-
-      const fragments = getNodesByType(
-        response[1].query,
-        Kind.FRAGMENT_DEFINITION
-      );
-      expect(
-        fragments.filter(f => 'name' in f && f.name.value === 'TodoFragment')
-      ).toHaveLength(1);
     });
   });
 });
@@ -378,13 +350,10 @@ describe('on (query w/ unused fragment) -> mutation', () => {
       expect(print(response[1].query)).toMatchInlineSnapshot(`
         "mutation MyMutation {
           addTodo {
-            ...Todo_PopulateFragment_0
+            __typename
+            id
+            text
           }
-        }
-
-        fragment Todo_PopulateFragment_0 on Todo {
-          id
-          text
         }"
       `);
     });
@@ -454,19 +423,15 @@ describe('on query -> (mutation w/ interface return type)', () => {
       expect(print(response[1].query)).toMatchInlineSnapshot(`
         "mutation MyMutation {
           removeTodo {
-            ...User_PopulateFragment_0
-            ...Todo_PopulateFragment_0
+            ... on User {
+              __typename
+              id
+            }
+            ... on Todo {
+              __typename
+              id
+            }
           }
-        }
-
-        fragment User_PopulateFragment_0 on User {
-          id
-          text
-        }
-
-        fragment Todo_PopulateFragment_0 on Todo {
-          id
-          name
         }"
       `);
     });
@@ -483,11 +448,11 @@ describe('on query -> (mutation w/ union return type)', () => {
         query {
           todos {
             id
-            name
+            text
           }
           users {
             id
-            text
+            name
           }
         }
       `,
@@ -520,26 +485,27 @@ describe('on query -> (mutation w/ union return type)', () => {
       expect(print(response[1].query)).toMatchInlineSnapshot(`
         "mutation MyMutation {
           updateTodo {
-            ...User_PopulateFragment_0
-            ...Todo_PopulateFragment_0
+            ... on User {
+              __typename
+              id
+              name
+            }
+            ... on Todo {
+              __typename
+              id
+              text
+            }
           }
-        }
-
-        fragment User_PopulateFragment_0 on User {
-          id
-          text
-        }
-
-        fragment Todo_PopulateFragment_0 on Todo {
-          id
-          name
         }"
       `);
     });
   });
 });
 
-describe('on query -> teardown -> mutation', () => {
+// TODO: figure out how to behave with teardown, just removing and
+// not requesting fields feels kinda incorrect as we would start having
+// stale cache values here
+describe.skip('on query -> teardown -> mutation', () => {
   const queryOp = makeOperation(
     'query',
     {
@@ -647,20 +613,18 @@ describe('interface returned in mutation', () => {
     expect(print(response[1].query)).toMatchInlineSnapshot(`
       "mutation MyMutation {
         addProduct {
-          ...SimpleProduct_PopulateFragment_0
-          ...ComplexProduct_PopulateFragment_0
+          ... on SimpleProduct {
+            __typename
+            id
+            price
+          }
+          ... on ComplexProduct {
+            __typename
+            id
+            price
+            tax
+          }
         }
-      }
-
-      fragment SimpleProduct_PopulateFragment_0 on SimpleProduct {
-        id
-        price
-      }
-
-      fragment ComplexProduct_PopulateFragment_0 on ComplexProduct {
-        id
-        price
-        tax
       }"
     `);
   });
@@ -716,31 +680,92 @@ describe('nested interfaces', () => {
     expect(print(response[1].query)).toMatchInlineSnapshot(`
       "mutation MyMutation {
         addProduct {
-          ...SimpleProduct_PopulateFragment_0
-          ...ComplexProduct_PopulateFragment_0
-        }
-      }
-
-      fragment SimpleProduct_PopulateFragment_0 on SimpleProduct {
-        id
-        price
-        store {
-          id
-          name
-          address
-        }
-      }
-
-      fragment ComplexProduct_PopulateFragment_0 on ComplexProduct {
-        id
-        price
-        tax
-        store {
-          id
-          name
-          website
+          ... on SimpleProduct {
+            __typename
+            id
+            price
+            store {
+              __typename
+              id
+              name
+              address
+            }
+          }
+          ... on ComplexProduct {
+            __typename
+            id
+            price
+            tax
+            store {
+              __typename
+              id
+              name
+              website
+            }
+          }
         }
       }"
     `);
+  });
+});
+
+describe('nested fragment', () => {
+  const fragment = gql`
+    fragment TodoFragment on Todo {
+      id
+      author {
+        id
+      }
+    }
+  `;
+
+  const queryOp = makeOperation(
+    'query',
+    {
+      key: 1234,
+      variables: undefined,
+      query: gql`
+        query {
+          todos {
+            ...TodoFragment
+          }
+        }
+        ${fragment}
+      `,
+    },
+    context
+  );
+
+  const mutationOp = makeOperation(
+    'mutation',
+    {
+      key: 5678,
+      variables: undefined,
+      query: gql`
+        mutation MyMutation {
+          updateTodo @populate
+        }
+      `,
+    },
+    context
+  );
+
+  it('should work with nested fragments', () => {
+    const response = pipe<Operation, any, Operation[]>(
+      fromArray([queryOp, mutationOp]),
+      populateExchange({ schema })(exchangeArgs),
+      toArray
+    );
+
+    expect(print(response[1].query)).toMatchInlineSnapshot(`
+    "mutation MyMutation {
+      updateTodo {
+        ... on Todo {
+          __typename
+          id
+        }
+      }
+    }"
+  `);
   });
 });


### PR DESCRIPTION
Resolves #1149

## Summary

This changes the way we populate slightly, rather than going over queries and assembling fragments for all the fields we find, we iterate over all selections within queries and hold a graph of all the requested fields. When we see a mutation we look at the return-type and start filling out the selection-sets based on the observed fields.

The issue now becomes that this keeps growing, we could say that when a `teardown` happens that we remove the fields but then we run the risk that data in the cache remains stale as a torn down query does not mean we remove the cached data so mutations on data that isn't mounted would become stale.

