### PR TITLE
fix(next): add empty pageprops object

### DIFF
--- a/.changeset/rare-panthers-sit.md
+++ b/.changeset/rare-panthers-sit.md
@@ -1,0 +1,5 @@
+---
+'next-urql': patch
+---
+
+Add empty pageProps object

--- a/.changeset/rare-panthers-sit.md
+++ b/.changeset/rare-panthers-sit.md
@@ -2,4 +2,4 @@
 'next-urql': patch
 ---
 
-Add empty pageProps object
+Add `pageProps: {}` entry to props on app components

--- a/packages/next-urql/src/with-urql-client.ts
+++ b/packages/next-urql/src/with-urql-client.ts
@@ -160,7 +160,9 @@ export function withUrqlClient(
         }
 
         const props = { ...pageProps, urqlClient };
-        const appTreeProps = isApp ? props : { pageProps: props };
+        const appTreeProps = isApp
+          ? { pageProps: {}, ...props }
+          : { pageProps: props };
 
         // Run the prepass step on AppTree. This will run all urql queries on the server.
         if (!options!.neverSuspend) {


### PR DESCRIPTION
Resolves #2892
Closes #2574

## Summary

This adds an empty `pageProps` object, the reason behind putting it before the spread is that if we have some HOC wrapping `next-urql` we don't want to override the existing pageProps.

