### PR TITLE
fix(core): Type response of CombinedError

### DIFF
--- a/.changeset/quick-chefs-happen.md
+++ b/.changeset/quick-chefs-happen.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Type response of CombinedError

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -126,7 +126,7 @@ goes wrong during a GraphQL request.
 | --------------- | -------------------------------- | ---------------------------------------------------------------------------------- |
 | `networkError`  | `?Error`                         | An unexpected error that might've occurred when trying to send the GraphQL request |
 | `graphQLErrors` | `?Array<string \| GraphQLError>` | GraphQL Errors (if any) that were returned by the GraphQL API                      |
-| `response`      | `?any`                           | The raw response object (if any) from the `fetch` call                             |
+| `response`      | `?Response`                      | The raw response object (if any) from the `fetch` call                             |
 
 [Read more about errors in `urql` on the "Error" page.](../basics/errors.md)
 

--- a/packages/core/src/utils/error.test.ts
+++ b/packages/core/src/utils/error.test.ts
@@ -68,7 +68,7 @@ describe('CombinedError', () => {
   });
 
   it('accepts a response that is attached to the resulting error', () => {
-    const response = {};
+    const response = {} as Response;
     const err = new CombinedError({
       graphQLErrors: [],
       response,

--- a/packages/core/src/utils/error.ts
+++ b/packages/core/src/utils/error.ts
@@ -39,12 +39,12 @@ export class CombinedError extends Error {
   public message: string;
   public graphQLErrors: GraphQLError[];
   public networkError?: Error;
-  public response?: any;
+  public response?: Response;
 
   constructor(input: {
     networkError?: Error;
     graphQLErrors?: Array<string | Partial<GraphQLError> | Error>;
-    response?: any;
+    response?: Response;
   }) {
     const normalizedGraphQLErrors = (input.graphQLErrors || []).map(
       rehydrateGraphQlError

--- a/packages/core/src/utils/result.test.ts
+++ b/packages/core/src/utils/result.test.ts
@@ -4,7 +4,7 @@ import { makeResult } from './result';
 
 describe('makeResult', () => {
   it('adds extensions and errors correctly', () => {
-    const response = {};
+    const response = {} as Response;
     const origResult = {
       data: undefined,
       errors: ['error message'],

--- a/packages/core/src/utils/result.ts
+++ b/packages/core/src/utils/result.ts
@@ -4,7 +4,7 @@ import { CombinedError } from './error';
 export const makeResult = (
   operation: Operation,
   result: ExecutionResult,
-  response?: any
+  response?: Response
 ): OperationResult => {
   if ((!('data' in result) && !('errors' in result)) || 'path' in result) {
     throw new Error('No Content');
@@ -28,7 +28,7 @@ export const makeResult = (
 export const mergeResultPatch = (
   prevResult: OperationResult,
   patch: ExecutionResult,
-  response?: any
+  response?: Response
 ): OperationResult => {
   const result = { ...prevResult };
   result.hasNext = !!patch.hasNext;
@@ -67,7 +67,7 @@ export const mergeResultPatch = (
 export const makeErrorResult = (
   operation: Operation,
   error: Error,
-  response?: any
+  response?: Response
 ): OperationResult => ({
   operation,
   data: undefined,


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

This PR changes type of `response` of `CombinedError` from `any` to `Response`.

I'm not sure this fix is OK but typed response is useful when check it in exchanges.

```ts
authExchange({
  ...
  didAuthError({ error }) {
    return error.response?.status === 401;
  }
});
```

## Set of changes

- Type response of CombinedError in `@urql/core`
