### PR TITLE
fix(graphcache): Patch message for `(19) Can't generate a key for invalidate(...)` error

### DIFF
--- a/.changeset/gentle-ligers-design.md
+++ b/.changeset/gentle-ligers-design.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Patch message for (19) Can't generate a key for invalidate(...) error

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -144,10 +144,9 @@ export class Store<
       entityKey,
       "Can't generate a key for invalidate(...).\n" +
         'You have to pass an id or _id field or create a custom `keys` field for `' +
-        typeof entity ===
-        'object'
-        ? (entity as Data).__typename
-        : entity + '`.',
+        (typeof entity === 'object'
+          ? (entity as Data).__typename
+          : entity + '`.'),
       19
     );
 


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

This PR will correct error message for https://formidable.com/open-source/urql/docs/graphcache/errors/#19-cant-generate-a-key-for-invalidate


current
```
CombinedError: [Network] [object Object]`.
```

expected
```
CombinedError: [Network] Can't generate a key for invalidate(...).
```

## Set of changes

`@urql/exchange-graphcache`
