### PR TITLE
(request-policy) - configurable upgrade policy and operation persistency fix

### DIFF
--- a/exchanges/request-policy/src/requestPolicyExchange.ts
+++ b/exchanges/request-policy/src/requestPolicyExchange.ts
@@ -16,13 +16,13 @@ export interface Options {
 }
 
 export const requestPolicyExchange = (options: Options): Exchange => {
-  return ({ forward }) => {
-    const operations = new Map();
-    const {
-      ttl: TTL = defaultTTL,
-      upgradePolicy: upgradedPolicy = 'cache-and-network',
-    } = options ?? {};
+  const operations = new Map();
+  const {
+    ttl: TTL = defaultTTL,
+    upgradePolicy: upgradedPolicy = 'cache-and-network',
+  } = options ?? {};
 
+  return ({ forward }) => {
     const processIncomingOperation = (operation: Operation): Operation => {
       if (
         operation.kind !== 'query' ||

--- a/exchanges/request-policy/src/requestPolicyExchange.ts
+++ b/exchanges/request-policy/src/requestPolicyExchange.ts
@@ -3,6 +3,7 @@ import {
   Operation,
   OperationResult,
   Exchange,
+  RequestPolicy,
 } from '@urql/core';
 import { pipe, tap, map } from 'wonka';
 
@@ -11,50 +12,54 @@ const defaultTTL = 5 * 60 * 1000;
 export interface Options {
   shouldUpgrade?: (op: Operation) => boolean;
   ttl?: number;
+  upgradePolicy?: RequestPolicy;
 }
 
-export const requestPolicyExchange = (options: Options): Exchange => ({
-  forward,
-}) => {
-  const operations = new Map();
-  const TTL = (options || {}).ttl || defaultTTL;
+export const requestPolicyExchange = (options: Options): Exchange => {
+  return ({ forward }) => {
+    const operations = new Map();
+    const {
+      ttl: TTL = defaultTTL,
+      upgradePolicy: upgradedPolicy = 'cache-and-network',
+    } = options ?? {};
 
-  const processIncomingOperation = (operation: Operation): Operation => {
-    if (
-      operation.kind !== 'query' ||
-      (operation.context.requestPolicy !== 'cache-first' &&
-        operation.context.requestPolicy !== 'cache-only')
-    ) {
+    const processIncomingOperation = (operation: Operation): Operation => {
+      if (
+        operation.kind !== 'query' ||
+        (operation.context.requestPolicy !== 'cache-first' &&
+          operation.context.requestPolicy !== 'cache-only')
+      ) {
+        return operation;
+      }
+
+      const currentTime = new Date().getTime();
+      const lastOccurrence = operations.get(operation.key) || 0;
+      if (
+        currentTime - lastOccurrence > TTL &&
+        (!options.shouldUpgrade || options.shouldUpgrade(operation))
+      ) {
+        return makeOperation(operation.kind, operation, {
+          ...operation.context,
+          requestPolicy: upgradedPolicy,
+        });
+      }
+
       return operation;
-    }
+    };
 
-    const currentTime = new Date().getTime();
-    const lastOccurrence = operations.get(operation.key) || 0;
-    if (
-      currentTime - lastOccurrence > TTL &&
-      (!options.shouldUpgrade || options.shouldUpgrade(operation))
-    ) {
-      return makeOperation(operation.kind, operation, {
-        ...operation.context,
-        requestPolicy: 'cache-and-network',
-      });
-    }
+    const processIncomingResults = (result: OperationResult): void => {
+      const meta = result.operation.context.meta;
+      const isMiss = !meta || meta.cacheOutcome === 'miss';
+      if (isMiss) {
+        operations.set(result.operation.key, new Date().getTime());
+      }
+    };
 
-    return operation;
-  };
-
-  const processIncomingResults = (result: OperationResult): void => {
-    const meta = result.operation.context.meta;
-    const isMiss = !meta || meta.cacheOutcome === 'miss';
-    if (isMiss) {
-      operations.set(result.operation.key, new Date().getTime());
-    }
-  };
-
-  return ops$ => {
-    return pipe(
-      forward(pipe(ops$, map(processIncomingOperation))),
-      tap(processIncomingResults)
-    );
+    return ops$ => {
+      return pipe(
+        forward(pipe(ops$, map(processIncomingOperation))),
+        tap(processIncomingResults)
+      );
+    };
   };
 };


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

These are changes I needed to make for this to be usable with React and ssr. Makes sense?

## Set of changes

### Allow configuring the upgraded requestPolicy

`ssrExchange` does not pass anything other than `network-only`, so needed to use that.

### Persist the lastOccurrence between calls

Seems like the exchange did not persist the lastOccurrence between calls, and thus always upgraded

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->
