### PR TITLE
fix(graphcache): make writes more consistent in production builds

### DIFF
--- a/.changeset/wicked-files-flash.md
+++ b/.changeset/wicked-files-flash.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Make writes more consistent when we have an unexpected undefined continue both in dev as well as in production

--- a/exchanges/graphcache/src/operations/write.ts
+++ b/exchanges/graphcache/src/operations/write.ts
@@ -253,6 +253,13 @@ const writeSelection = (
       } else if (ctx.store.schema && typename && fieldName !== '__typename') {
         isFieldAvailableOnType(ctx.store.schema, typename, fieldName);
       }
+    } else if (
+      !isRoot &&
+      fieldValue === undefined &&
+      !deferRef.current &&
+      !ctx.optimistic
+    ) {
+      continue;
     }
 
     if (


### PR DESCRIPTION
## Summary

When we encounter an unexpected undefined currently in dev we warn and `continue` the operation, this can lead to unexpected behavior when the warning is missed and this ends up in production. In production this won't update the cache correctly.

Alternatively we could remove the `continue` in the dev build, issue noticed in https://github.com/urql-graphql/urql/discussions/2902
