### PR TITLE
feat: Implement PromiseLike and Observable interface on extended sources

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -38,13 +38,13 @@ import {
   OperationResult,
   OperationType,
   RequestPolicy,
-  PromisifiedSource,
+  SourceExtensions,
   DebugEvent,
 } from './types';
 
 import {
   createRequest,
-  withPromise,
+  extendSource,
   maskTypename,
   noop,
   makeOperation,
@@ -103,7 +103,7 @@ export interface Client {
     query: DocumentNode | TypedDocumentNode<Data, Variables> | string,
     variables: Variables,
     context?: Partial<OperationContext>
-  ): PromisifiedSource<OperationResult<Data, Variables>>;
+  ): SourceExtensions<OperationResult<Data, Variables>>;
 
   readQuery<Data = any, Variables extends AnyVariables = AnyVariables>(
     query: DocumentNode | TypedDocumentNode<Data, Variables> | string,
@@ -134,7 +134,7 @@ export interface Client {
     query: DocumentNode | TypedDocumentNode<Data, Variables> | string,
     variables: Variables,
     context?: Partial<OperationContext>
-  ): PromisifiedSource<OperationResult<Data, Variables>>;
+  ): SourceExtensions<OperationResult<Data, Variables>>;
 
   executeMutation<Data = any, Variables extends AnyVariables = AnyVariables>(
     query: GraphQLRequest<Data, Variables>,
@@ -371,7 +371,7 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
         context = { ...context, suspense: false };
       }
 
-      return withPromise(
+      return extendSource(
         client.executeQuery(createRequest(query, variables), context)
       );
     },
@@ -397,7 +397,7 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
     },
 
     mutation(query, variables, context) {
-      return withPromise(
+      return extendSource(
         client.executeMutation(createRequest(query, variables), context)
       );
     },

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,5 +1,5 @@
 import type { GraphQLError, DocumentNode } from 'graphql';
-import { Source } from 'wonka';
+import { toObservable, Source } from 'wonka';
 import { Client } from './client';
 import { CombinedError } from './utils/error';
 
@@ -39,6 +39,10 @@ export type ExecutionResult =
 export type PromisifiedSource<T = any> = Source<T> & {
   toPromise: () => Promise<T>;
 };
+
+export type SourceExtensions<T = any> = PromisifiedSource<T> &
+  PromiseLike<T> &
+  ReturnType<typeof toObservable>;
 
 /** The type of GraphQL operation being executed. */
 export type OperationType = 'subscription' | 'query' | 'mutation' | 'teardown';


### PR DESCRIPTION
Extend methods such as `client.query(...)` to return an extended Source
This source now allows it to be awaited directly, and for a subscribe via a Observable interface
to be used.

This needs these PRs to be merged and released:
- https://github.com/0no-co/wonka/pull/131
- https://github.com/0no-co/wonka/pull/132