### PR TITLE
fix(graphcache): Fix onOnline data loss bug in offlineExchange

### DIFF
--- a/.changeset/fast-fishes-destroy.md
+++ b/.changeset/fast-fishes-destroy.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix potential data loss in `offlineExchange` that's caused when `onOnline` triggers and flushes mutation queue before the mutation queue is used.

--- a/exchanges/graphcache/src/offlineExchange.test.ts
+++ b/exchanges/graphcache/src/offlineExchange.test.ts
@@ -226,10 +226,16 @@ describe('offline', () => {
     );
   });
 
-  it('should flush the queue when we become online', () => {
+  it('should flush the queue when we become online', async () => {
+    let resolveOnOnlineCalled: () => void;
+    const onOnlineCalled = new Promise<void>(
+      resolve => (resolveOnOnlineCalled = resolve)
+    );
+
     let flush: () => {};
     storage.onOnline.mockImplementation(cb => {
       flush = cb;
+      resolveOnOnlineCalled!();
     });
 
     const onlineSpy = vi.spyOn(navigator, 'onLine', 'get');
@@ -289,6 +295,8 @@ describe('offline', () => {
         variables: {},
       },
     ]);
+
+    await onOnlineCalled;
 
     flush!();
     expect(reexecuteOperation).toHaveBeenCalledTimes(1);

--- a/exchanges/graphcache/src/offlineExchange.ts
+++ b/exchanges/graphcache/src/offlineExchange.ts
@@ -150,7 +150,7 @@ export const offlineExchange = <C extends Partial<CacheExchangeOpts>>(
           flushQueue();
         }
       })
-      .finally(() => storage?.onOnline?.(flushQueue));
+      .finally(() => storage.onOnline!(flushQueue));
 
     const cacheResults$ = cacheExchange({
       ...opts,

--- a/exchanges/graphcache/src/offlineExchange.ts
+++ b/exchanges/graphcache/src/offlineExchange.ts
@@ -134,21 +134,23 @@ export const offlineExchange = <C extends Partial<CacheExchangeOpts>>(
       );
     };
 
-    storage.onOnline(flushQueue);
-    storage.readMetadata().then(mutations => {
-      if (mutations) {
-        for (let i = 0; i < mutations.length; i++) {
-          failedQueue.push(
-            client.createRequestOperation(
-              'mutation',
-              createRequest(mutations[i].query, mutations[i].variables)
-            )
-          );
-        }
+    storage
+      .readMetadata()
+      .then(mutations => {
+        if (mutations) {
+          for (let i = 0; i < mutations.length; i++) {
+            failedQueue.push(
+              client.createRequestOperation(
+                'mutation',
+                createRequest(mutations[i].query, mutations[i].variables)
+              )
+            );
+          }
 
-        flushQueue();
-      }
-    });
+          flushQueue();
+        }
+      })
+      .finally(() => storage?.onOnline?.(flushQueue));
 
     const cacheResults$ = cacheExchange({
       ...opts,


### PR DESCRIPTION
## Summary

It's important that onOnline isn't established until after mutations are read from storage and processed by flushQueue. If the storage adapter's onOnline implementation calls flushQueue in the same task, then the storage will be wiped before it is read from, and all mutations that were in the metadata storage will be deleted before they can be read and processed.

Our team ran into this in our react-native project. The library we use for listening to network information state changes immediately invokes the event listener we install on it. Therefore, it's calling flushQueue before urql's offlineExchange even attempts to read from metadata storage.

## Set of changes

### @urql/exchange-graphcache:
- Change how onOnline is set up in offlineExchange. Wait to install the onOnline callback on the StorageAdapter until after the mutations have been read from the StorageAdapter's metadata store.
