### PR TITLE
fix(graphcache): Patch message for `(16) Heuristic Fragment Matching`

### DIFF
--- a/.changeset/flat-lions-talk.md
+++ b/.changeset/flat-lions-talk.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Patch message for `(16) Heuristic Fragment Matching`

--- a/exchanges/graphcache/src/operations/shared.ts
+++ b/exchanges/graphcache/src/operations/shared.ts
@@ -135,7 +135,7 @@ const isFragmentHeuristicallyMatching = (
       typeCondition +
       '`. Since GraphQL allows for interfaces `' +
       typeCondition +
-      '` may be an' +
+      '` may be an ' +
       'interface.\nA schema needs to be defined for this match to be deterministic, ' +
       'otherwise the fragment will be matched heuristically!',
     16


### PR DESCRIPTION
## Summary

This PR will fix warning message for https://formidable.com/open-source/urql/docs/graphcache/errors/#16-heuristic-fragment-matching

current
```
Since GraphQL allows for interfaces `???` may be aninterface.
```

expected
```
Since GraphQL allows for interfaces `???` may be an interface.
```

## Set of changes

`@urql/exchange-graphcache`