### PR TITLE
docs(core): Add TSDocs annotations to @urql/core exported APIs

### DIFF
--- a/.changeset/giant-tables-help.md
+++ b/.changeset/giant-tables-help.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Add TSDoc annotations to all external `@urql/core` APIs.

--- a/packages/core/src/exchanges/cache.ts
+++ b/packages/core/src/exchanges/cache.ts
@@ -17,6 +17,26 @@ type OperationCache = Map<string, Set<number>>;
 const shouldSkip = ({ kind }: Operation) =>
   kind !== 'mutation' && kind !== 'query';
 
+/** Default document cache exchange.
+ *
+ * @remarks
+ * The default document cache in `urql` avoids sending the same GraphQL request
+ * multiple times by caching it using the {@link Operation.key}. It will invalidate
+ * query results automatically whenever it sees a mutation responses with matching
+ * `__typename`s in their responses.
+ *
+ * The document cache will get the introspected `__typename` fields by modifying
+ * your GraphQL operation documents using the {@link formatDocument} utility.
+ *
+ * This automatic invalidation strategy can fail if your query or mutation don’t
+ * contain matching typenames, for instance, because the query contained an
+ * empty list.
+ * You can manually add hints for this exchange by specifying a list of
+ * {@link OperationContext.additionalTypenames} for queries and mutations that
+ * should invalidate one another.
+ *
+ * @see {@link https://formidable.com/open-source/urql/docs/basics/document-caching/} for more information on this cache.
+ */
 export const cacheExchange: Exchange = ({ forward, client, dispatchDebug }) => {
   const resultCache: ResultCache = new Map();
   const operationCache: OperationCache = new Map();
@@ -148,7 +168,9 @@ export const cacheExchange: Exchange = ({ forward, client, dispatchDebug }) => {
   };
 };
 
-// Reexecutes a given operation with the default requestPolicy
+/** Reexecutes an `Operation` with the `network-only` request policy.
+ * @internal
+ */
 export const reexecuteOperation = (client: Client, operation: Operation) => {
   return client.reexecuteOperation(
     makeOperation(operation.kind, operation, {

--- a/packages/core/src/exchanges/compose.ts
+++ b/packages/core/src/exchanges/compose.ts
@@ -1,11 +1,24 @@
-import { Exchange, ExchangeInput } from '../types';
+import type { ExchangeIO, Exchange, ExchangeInput } from '../types';
 
-/** This composes an array of Exchanges into a single ExchangeIO function */
-export const composeExchanges = (exchanges: Exchange[]) => ({
+/** Composes an array of Exchanges into a single one.
+ *
+ * @param exchanges - An array of {@link Exchange | Exchanges}.
+ * @returns - A composed {@link Exchange}.
+ *
+ * @remarks
+ * `composeExchanges` returns an {@link Exchange} that when instantiated
+ * composes the array of passed `Exchange`s into one, calling them from
+ * right to left, with the prior `Exchange`’s {@link ExchangeIO} function
+ * as the {@link ExchangeInput.forward} input.
+ *
+ * This simply merges all exchanges into one and is used by the {@link Client}
+ * to merge the `exchanges` option it receives.
+ */
+export const composeExchanges = (exchanges: Exchange[]): Exchange => ({
   client,
   forward,
   dispatchDebug,
-}: ExchangeInput) =>
+}: ExchangeInput): ExchangeIO =>
   exchanges.reduceRight(
     (forward, exchange) =>
       exchange({

--- a/packages/core/src/exchanges/debug.ts
+++ b/packages/core/src/exchanges/debug.ts
@@ -1,6 +1,20 @@
 import { pipe, tap } from 'wonka';
 import { Exchange } from '../types';
 
+/** Simple log debugger exchange.
+ *
+ * @remarks
+ * An exchange that logs incoming {@link Operation | Operations} and
+ * {@link OperationResult | OperationResults} in development.
+ *
+ * This exchange is a no-op in production and often used in issue reporting
+ * to understand certain usage patterns of `urql` without having access to
+ * the original source code.
+ *
+ * Hint: When you report an issue you’re having with `urql`, adding
+ * this as your first exchange and posting its output can speed up
+ * issue triaging a lot!
+ */
 export const debugExchange: Exchange = ({ forward }) => {
   if (process.env.NODE_ENV === 'production') {
     return ops$ => forward(ops$);

--- a/packages/core/src/exchanges/dedup.ts
+++ b/packages/core/src/exchanges/dedup.ts
@@ -1,7 +1,22 @@
 import { filter, pipe, tap } from 'wonka';
 import { Exchange, Operation, OperationResult } from '../types';
 
-/** A default exchange for debouncing GraphQL requests. */
+/** Default deduplication exchange.
+ *
+ * @remarks
+ * The `dedupExchange` deduplicates queries and subscriptions that are
+ * started with identical documents and variables by deduplicating by
+ * their {@link Operation.key}.
+ * This can prevent duplicate requests from being sent to your GraphQL API.
+ *
+ * Because this is a very safe exchange to add to any GraphQL setup, it’s
+ * not only the default, but we also recommend you to always keep this
+ * exchange added and included in your setup.
+ *
+ * Hint: In React and Vue, some common usage patterns can trigger duplicate
+ * operations. For instance, in React a single render will actually
+ * trigger two phases that execute an {@link Operation}.
+ */
 export const dedupExchange: Exchange = ({ forward, dispatchDebug }) => {
   const inFlightKeys = new Set<number>();
 

--- a/packages/core/src/exchanges/fallback.ts
+++ b/packages/core/src/exchanges/fallback.ts
@@ -1,6 +1,5 @@
 import { filter, pipe, tap } from 'wonka';
 import { Operation, ExchangeIO, ExchangeInput } from '../types';
-import { noop } from '../utils';
 
 /** This is always the last exchange in the chain; No operation should ever reach it */
 export const fallbackExchange: ({
@@ -28,7 +27,3 @@ export const fallbackExchange: ({
     /* All operations that skipped through the entire exchange chain should be filtered from the output */
     filter<any>(() => false)
   );
-
-export const fallbackExchangeIO: ExchangeIO = fallbackExchange({
-  dispatchDebug: noop,
-});

--- a/packages/core/src/exchanges/fallback.ts
+++ b/packages/core/src/exchanges/fallback.ts
@@ -1,7 +1,15 @@
 import { filter, pipe, tap } from 'wonka';
 import { Operation, ExchangeIO, ExchangeInput } from '../types';
 
-/** This is always the last exchange in the chain; No operation should ever reach it */
+/** Used by the `Client` as the last exchange to warn about unhandled operations.
+ *
+ * @remarks
+ * In a normal setup, some operations may go unhandled when a {@link Client} isn’t set up
+ * with the right exchanges.
+ * For instance, a `Client` may be missing a fetch exchange, or an exchange handling subscriptions.
+ * This {@link Exchange} is added by the `Client` automatically to log warnings about unhandled
+ * {@link Operaiton | Operations} in development.
+ */
 export const fallbackExchange: ({
   dispatchDebug,
 }: Pick<ExchangeInput, 'dispatchDebug'>) => ExchangeIO = ({
@@ -24,6 +32,6 @@ export const fallbackExchange: ({
         console.warn(message);
       }
     }),
-    /* All operations that skipped through the entire exchange chain should be filtered from the output */
+    // All operations that skipped through the entire exchange chain should be filtered from the output
     filter<any>(() => false)
   );

--- a/packages/core/src/exchanges/fetch.ts
+++ b/packages/core/src/exchanges/fetch.ts
@@ -9,7 +9,23 @@ import {
   makeFetchSource,
 } from '../internal';
 
-/** A default exchange for fetching GraphQL requests. */
+/** Default GraphQL over HTTP fetch exchange.
+ *
+ * @remarks
+ * The default fetch exchange in `urql` supports sending GraphQL over HTTP
+ * requests, can optionally send GraphQL queries as GET requests, and
+ * handles incremental multipart responses.
+ *
+ * This exchange does not handle persisted queries or multipart uploads.
+ * Support for the former can be added using `@urql/exchange-persisted-fetch`
+ * and the latter using `@urql/exchange-multipart-fetch`.
+ *
+ * Hint: The `fetchExchange` and the two other exchanges all use the built-in fetch
+ * utilities in `@urql/core/internal`, which you can also use to implement
+ * a customized fetch exchange.
+ *
+ * @see {@link makeFetchSource} for the shared utility calling the Fetch API.
+ */
 export const fetchExchange: Exchange = ({ forward, dispatchDebug }) => {
   return ops$ => {
     const sharedOps$ = share(ops$);

--- a/packages/core/src/exchanges/index.ts
+++ b/packages/core/src/exchanges/index.ts
@@ -4,7 +4,6 @@ export { subscriptionExchange } from './subscription';
 export { debugExchange } from './debug';
 export { dedupExchange } from './dedup';
 export { fetchExchange } from './fetch';
-export { fallbackExchangeIO } from './fallback';
 export { composeExchanges } from './compose';
 
 export type {

--- a/packages/core/src/exchanges/map.ts
+++ b/packages/core/src/exchanges/map.ts
@@ -2,14 +2,70 @@ import { mergeMap, fromValue, fromPromise, pipe } from 'wonka';
 import { Operation, OperationResult, Exchange } from '../types';
 import { CombinedError } from '../utils';
 
+/** Options for the `mapExchange` allowing it to react to incoming operations, results, or errors. */
 export interface MapExchangeOpts {
+  /** Accepts a callback for incoming `Operation`s.
+   *
+   * @param operation - An {@link Operation} that the {@link mapExchange} received.
+   * @returns optionally a new {@link Operation} replacing the original.
+   *
+   * @remarks
+   * You may return new {@link Operation | Operations} from this function replacing
+   * the original that the {@link mapExchange} received.
+   * It’s recommended that you use the {@link makeOperation} utility to create a copy
+   * of the original when you do this. (However, this isn’t required)
+   *
+   * Hint: The callback may also be promisified and return a new {@link Operation} asynchronously,
+   * provided you place your {@link mapExchange} after all synchronous {@link Exchange | Exchanges},
+   * like after your `cacheExchange`.
+   */
   onOperation?(operation: Operation): Promise<Operation> | Operation | void;
+  /** Accepts a callback for incoming `OperationResult`s.
+   *
+   * @param result - An {@link OperationResult} that the {@link mapExchange} received.
+   * @returns optionally a new {@link OperationResult} replacing the original.
+   *
+   * @remarks
+   * This callback may optionally return a new {@link OperationResult} that replaces the original,
+   * which you can use to modify incoming API results.
+   *
+   * Hint: The callback may also be promisified and return a new {@link Operation} asynchronously,
+   * provided you place your {@link mapExchange} after all synchronous {@link Exchange | Exchanges},
+   * like after your `cacheExchange`.
+   */
   onResult?(
     result: OperationResult
   ): Promise<OperationResult> | OperationResult | void;
+  /** Accepts a callback for incoming `CombinedError`s.
+   *
+   * @param error - A {@link CombinedError} that an incoming {@link OperationResult} contained.
+   * @param operation - The {@link Operation} of the incoming {@link OperationResult}.
+   *
+   * @remarks
+   * The callback may also be promisified and return a new {@link Operation} asynchronously,
+   * provided you place your {@link mapExchange} after all synchronous {@link Exchange | Exchanges},
+   * like after your `cacheExchange`.
+   */
   onError?(error: CombinedError, operation: Operation): void;
 }
 
+/** Creates an `Exchange` mapping over incoming operations, results, and/or errors.
+ *
+ * @param opts - A {@link MapExchangeOpts} configuration object, containing the callbacks the `mapExchange` will use.
+ * @returns the created {@link Exchange}
+ *
+ * @remarks
+ * The `mapExchange` may be used to react to or modify incoming {@link Operation | Operations}
+ * and {@link OperationResult | OperationResults}. Optionally, it can also modify these
+ * asynchronously, when a promise is returned from the callbacks.
+ *
+ * This is useful to, for instance, add an authentication token to a given request, when
+ * the `@urql/exchange-auth` package would be overkill.
+ *
+ * It can also accept an `onError` callback, which can be used to react to incoming
+ * {@link CombinedError | CombinedErrors} on results, and trigger side-effects.
+ *
+ */
 export const mapExchange = ({
   onOperation,
   onResult,

--- a/packages/core/src/exchanges/ssr.ts
+++ b/packages/core/src/exchanges/ssr.ts
@@ -4,31 +4,102 @@ import { Exchange, OperationResult, Operation } from '../types';
 import { addMetadata, CombinedError } from '../utils';
 import { reexecuteOperation } from './cache';
 
+/** A serialized version of an {@link OperationResult}.
+ *
+ * @remarks
+ * All properties are serialized separately as JSON strings, except for the
+ * {@link CombinedError} to speed up JS parsing speed, even if a result doesn’t
+ * end up being used.
+ *
+ * @internal
+ */
 export interface SerializedResult {
   hasNext?: boolean;
+  /** JSON-serialized version of {@link OperationResult.data}. */
   data?: string | undefined; // JSON string of data
-  extensions?: string | undefined; // JSON string of data
+  /** JSON-serialized version of {@link OperationResult.extensions}. */
+  extensions?: string | undefined;
+  /** JSON version of {@link CombinedError}. */
   error?: {
     graphQLErrors: Array<Partial<GraphQLError> | string>;
     networkError?: string;
   };
 }
 
+/** A dictionary of {@link Operation.key} keys to serializable {@link SerializedResult} objects.
+ *
+ * @remarks
+ * It’s not recommended to modify the serialized data manually, however, multiple payloads of
+ * this dictionary may safely be merged and combined.
+ */
 export interface SSRData {
   [key: string]: SerializedResult;
 }
 
+/** Options for the `ssrExchange` allowing it to either operate on the server- or client-side. */
 export interface SSRExchangeParams {
+  /** Indicates to the {@link SSRExchange} whether it's currently in server-side or client-side mode.
+   *
+   * @remarks
+   * Depending on this option, the {@link SSRExchange} will either capture or replay results.
+   * When `true`, it’s in client-side mode and results will be serialized. When `false`, it’ll
+   * use its deserialized data and replay results from it.
+   */
   isClient?: boolean;
+  /** May be used on the client-side to pass the {@link SSRExchange} serialized data from the server-side.
+   *
+   * @remarks
+   * Alternatively, {@link SSRExchange.restoreData} may be called to imperatively add serialized data to
+   * the exchange.
+   *
+   * Hint: This method also works on the server-side to add to the initial serialized data, which enables
+   * you to combine multiple {@link SSRExchange} results, as needed.
+   */
   initialState?: SSRData;
+  /** Forces a new API request to be sent in the background after replaying the deserialized result.
+   *
+   * @remarks
+   * Similarly to the `cache-and-network` {@link RequestPolicy}, this option tells the {@link SSRExchange}
+   * to send a new API request for the {@link Operation} after replaying a serialized result.
+   *
+   * Hint: This is useful when you're caching SSR results and need the client-side to update itself after
+   * rendering the initial serialized SSR results.
+   */
   staleWhileRevalidate?: boolean;
+  /** Forces {@link OperationResult.extensions} to be serialized alongside the rest of a result.
+   *
+   * @remarks
+   * Entries in the `extension` object of a GraphQL result are often non-standard metdata, and many
+   * APIs use it for data that changes between every request. As such, the {@link SSRExchange} will
+   * not serialize this data by default, unless this flag is set.
+   */
   includeExtensions?: boolean;
 }
 
+/** An `SSRExchange` either in server-side mode, serializing results, or client-side mode, deserializing and replaying results..
+ *
+ * @remarks
+ * This same {@link Exchange} is used in your code both for the client-side and server-side as it’s “universal”
+ * and can be put into either client-side or server-side mode using the {@link SSRExchangeParams.isClient} flag.
+ *
+ * In server-side mode, the `ssrExchange` will “record” results it sees from your API and provide them for you
+ * to send to the client-side using the {@link SSRExchange.extractData} method.
+ *
+ * In client-side mode, the `ssrExchange` will use these serialized results, rehydrated either using
+ * {@link SSRExchange.restoreData} or {@link SSRexchangeParams.initialState}, to replay results the
+ * server-side has seen and sent before.
+ *
+ * Each serialized result will only be replayed once, as it’s assumed that your cache exchange will have the
+ * results cached afterwards.
+ */
 export interface SSRExchange extends Exchange {
-  /** Rehydrates cached data */
+  /** Client-side method to add serialized results to the {@link SSRExchange}.
+   * @param data - {@link SSRData},
+   */
   restoreData(data: SSRData): void;
-  /** Extracts cached data */
+  /** Server-side method to get all serialized results the {@link SSRExchange} has captured.
+   * @returns an {@link SSRData} dictionary.
+   */
   extractData(): SSRData;
 }
 
@@ -65,7 +136,9 @@ const serializeResult = (
   return result;
 };
 
-/** Deserialize plain JSON to an OperationResult */
+/** Deserialize plain JSON to an OperationResult
+ * @internal
+ */
 const deserializeResult = (
   operation: Operation,
   result: SerializedResult,
@@ -90,7 +163,22 @@ const deserializeResult = (
 
 const revalidated = new Set<number>();
 
-/** The ssrExchange can be created to capture data during SSR and also to rehydrate it on the client */
+/** Creates a server-side rendering `Exchange` that either captures responses on the server-side or replays them on the client-side.
+ *
+ * @param params - An {@link SSRExchangeParams} configuration object.
+ * @returns the created {@link SSRExchange}
+ *
+ * @remarks
+ * When dealing with server-side rendering, we essentially have two {@link Client | Clients} making requests,
+ * the server-side client, and the client-side one. The `ssrExchange` helps implementing a tiny cache on both
+ * sides that:
+ *
+ * - captures results on the server-side which it can serialize,
+ * - replays results on the client-side that it deserialized from the server-side.
+ *
+ * Hint: The `ssrExchange` is basically an exchange that acts like a replacement for any fetch exchange
+ * temporarily. As such, you should place it after your cache exchange but in front of any fetch exchange.
+ */
 export const ssrExchange = (params: SSRExchangeParams = {}): SSRExchange => {
   const staleWhileRevalidate = !!params.staleWhileRevalidate;
   const includeExtensions = !!params.includeExtensions;

--- a/packages/core/src/exchanges/subscription.ts
+++ b/packages/core/src/exchanges/subscription.ts
@@ -25,14 +25,38 @@ import {
   OperationResult,
 } from '../types';
 
+/** An abstract observer-like interface.
+ *
+ * @remarks
+ * Observer-like interfaces are passed to {@link ObservableLike.subscribe} to provide them
+ * with callbacks for their events.
+ *
+ * @see {@link https://github.com/tc39/proposal-observable} for the full TC39 Observable proposal.
+ */
 export interface ObserverLike<T> {
+  /** Callback for values an {@link ObservableLike} emits. */
   next: (value: T) => void;
+  /** Callback for an error an {@link ObservableLike} emits, which ends the subscription. */
   error: (err: any) => void;
+  /** Callback for the completion of an {@link ObservableLike}, which ends the subscription. */
   complete: () => void;
 }
 
-/** An abstract observable interface conforming to: https://github.com/tc39/proposal-observable */
+/** An abstract observable-like interface.
+ *
+ * @remarks
+ * Observable, or Observable-like interfaces, are often used by GraphQL transports to abstract
+ * how they send {@link ExecutionResult | ExecutionResults} to consumers. These generally contain
+ * a `subscribe` method accepting an {@link ObserverLike} structure.
+ *
+ * @see {@link https://github.com/tc39/proposal-observable} for the full TC39 Observable proposal.
+ */
 export interface ObservableLike<T> {
+  /** Start the Observable-like subscription and returns a subscription handle.
+   *
+   * @param observer - an {@link ObserverLike} object with result, error, and completion callbacks.
+   * @returns a subscription handle providing an `unsubscribe` method to stop the subscription.
+   */
   subscribe(
     observer: ObserverLike<T>
   ): {
@@ -40,6 +64,13 @@ export interface ObservableLike<T> {
   };
 }
 
+/** A more cross-compatible version of the {@link Operation} structure.
+ *
+ * @remarks
+ * When the `subscriptionExchange` was first created, some transports needed a specific shape
+ * of {@link GraphQLRequest} objects to be passed to them. This is a shim that is as compatible
+ * with most transports out of the box as possible.
+ */
 export interface SubscriptionOperation {
   query: string;
   variables: Record<string, unknown> | undefined;
@@ -47,21 +78,67 @@ export interface SubscriptionOperation {
   context: OperationContext;
 }
 
+/** A subscription forwarding function, which must accept a {@link SubscriptionOperation}.
+ *
+ * @param operation - A {@link SubscriptionOperation}
+ * @returns An {@link ObservableLike} object issuing {@link ExecutionResult | ExecutionResults}.
+ */
 export type SubscriptionForwarder = (
   operation: SubscriptionOperation
 ) => ObservableLike<ExecutionResult>;
 
 /** This is called to create a subscription and needs to be hooked up to a transport client. */
 export interface SubscriptionExchangeOpts {
-  // This has been modelled to work with subscription-transport-ws
-  // See: https://github.com/apollographql/subscriptions-transport-ws#requestoptions--observableexecutionresult-returns-observable-to-execute-the-operation
+  /** A subscription forwarding function, which must accept a {@link SubscriptionOperation}.
+   *
+   * @param operation - A {@link SubscriptionOperation}
+   * @returns An {@link ObservableLike} object issuing {@link ExecutionResult | ExecutionResults}.
+   *
+   * @remarks
+   * This callback is called for each {@link Operation} that this `subscriptionExchange` will
+   * handle. It receives the {@link SubscriptionOperation}, which is a more compatible version
+   * of the raw {@link Operation} objects and must return an {@link ObservableLike} of results.
+   */
   forwardSubscription: SubscriptionForwarder;
 
-  /** This flag may be turned on to allow your subscriptions-transport to handle all operation types */
+  /** Flag to enable this exchange to handle all types of GraphQL operations.
+   *
+   * @remarks
+   * When you aren’t using fetch exchanges and GraphQL over HTTP as a transport for your GraphQL requests,
+   * or you have a third-party GraphQL transport implementation, which must also be used for queries and
+   * mutations, this flag may be used to allow this exchange to handle all kinds of GraphQL operations.
+   *
+   * By default, this flag is `false` and the exchange will only handle GraphQL subscription operations.
+   */
   enableAllOperations?: boolean;
+
+  /** A predicate function that causes an operation to be handled by this `subscriptionExchange` if `true` is returned.
+   *
+   * @param operation - an {@link Operation}
+   * @returns true when the operation is handled by this exchange.
+   *
+   * @remarks
+   * In some cases, a `subscriptionExchange` will be used to only handle some {@link Operation | Operations},
+   * e.g. all that contain `@live` directive. For these cases, this function may be passed to precisely
+   * determine which `Operation`s this exchange should handle, instead of forwarding.
+   *
+   * When specified, the {@link SubscriptionExchangeOpts.enableAllOperations} flag is disregarded.
+   */
   isSubscriptionOperation?: (operation: Operation) => boolean;
 }
 
+/** Generic subscription exchange factory used to either create an exchange handling just subscriptions or all operation kinds.
+ *
+ * @remarks
+ * `subscriptionExchange` can be used to create an {@link Exchange} that either
+ * handles just GraphQL subscription operations, or optionally all operations,
+ * when the {@link SubscriptionExchangeOpts.enableAllOperations} flag is passed.
+ *
+ * The {@link SubscriptionExchangeOpts.forwardSubscription} function must
+ * be provided and provides a generic input that's based on {@link Operation}
+ * but is compatible with many libraries implementing GraphQL request or
+ * subscription interfaces.
+ */
 export const subscriptionExchange = ({
   forwardSubscription,
   enableAllOperations,

--- a/packages/core/src/gql.ts
+++ b/packages/core/src/gql.ts
@@ -34,6 +34,52 @@ const applyDefinitions = (
   }
 };
 
+/** A GraphQL parse function, which may be called as a tagged template literal, returning a parsed {@link DocumentNode}.
+ *
+ * @remarks
+ * The `gql` tag or function is used to parse a GraphQL query document into a {@link DocumentNode}.
+ *
+ * When used as a tagged template, `gql` will automatically merge fragment definitions into the resulting
+ * document and deduplicate them.
+ *
+ * It enforces that all fragments have a unique name. When fragments with different definitions share a name,
+ * it will log a warning in development.
+ *
+ * Hint: It’s recommended to use this `gql` function over other GraphQL parse functions, since it puts the parsed
+ * results directly into `@urql/core`’s internal caches and prevents further unnecessary work.
+ *
+ * @example
+ * ```ts
+ * const AuthorFragment = gql`
+ *   fragment AuthorDisplayComponent on Author {
+ *     id
+ *     name
+ *   }
+ * `;
+ *
+ * const BookFragment = gql`
+ *   fragment ListBookComponent on Book {
+ *     id
+ *     title
+ *     author {
+ *       ...AuthorDisplayComponent
+ *     }
+ *   }
+ *
+ *   ${AuthorFragment}
+ * `;
+ *
+ * const BookQuery = gql`
+ *   query Book($id: ID!) {
+ *     book(id: $id) {
+ *       ...BookFragment
+ *     }
+ *   }
+ *
+ *   ${BookFragment}
+ * `;
+ * ```
+ */
 function gql<Data = any, Variables extends AnyVariables = AnyVariables>(
   strings: TemplateStringsArray,
   ...interpolations: Array<TypedDocumentNode | DocumentNode | string>

--- a/packages/core/src/internal/fetchOptions.ts
+++ b/packages/core/src/internal/fetchOptions.ts
@@ -5,6 +5,7 @@ import {
 } from '../utils';
 import { AnyVariables, GraphQLRequest, Operation } from '../types';
 
+/** Abstract definition of the JSON data sent during GraphQL HTTP POST requests. */
 export interface FetchBody {
   query?: string;
   operationName: string | undefined;
@@ -12,6 +13,11 @@ export interface FetchBody {
   extensions: undefined | Record<string, any>;
 }
 
+/** Creates a GraphQL over HTTP compliant JSON request body.
+ * @param request - An object containing a `query` document and `variables`.
+ * @returns A {@link FetchBody}
+ * @see {@link https://github.com/graphql/graphql-over-http} for the GraphQL over HTTP spec.
+ */
 export function makeFetchBody<
   Data = any,
   Variables extends AnyVariables = AnyVariables
@@ -24,6 +30,17 @@ export function makeFetchBody<
   };
 }
 
+/** Creates a URL that will be called for a GraphQL HTTP request.
+ *
+ * @param operation - An {@link Operation} for which to make the request.
+ * @param body - A {@link FetchBody} which may be replaced with a URL.
+ *
+ * @remarks
+ * Creates the URL that’ll be called as part of a GraphQL HTTP request.
+ * Built-in fetch exchanges support sending GET requests, even for
+ * non-persisted full requests, which this function supports by being
+ * able to serialize GraphQL requests into the URL.
+ */
 export const makeFetchURL = (
   operation: Operation,
   body?: FetchBody
@@ -50,6 +67,19 @@ export const makeFetchURL = (
   return finalUrl;
 };
 
+/** Creates a `RequestInit` object for a given `Operation`.
+ *
+ * @param operation - An {@link Operation} for which to make the request.
+ * @param body - A {@link FetchBody} which is added to the options, if the request isn’t a GET request.
+ *
+ * @remarks
+ * Creates the fetch options {@link RequestInit} object that’ll be passed to the Fetch API
+ * as part of a GraphQL over HTTP request. It automatically sets a default `Content-Type`
+ * header.
+ *
+ * @see {@link https://github.com/graphql/graphql-over-http} for the GraphQL over HTTP spec.
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API} for the Fetch API spec.
+ */
 export const makeFetchOptions = (
   operation: Operation,
   body?: FetchBody

--- a/packages/core/src/internal/fetchSource.ts
+++ b/packages/core/src/internal/fetchSource.ts
@@ -15,6 +15,33 @@ const toString = (input: Buffer | ArrayBuffer): string =>
     ? (input as Buffer).toString()
     : decoder!.decode(input as ArrayBuffer);
 
+/** Makes a GraphQL HTTP request to a given API by wrapping around the Fetch API.
+ *
+ * @param operation - The {@link Operation} that should be sent via GraphQL over HTTP.
+ * @param url - The endpoint URL for the GraphQL HTTP API.
+ * @param fetchOptions - The {@link RequestInit} fetch options for the request.
+ * @returns A Wonka {@link Source} of {@link OperationResult | OperationResults}.
+ *
+ * @remarks
+ * This utility defines how all built-in fetch exchanges make GraphQL HTTP requests,
+ * supporting multipart incremental responses, cancellation and other smaller
+ * implementation details.
+ *
+ * If you’re implementing a modified fetch exchange for a GraphQL over HTTP API
+ * it’s recommended you use this utility.
+ *
+ * Hint: This function does not use the passed `operation` to create or modify the
+ * `fetchOptions` and instead expects that the options have already been created
+ * using {@link makeFetchOptions} and modified as needed.
+ *
+ * @throws
+ * If the `fetch` polyfill or globally available `fetch` function doesn’t support
+ * streamed multipart responses while trying to handle a `multipart/mixed` GraphQL response,
+ * the source will throw “Streaming requests unsupported”.
+ * This shouldn’t happen in modern browsers and Node.js.
+ *
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API} for the Fetch API spec.
+ */
 export const makeFetchSource = (
   operation: Operation,
   url: string,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -3,169 +3,621 @@ import { Source } from 'wonka';
 import { Client } from './client';
 import { CombinedError } from './utils/error';
 
-// NOTE: This is mirrored from @graphql-typed-document-node/core and must match this type exactly.
-// It has been copied here to avoid tooling problems where build systems get confused about the type-only nature of this package.
-// See for original: https://github.com/dotansimha/graphql-typed-document-node/blob/3711b12/packages/core/src/index.ts#L3-L10
+/** A GraphQL `DocumentNode` with attached generics for its result data and variables.
+ *
+ * @remarks
+ * A GraphQL {@link DocumentNode} defines both the variables it accepts on request and the `data`
+ * shape it delivers on a response in the GraphQL query language.
+ *
+ * To bridge the gap to TypeScript, tools may be used to generate TypeScript types that define the shape
+ * of `data` and `variables` ahead of time. These types are then attached to GraphQL documents using this
+ * `TypedDocumentNode` type.
+ *
+ * Using a `DocumentNode` that is typed like this will cause any `urql` API to type its input `variables`
+ * and resulting `data` using the types provided.
+ *
+ * @privateRemarks
+ * For compatibility reasons this type has been copied and internalized from:
+ * https://github.com/dotansimha/graphql-typed-document-node/blob/3711b12/packages/core/src/index.ts#L3-L10
+ *
+ * @see {@link https://github.com/dotansimha/graphql-typed-document-node} for more information.
+ */
 export interface TypedDocumentNode<
   Result = { [key: string]: any },
   Variables = { [key: string]: any }
 > extends DocumentNode {
-  /**
-   * This type is used to ensure that the variables you pass in to the query are assignable to Variables
-   * and that the Result is assignable to whatever you pass your result to. The method is never actually
-   * implemented, but the type is valid because we list it as optional
+  /** Type to check whether `Variables` and `Result` are assignable types.
+   * @internal
    */
   __apiType?: (variables: Variables) => Result;
 }
 
+/** The response format to GraphQL API requests.
+ *
+ * @remarks
+ * `ExecutionResult` describes the JSON shape of GraphQL API responses and results from
+ * executing GraphQL operations. A result can contain an array of errors and/or the
+ * requested data. The result may also contain a map of `extensions`.
+ *
+ * Results that are incrementally delivered may indicate that more results will follow
+ * after the first by adding a `hasNext: true` flag.
+ * Furthermore, when `path` is set, the `data` of the result indicates where the `data`
+ * sent in the result must be inserted.
+ *
+ * @see {@link https://spec.graphql.org/October2021/#sec-Response-Format} for the GraphQL Response Format spec
+ */
 export type ExecutionResult =
   | {
+      /** Contains a list of errors raised by fields or the request itself.
+       * @see {@link https://spec.graphql.org/October2021/#sec-Errors} for the GraphQL Errors Response spec
+       */
       errors?:
         | Array<Partial<GraphQLError> | string | Error>
         | readonly GraphQLError[];
+      /** The result of the execution of the GraphQL operation.
+       * @see {@link https://spec.graphql.org/October2021/#sec-Data} for the GraphQL Data Response spec
+       */
       data?: null | Record<string, any>;
+      /** Additional metadata that a GraphQL API may choose to send that is out of spec.
+       * @see {@link https://spec.graphql.org/October2021/#sel-EAPHJCAACCoGu9J} for the GraphQL Response spec
+       */
       extensions?: Record<string, any>;
+      /** Flag indicating whether a future, incremental response may update this response.
+       * @see {@link https://github.com/graphql/graphql-wg/blob/main/rfcs/DeferStream.md#payload-format} for the DeferStream spec
+       */
       hasNext?: boolean;
     }
   | {
+      /** Contains a list of errors raised by fields or the request itself.
+       * @see {@link https://spec.graphql.org/October2021/#sec-Errors} for the GraphQL Errors Response specification
+       */
       errors?:
         | Array<Partial<GraphQLError> | string | Error>
         | readonly GraphQLError[];
+      /** JSON data that replaces existing data as part of an incremental response.
+       * @see {@link https://github.com/graphql/graphql-wg/blob/main/rfcs/DeferStream.md#payload-format} for the DeferStream spec
+       */
       data: any;
+      /** JSON path at which the `data` should be inserted or replace existing data.
+       *
+       * @remarks
+       * The `data` of an incremental response is inserted at `path` to update a previous result, as indicated when `hasNext: true`
+       * was set previously. This means that an incremental GraphQL response can be updated with future response payloads, changing
+       * or completing a GraphQL operation over time. This is used for `@defer`, `@stream`, and `@live` queries.
+       *
+       * @see {@link https://github.com/graphql/graphql-wg/blob/main/rfcs/DeferStream.md#payload-format} for the DeferStream spec
+       */
       path: (string | number)[];
+      /** Flag indicating whether a future, incremental response may update this response.
+       * @see {@link https://github.com/graphql/graphql-wg/blob/main/rfcs/DeferStream.md#payload-format} for the DeferStream spec
+       */
       hasNext?: boolean;
     };
 
+/** A `Source` with a `PromisifiedSource.toPromise` helper method, to promisify a single result.
+ *
+ * @remarks
+ * The {@link Client} will often return a `PromisifiedSource` to provide the `toPromise` method. When called, this returns
+ * a promise of the source that resolves on the first {@link OperationResult} of the `Source` that doesn't have `stale: true`
+ * nor `hasNext: true` set, meaning, it'll resolve to the first result that is stable and complete.
+ */
 export type PromisifiedSource<T = any> = Source<T> & {
   toPromise: () => Promise<T>;
 };
 
-/** The type of GraphQL operation being executed. */
+/** A type of Operation, either a GraphQL `query`, `mutation`, or `subscription`; or a `teardown` signal.
+ *
+ * @remarks
+ * Internally, {@link Operation | Operations} instruct the {@link Client} to perform a certain action on its exchanges.
+ * Any of the three GraphQL operations tell it to execute these operations, and the `teardown` signal instructs it that
+ * the operations are cancelled and/or have ended.
+ *
+ * The `teardown` signal is sent when nothing is subscribed to an operation anymore and no longer interested in its results
+ * or any updates.
+ */
 export type OperationType = 'subscription' | 'query' | 'mutation' | 'teardown';
 
-/** The strategy that is used to request results from network and/or the cache. */
+/** The request and caching strategy that is used by exchanges to retrive cached results.
+ *
+ * @remarks
+ * The `RequestPolicy` is used by cache exchanges to decide how a query operation may be resolved with cached results.h
+ * A cache exchange may behave differently depending on which policy is returned.
+ *
+ * - `cache-first` (the default) prefers cached results and falls back to sending an API request.
+ * - `cache-and-network` returns cached results but also always sends an API request in the background.
+ * - `network-only` will ignore any cached results and send an API request.
+ * - `cache-only` will always return cached results and prevent API requests.
+ */
 export type RequestPolicy =
   | 'cache-first'
-  | 'cache-only'
+  | 'cache-and-network'
   | 'network-only'
-  | 'cache-and-network';
+  | 'cache-only';
 
-/** How the operation has */
+/** A metadata flag set by cache exchanges to indicate whether a cache miss, a cache hit, or a partial cache hit has occurred.
+ *
+ * @remarks
+ * A cache exchange may update {@link OperationDebugMeta.cacheOutcome} on {@link OperationContext.meta} to indicate whether
+ * an operation has been resolved from the cache.
+ *
+ * A cache hit is considered a result that has fully come from a cache. A partial result is a result that has come from a cache
+ * but is incomplete, which may trigger another API request. A cache miss means a result must be requested from the API as no
+ * cache result has been delivered.
+ */
 export type CacheOutcome = 'miss' | 'partial' | 'hit';
 
 /** A default type for variables */
 export type AnyVariables = { [prop: string]: any } | void | undefined;
 
-/** A Graphql query, mutation, or subscription. */
+/** A GraphQL request representing a single execution in GraphQL.
+ *
+ * @remarks
+ * A `GraphQLRequest` is a single executable request that may be used by a cache or a GraphQL API to deliver a result.
+ * A request contains a `DocumentNode` for the query document of a GraphQL operation and the `variables` for the given
+ * request.
+ *
+ * A unique `key` is generated to identify the request internally by `urql`. Two requests with the same query and
+ * variables will share the same `key`.
+ *
+ * The `Data` and `Variables` generics may be provided by a {@link TypedDocumentNode}, adding TypeScript types for what
+ * the result shape and variables shape are.
+ *
+ * @see {@link https://spec.graphql.org/October2021/#sec-Executing-Requests} for more information on GraphQL reuqests.
+ */
 export interface GraphQLRequest<
   Data = any,
   Variables extends AnyVariables = AnyVariables
 > {
-  /** Unique identifier of the request. */
+  /** Unique identifier for the `GraphQLRequest`.
+   *
+   * @remarks
+   * This is a key that combines the unique key of the `query` and the `variables` into a unique
+   * `key` for the `GraphQLRequest`. Any request with the same query and variables will have a unique
+   * `key` by which results and requests can be identified as identical.
+   *
+   * Internally, a stable, cached `key` is generated for the `DocumentNode` and for the `variables` and
+   * both will be combined into a combined `key` which is set here, based on a DJB2 hash,
+   *
+   * The `variables` will change the key even if they contain a non-JSON reference. If you pass a custom
+   * class instance to `variables` that doesn't contain a `toString` or `toJSON` method, a stable but random
+   * identifier will replace this class to generate a key.
+   */
   key: number;
+  /** A GraphQL document to execute against a cache or API.
+   *
+   * @remarks
+   * A `GraphQLRequest` is executed against an operation in a GraphQL document.
+   * In `urql`, we expect a document to only contain a single operation that is executed rather than
+   * multiple ones by convention.
+   */
   query: DocumentNode | TypedDocumentNode<Data, Variables>;
+  /** Variables used to execute the `query` document.
+   *
+   * @remarks
+   * The `variables`, based either on the {@link AnyVariables} type or the {@link TypedDocumentNode}'s provided
+   * generic, are sent to the GraphQL API to execute a request.
+   */
   variables: Variables;
 }
 
-/** Metadata that is only available in development for devtools. */
+/** Metadata used to annotate an `Operation` in development for the `urql-devtools`.
+ *
+ * @remarks
+ * The `OperationDebugMeta` is found on {@link OperationContext.meta} only in development,
+ * and is used to send additional metadata to the `urql-devtools` about the {@link Operation}.
+ *
+ * In production, most of this metadata will be missing, and it must not be used outside
+ * of development, and should only be used by the `urql-devtools`.
+ */
 export interface OperationDebugMeta {
+  /** A label for the source of the `Operation`.
+   *
+   * @remarks
+   * The `source` string indicates a human readable originator for the `Operation`.
+   * This may be set to a component name or function name to indicate what originally
+   * triggered the `Operation`.
+   */
   source?: string;
+  /** A type of caching outcome set by cache exchanges on `OperationResult`s.
+   *
+   * @remarks
+   * The `cacheOutcome` flag is set to a {@link CacheOutcome} on {@link Operation | Operations}
+   * after they passed through the cache exchange. This flag indicates whether a cache hit, miss,
+   * or partial cache hit has occurred.
+   */
   cacheOutcome?: CacheOutcome;
+  /** Reserved to indicate the time it took for a GraphQL request to receive a response from a GraphQL API.
+   *
+   * @remarks
+   * The `networkLatency` may be set to the time it took (in ms) for a GraphQL API to respond to a request
+   * and deliver a result.
+   * @internal
+   */
   networkLatency?: number;
+  /** Reserved to indicate the timestamp at which a GraphQL request was sent to a GraphQL API.
+   *
+   * @remarks
+   * The `startTime` is set to an epoch timestamp (in ms) at which a GraphQL request was started
+   * and sent to a GraphQL API.
+   * @internal
+   */
   startTime?: number;
 }
 
-/** A unique marker that marks the operation's identity when multiple mutation operations with identical keys are issued. */
-export type OperationInstance = number & { readonly _opaque: unique symbol };
+/** A unique identity for GraphQL mutations.
+ *
+ * @remarks
+ * GraphQL mutations not only use {@link GraphQLRequest.key} to identify a result, but instead use
+ * an identity to mark which result belongs to them.
+ *
+ * While two GraphQL queries and subscriptions sharing the same variables and the same operation
+ * (i.e. `DocumentNode`) are considered identical, two mutations are not.
+ * Two GraphQL queries or subscription results with the same {@link GraphQLRequest.key} can be used
+ * to resolve any {@link GraphQLRequest} with this same `key`.
+ * This is because identical queries and subscriptions are idempotent.
+ *
+ * However, two mutations with the same variables may receive different results from a GraphQL API,
+ * since they may trigger side-effects.
+ * This means that `urql` needs an additional identifier to differentiate between two mutations with
+ * the same `DocumentNode`s and `variables`.
+ */
+export type OperationInstance = number & {
+  /** Marker to indicate that an `OperationInstance` may not be created by a user.
+   *
+   * @remarks
+   * The {@link Client} creates `OperationInstance` indentities automatically and uses them internally
+   * to identify mutations results as belonging to mutation operations. These are just integers (numbers),
+   * however, they're used as if they are objects (e.g. `{}`). However, since instances of arrays and
+   * objects are not serialisable numbers are used instead.
+   *
+   * Because these are internal, the TypeScript type is marked using a `unique symbol` because they're
+   * created opaquely and privately.
+   *
+   * @internal
+   */
+  readonly _opaque: unique symbol;
+};
 
-/** Additional metadata passed to [exchange]{@link Exchange} functions. */
+/** Additional metadata for an `Operation` used to execute it.
+ *
+ * @remarks
+ * The `OperationContext` is found on {@link Operation.context} and gives exchanges additional metadata
+ * and options used to execute the operation.
+ *
+ * The context can often be changed on a per-operation basis, meaning, APIs on the {@link Client} or
+ * bindings can pass a partial context that alters these options for a single operation.
+ *
+ * The `OperationContext` is populated mostly from the initial options passed to the `Client` at its
+ * time of creation, but may also be modified by exchanges when an {@link Operation} is passed through
+ * to the next exchange or when a result is returned.
+ */
 export interface OperationContext {
-  [key: string]: any;
+  /** A unique identity for GraphQL mutations.
+   *
+   * @remarks
+   * This is an internal property set by the `Client` to an identity of type {@link OperationInstance}.
+   * An `OperationInstance` is an identifier that's used to tell two mutation operations with identical
+   * `query` documents and `variables` apart from one another.
+   * @internal
+   */
   readonly _instance?: OperationInstance | undefined;
+  /** Additional cache tags for `@urql/core`'s document `cacheExchange`.
+   *
+   * @remarks
+   * The built-in {@link cacheExchange} in `@urql/core` is a document cache that uses `__typename`s in
+   * mutation results to invalidate past, cached queries.
+   * The `additionalTypenames` array may be set to the list of custom typenames whenever a result may
+   * not deliver `__typename` properties, e.g. when an empty array may be sent.
+   *
+   * By providing a list of custom typenames you may "tag" a result as containing a certain type, which
+   * helps the document cache associate mutations with queries when either don't actually contain a
+   * `__typename` in the JSON result.
+   */
   additionalTypenames?: string[];
+  /** The `fetch` function used to make API calls.
+   *
+   * @remarks
+   * This is the fetch polyfill used by any fetch exchange to make an API request. By default, when this
+   * option isn't set, any fetch exchange will attempt to use the globally available `fetch` function
+   * to make a request instead.
+   *
+   * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API} for the Fetch API spec.
+   */
   fetch?: typeof fetch;
-  fetchOptions?: RequestInit | (() => RequestInit);
-  requestPolicy: RequestPolicy;
+  /** The `url` passed to the `fetch` call on API requests.
+   * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/fetch} for a description of the `fetch` calls.
+   */
   url: string;
+  /** Additional options passed to the `fetch` call on API requests.
+   *
+   * @remarks
+   * The options in this object or an object returned by a callback function will be merged into the
+   * {@link RequestInit} options passed to the `fetch` call.
+   *
+   * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/fetch} for a description of this object.
+   */
+  fetchOptions?: RequestInit | (() => RequestInit);
+  /** The request and caching strategy instructing cache exchanges how to treat cached results.
+   *
+   * @remarks
+   * The {@link RequestPolicy} instructing cache exchanges how to use and treat their cached results.
+   * By default `cache-first` is set and used, which will use cache results, and only make an API request
+   * on a cache miss.
+   */
+  requestPolicy: RequestPolicy;
+  /** Metadata that annotates an `Operation` in development for the `urql-devtools`.
+   *
+   * @remarks
+   * This is metadata that is used by the `urql-devtools` to get more information about `Operation`s and
+   * `OperationResult`s and is filled in by exchanges across the codebase in development.
+   *
+   * This data is not for production use and hence shouldn't be used or relied upon directly.
+   */
   meta?: OperationDebugMeta;
-  suspense?: boolean;
   /** Instructs fetch exchanges to use a GET request.
-   * When true or 'within-url-limit' is passed, GET won't be used when the resulting URL exceeds a length of 2048. */
+   *
+   * @remarks
+   * By default, GraphQL over HTTP requests are always sent as POST requests with a JSON body.
+   * However, sometimes it's preferable to send a GET request instead, for instance, for caching with or
+   * without persisted queries.
+   *
+   * When set to `true`, the `preferGetMethod` instructs fetch exchanges to instead send a GET request
+   * for query operations.
+   *
+   * Additionally, `urql`'s built-in fetch exchanges will default to `'within-url-limit'` and not send a GET request
+   * when the resulting URL would be 2,048 characters or longer. This can be forced and circumvented by setting
+   * this option to `'force'`.
+   */
   preferGetMethod?: boolean | 'force' | 'within-url-limit';
+  /** A configuration flag indicating whether this operation may trigger "Suspense".
+   *
+   * @remarks
+   * This configuration flag is reserved for `urql` (`react-urql`) and `@urql/preact` to activate or
+   * deactivate support for Suspense, and is ignored in other bindings.
+   * When activated here and on {@link `Client.suspense`} it allows the bindings to "suspend" instead
+   * of returning a loading state, which will stop updates in a querying component and instead cascade
+   * to a higher suspense boundary for a loading state.
+   *
+   * @see {@link https://beta.reactjs.org/blog/2022/03/29/react-v18#new-suspense-features} for more information on React Suspense.
+   */
+  suspense?: boolean;
+  [key: string]: any;
 }
 
-/** A [query]{@link Query} or [mutation]{@link Mutation} with additional metadata for use during transmission. */
+/** The inputs to `urql`'s Exchange pipeline to instruct them to execute a GraphQL operation.
+ *
+ * @remarks
+ * An `Operation`, in `urql`, starts a {@link GraphQLRequest} and are events. The `kind` of an `Operation` can
+ * be set to any operation kind of GraphQL, namely `query`, `mutation`, or `subscription`. To terminate an
+ * operation, once it's cancelled, a `teardown` kind event is sent.
+ *
+ * The {@link ExchangeIO} type describes how {@link Exchange | Exchanges} receive `Operation`s and return
+ * `OperationResults`, using `teardown` `Operation`s to cancel ongoing operations.
+ *
+ * @see {@link https://formidable.com/open-source/urql/docs/architecture/#the-client-and-exchanges} for more information
+ * on the flow of Exchanges.
+ */
 export interface Operation<
   Data = any,
   Variables extends AnyVariables = AnyVariables
 > extends GraphQLRequest<Data, Variables> {
+  /** The `OperationType` describing the kind of `Operation`.
+   *
+   * @remarks
+   * This is used to describe what to do with the {@link GraphQLRequest} of an {@link Operation} and is set
+   * to a GraphQL operation type (`query`, `mutation`, or `subscription`) to start an `Operation`; and to
+   * `teardown` to cancel an operation, which either terminates it early or lets exchanges know that no
+   * consumer is interested in this operation any longer.
+   */
   readonly kind: OperationType;
+  /** Holds additional metadata for an `Operation` used to execute it.
+   *
+   * @remarks
+   * The {@link OperationContext} is created by the {@link Client} but may also be modified by
+   * {@link Exchange | Exchanges} and is used as metadata by them.
+   */
   context: OperationContext;
 }
 
-/** Resulting data from an [operation]{@link Operation}. */
+/** A result for an `Operation` carrying a full GraphQL response.
+ *
+ * @remarks
+ * An `OperationResult` is the result of an {@link Operation} and carry a description of the full response
+ * on them. The {@link OperationResult.operation} is set to the `Operation` that this result fulfils.
+ *
+ * Unlike {@link ExecutionResult}, an `OperationResult` will never be an incremental result and will
+ * always match the fully merged type of a GraphQL request. It essentially is a postprocessed version
+ * of a GraphQL API response.
+ */
 export interface OperationResult<
   Data = any,
   Variables extends AnyVariables = AnyVariables
 > {
   /** The [operation]{@link Operation} which has been executed. */
+  /** The `Operation` which this `OperationResult` is for.
+   *
+   * @remarks
+   * The `operation` property is set to the {@link Operation} that this result is. At the time the
+   * {@link OperationResult} is constructed (either from the cache or an API response) the original
+   * `Operation` that the exchange delivering this result has received will be added.
+   *
+   * The {@link Client} uses this to identify which {@link Operation} this {@link OperationResult} is
+   * for and to filter and deliver this result to the right place and consumers.
+   */
   operation: Operation<Data, Variables>;
-  /** The data returned from the Graphql server. */
+  /** The result of the execution of the GraphQL operation.
+   * @see {@link https://spec.graphql.org/October2021/#sec-Data} for the GraphQL Data Response spec
+   */
   data?: Data;
-  /** Any errors resulting from the operation. */
+  /** Contains a description of errors raised by GraphQL fields or the request itself by the API.
+   *
+   * @remarks
+   * The `error` of an `OperationResult` is set to a {@link CombinedError} if the GraphQL API response
+   * contained any GraphQL errors.
+   *
+   * GraphQL errors occur when either a GraphQL request was prevented from executing entirely
+   * (at which point `data: undefined` is set) or when one or more fields of a GraphQL request
+   * failed to execute. Due to the latter, you may receive partial data when a GraphQL request
+   * partially failed.
+   */
   error?: CombinedError;
-  /** Optional extensions return by the Graphql server. */
+  /** Additional metadata that a GraphQL API may choose to send that is out of spec.
+   * @see {@link https://spec.graphql.org/October2021/#sel-EAPHJCAACCoGu9J} for the GraphQL Response spec
+   */
   extensions?: Record<string, any>;
-  /** Optional stale flag added by exchanges that return stale results. */
+  /** Indicates that an `OperationResult` is not fresh and a new result will follow.
+   *
+   * @remarks
+   * The `stale` flag indicates whether a result is expected to be superseded by a new result soon.
+   * This flag is set whenever a new result is being awaited and will be deliverd as soon as the API responds.
+   *
+   * It may be set by the {@link Client} when the `Operation` was already active, at which point
+   * the {@link Client} asks the {@link Exchange | Exchanges} to request a new API response, or
+   * by cache exchanges when a temporary, incomplete, or initial cache result has been deliverd, and
+   * a new API request has been started in the background. (For partial cache results)
+   *
+   * Most commonly, this flag is set for a cached result when the operation is executed using the
+   * `cache-and-network` {@link RequestPolicy}.
+   */
   stale?: boolean;
-  /** Optional hasNext flag indicating deferred/streamed results are following. */
+  /** Indicates that the GraphQL response is streamed and updated results will follow.
+   *
+   * @remarks
+   * Due to incremental delivery, an API may deliver multiple {@link ExecutionResult | ExecutionResults} for a
+   * single GraphQL request. This can happen for `@defer`, `@stream`, or `@live` queries, which allow an API
+   * to update an initial GraphQL response over time, like a subscription.
+   *
+   * For GraphQL subscriptions, this flag will always be set to `true`.
+   */
   hasNext?: boolean;
 }
 
-/** Input parameters for to an Exchange factory function. */
+/** The input parameters a `Client` passes to an `Exchange` when it's created.
+ *
+ * @remarks
+ * When instantiated, a {@link Client} passes these inputs parameters to an {@link Exchange}.
+ *
+ * This input contains the `Client` itself, a `dispatchDebug` function for the `urql-devtools`, and
+ * `forward`, which is set to the next exchange's {@link ExchangeIO} function in the exchange pipeline.
+ */
 export interface ExchangeInput {
+  /** The `Client` that is using this `Exchange`.
+   *
+   * @remarks
+   * The {@link Client} instantiating the {@link Exchange} will call it with the `ExchangeInput` object,
+   * while setting `client` to itself.
+   *
+   * Exchanges use methods like {@link Client.reexecuteOperation} to issue {@link Operation | Operations}
+   * themselves, and communicate with the exchange pipeline as a whole.
+   */
   client: Client;
+  /** The next `Exchange`'s {@link ExchangeIO} function in the pipeline.
+   *
+   * @remarks
+   * `Exchange`s are like middleware function, and are henced composed like a recursive pipeline.
+   * Each `Exchange` will receive the next `Exchange`'s {@link ExchangeIO} function which they
+   * then call to compose each other.
+   *
+   * Since each `Exchange` calls the next, this creates a pipeline where operations are forwarded
+   * in sequence and `OperationResult`s from the next `Exchange` are combined with the current.
+   */
   forward: ExchangeIO;
-  dispatchDebug: <T extends keyof DebugEventTypes | string>(
+  /** Issues a debug event to the `urql-devtools`.
+   *
+   * @remarks
+   * If `@urql/devtools` are set up, this dispatch function issues events to the `urql-devtools`.
+   * These events give the devtools more granular insights on what's going on in exchanges asynchronously,
+   * since `Operation`s and `OperationResult`s only signify the “start” and “end” of a request.
+   */
+  dispatchDebug<T extends keyof DebugEventTypes | string>(
     t: DebugEventArg<T>
-  ) => void;
+  ): void;
 }
 
-/** Function responsible for listening for streamed [operations]{@link Operation}. */
+/** `Exchange`s are both extensions for a `Client` and part of the control-flow executing `Operation`s.
+ *
+ * @remarks
+ * `Exchange`s are responsible for the pipeline in `urql` that accepts {@link Operation | Operations} and
+ * returns {@link OperationResult | OperationResults}. They take care of adding functionality to a {@link Client},
+ * like deduplication, caching, and fetching (i.e. making GraphQL requests).
+ *
+ * When passed to the `Client`, they're instantiated with the {@link ExchangeInput} object and return an {@link ExchangeIO}
+ * function, which is a mapping function that receives a stream of `Operation`s and returns a stream of `OperationResult`s.
+ *
+ * Like middleware, exchanges are composed, calling each other in a pipeline-like fashion, which is facilitated by exchanges
+ * calling {@link ExchangeInput.forward}, which is set to the next exchange's {@link ExchangeIO} function in the pipeline.
+ *
+ * @see {@link https://formidable.com/open-source/urql/docs/architecture/#the-client-and-exchanges} for more information on Exchanges.
+ * @see {@link https://formidable.com/open-source/urql/docs/advanced/authoring-exchanges/} on how Exchanges are authored.
+ */
 export type Exchange = (input: ExchangeInput) => ExchangeIO;
 
-/** Function responsible for receiving an observable [operation]{@link Operation} and returning a [result]{@link OperationResult}. */
+/** Returned by `Exchange`s, the `ExchangeIO` function are the composed pipeline functions.
+ *
+ * @remarks
+ * An {@link Exchange} must return an `ExchangeIO` function, which accepts a stream of {@link Operation | Operations} which
+ * this exchange handles and returns a stream of {@link OperationResult | OperationResults}. These streams are Wonka {@link Source | Sources}.
+ *
+ * An exchange may enhance the incoming stream of `Operation`s to add, filter, map (change), or remove `Operation`s, before
+ * forwarding those to {@link ExchangeInput.forward}, using Wonka's operators, and may add or remove `OperationResult`s from
+ * the returned stream.
+ *
+ * Generally, the stream of `OperationResult` returned by {@link ExchangeInput.forward} is always merged and combined with
+ * the `Exchange`'s own stream of results if the `Exchange` creates and delivers results of its own.
+ *
+ * @see {@link https://formidable.com/open-source/urql/docs/advanced/authoring-exchanges/} on how Exchanges are authored.
+ */
 export type ExchangeIO = (ops$: Source<Operation>) => Source<OperationResult>;
 
-/** Debug event types (interfaced for declaration merging). */
+/** A mapping type of debug event types to their payloads.
+ *
+ * @remarks
+ * These are the debug events that {@link ExchangeInput.dispatchDebug} accepts mapped to the payloads these events carry.
+ * Debug events are only used in development and only consumed by the `urql-devtools`.
+ */
 export interface DebugEventTypes {
-  // Cache exchange
+  /** Signals to the devtools that a cache exchange will deliver a cached result. */
   cacheHit: { value: any };
+  /** Signals to the devtools that a cache exchange will invalidate a cached result. */
   cacheInvalidation: {
     typenames: string[];
     response: OperationResult;
   };
-  // Fetch exchange
+  /** Signals to the devtools that a fetch exchange will make a GraphQL API request. */
   fetchRequest: {
     url: string;
     fetchOptions: RequestInit;
   };
+  /** Signals to the devtools that a fetch exchange has received a GraphQL API response successfully. */
   fetchSuccess: {
     url: string;
     fetchOptions: RequestInit;
     value: object;
   };
+  /** Signals to the devtools that a fetch exchange has failed to execute a GraphQL API request. */
   fetchError: {
     url: string;
     fetchOptions: RequestInit;
     value: Error;
   };
-  // Retry exchange
+  /** Signals to the devtools that a retry exchange will retry an Operation. */
   retryRetrying: {
     retryCount: number;
   };
 }
 
+/** Utility type that maps a debug event type to its payload.
+ *
+ * @remarks
+ * This is a utility type that determines the required payload for a given debug event, which is
+ * sent to the `urql-devtools`.
+ *
+ * The payloads for known debug events are defined by the {@link DebugEventTypes} type, and
+ * each event additionally carries a human readable `message` with it, and the {@link Operation}
+ * for which the event is.
+ *
+ * @internal
+ */
 export type DebugEventArg<T extends keyof DebugEventTypes | string> = {
   type: T;
   message: string;
@@ -174,6 +626,14 @@ export type DebugEventArg<T extends keyof DebugEventTypes | string> = {
   ? { data: DebugEventTypes[T] }
   : { data?: any });
 
+/** Utility type of the full payload that is sent to the `urql-devtools`.
+ *
+ * @remarks
+ * While the {@link DebugEventArg} defines the payload that {@link ExchangeInput.dispatchDebug}
+ * accepts, each debug event then receives additional properties which are sent to the `urql-devtools`,
+ * which this type defines.
+ * @internal
+ */
 export type DebugEvent<
   T extends keyof DebugEventTypes | string = string
 > = DebugEventArg<T> & {

--- a/packages/core/src/utils/error.ts
+++ b/packages/core/src/utils/error.ts
@@ -33,12 +33,58 @@ const rehydrateGraphQlError = (error: any): GraphQLError => {
   }
 };
 
-/** An error which can consist of GraphQL errors and Network errors. */
+/** An abstracted `Error` that provides either a `networkError` or `graphQLErrors`.
+ *
+ * @remarks
+ * During a GraphQL request, either the request can fail entirely, causing a network error,
+ * or the GraphQL execution or fields can fail, which will cause an {@link ExecutionResult}
+ * to contain an array of GraphQL errors.
+ *
+ * The `CombinedError` abstracts and normalizes both failure cases. When {@link OperationResult.error}
+ * is set to this error, the `CombinedError` abstracts all errors, making it easier to handle only
+ * a subset of error cases.
+ *
+ * @see {@link https://formidable.com/open-source/urql/docs/basics/errors/} for more information on handling
+ * GraphQL errors and the `CombinedError`.
+ */
 export class CombinedError extends Error {
   public name: string;
   public message: string;
+
+  /** A list of GraphQL errors rehydrated from a {@link ExecutionResult}.
+   *
+   * @remarks
+   * If an {@link ExecutionResult} received from the API contains a list of errors,
+   * the `CombinedError` will rehydrate them, normalize them to
+   * {@link GraphQLError | GraphQLErrors} and list them here.
+   * An empty list indicates that no GraphQL error has been sent by the API.
+   */
   public graphQLErrors: GraphQLError[];
+
+  /** Set to an error, if a GraphQL request has failed outright.
+   *
+   * @remarks
+   * A GraphQL over HTTP request may fail and not reach the API. Any error that
+   * prevents a GraphQl request outright, will be considered a “network error” and
+   * set here.
+   */
   public networkError?: Error;
+
+  /** Set to the {@link Response} object a fetch exchange received.
+   *
+   * @remarks
+   * If a built-in fetch {@link Exchange} is used in `urql`, this may
+   * be set to the {@link Response} object of the Fetch API response.
+   * However, since `urql` doesn’t assume that all users will use HTTP
+   * as the only or exclusive transport for GraphQL this property is
+   * neither typed nor guaranteed and may be re-used for other purposes
+   * by non-fetch exchanges.
+   *
+   * Hint: It can be useful to use `response.status` here, however, if
+   * you plan on relying on this being a {@link Response} in your app,
+   * which it is by default, then make sure you add some extra checks
+   * before blindly assuming so!
+   */
   public response?: any;
 
   constructor(input: {

--- a/packages/core/src/utils/hash.ts
+++ b/packages/core/src/utils/hash.ts
@@ -1,8 +1,34 @@
-export type HashValue = number & { readonly _opaque: unique symbol };
+/** A hash value as computed by {@link phash}.
+ *
+ * @remarks
+ * Typically `HashValue`s are used as hashes and keys of GraphQL documents,
+ * variables, and combined, for GraphQL requests.
+ */
+export type HashValue = number & {
+  /** Marker to indicate that a `HashValue` may not be created by a user.
+   *
+   * @remarks
+   * `HashValue`s are created by {@link phash} and are marked as such to not mix them
+   * up with other numbers and prevent them from being created or used outside of this
+   * hashing function.
+   *
+   * @internal
+   */
+  readonly _opaque: unique symbol;
+};
 
-// When we have separate strings it's useful to run a progressive
-// version of djb2 where we pretend that we're still looping over
-// the same string
+/** Computes a djb2 hash of the given string.
+ *
+ * @param x - the string to be hashed
+ * @param seed - optionally a prior hash for progressive hashing
+ * @returns a hash value, i.e. a number
+ *
+ * @remark
+ * This is the hashing function used throughout `urql`, primarily to compute
+ * {@link Operation.key}.
+ *
+ * @see {@link http://www.cse.yorku.ca/~oz/hash.html#djb2} for a further description of djb2.
+ */
 export const phash = (x: string, seed?: HashValue): HashValue => {
   let h = typeof seed === 'number' ? seed | 0 : 5381;
   for (let i = 0, l = x.length | 0; i < l; i++)

--- a/packages/core/src/utils/maskTypename.ts
+++ b/packages/core/src/utils/maskTypename.ts
@@ -1,3 +1,15 @@
+/** Used to recursively mark `__typename` fields in data as non-enumerable.
+ *
+ * @remarks
+ * This utility can be used to recursively copy GraphQl response data and hide
+ * all `__typename` fields present on it.
+ *
+ * Hint: It’s not recommended to do this, unless it's absolutely necessary as
+ * cloning and modifying all data of a response can be unnecessarily slow, when
+ * a manual and more specific copy/mask is more efficient.
+ *
+ * @see {@link ClientOptions.maskTypename} for a description of how the `Client` uses this utility.
+ */
 export const maskTypename = (data: any, isRoot?: boolean): any => {
   if (!data || typeof data !== 'object') {
     return data;

--- a/packages/core/src/utils/operation.ts
+++ b/packages/core/src/utils/operation.ts
@@ -6,6 +6,29 @@ import {
   OperationType,
 } from '../types';
 
+/** Creates a {@link Operation} from the given parameters.
+ *
+ * @param kind - The {@link OperationType} of GraphQL operation, i.e. `query`, `mutation`, or `subscription`.
+ * @param request - The {@link GraphQLRequest} used as a template for the `Operation`.
+ * @param context - The {@link OperationContext} `context` data for the `Operation`.
+ * @returns An {@link Operation}.
+ *
+ * @remarks
+ * This method is both used to create new {@link Operation | Operations} as well as copy and modify existing
+ * operations. While it’s not required to use this function to copy an `Operation`, it is recommended, in case
+ * additional dynamic logic is added to them in the future.
+ *
+ * @example
+ * An example of copying an existing `Operation` to modify its `context`:
+ *
+ * ```ts
+ * makeOperation(
+ *   operation.kind,
+ *   operation,
+ *   { ...operation.context, requestPolicy: 'cache-first' },
+ * );
+ * ```
+ */
 function makeOperation<
   Data = any,
   Variables extends AnyVariables = AnyVariables
@@ -38,7 +61,9 @@ function makeOperation(kind, request, context) {
 
 export { makeOperation };
 
-/** Spreads the provided metadata to the source operation's meta property in context.  */
+/** Adds additional metadata to an `Operation`'s `context.meta` property while copying it.
+ * @see {@link OperationDebugMeta} for more information on the {@link OperationContext.meta} property.
+ */
 export const addMetadata = (
   operation: Operation,
   meta: OperationContext['meta']

--- a/packages/core/src/utils/result.ts
+++ b/packages/core/src/utils/result.ts
@@ -1,6 +1,23 @@
 import { ExecutionResult, Operation, OperationResult } from '../types';
 import { CombinedError } from './error';
 
+/** Converts the `ExecutionResult` received for a given `Operation` to an `OperationResult`.
+ *
+ * @param operation - The {@link Operation} for which the API’s result is for.
+ * @param result - The GraphQL API’s {@link ExecutionResult}.
+ * @param response - Optionally, a raw object representing the API’s result (Typically a {@link Response}).
+ * @returns An {@link OperationResult}.
+ *
+ * @remarks
+ * This utility can be used to create {@link OperationResult | OperationResults} in the shape
+ * that `urql` expects and defines, and should be used rather than creating the results manually.
+ *
+ * @throws
+ * If no data, or errors are contained within the result, or the result is instead an incremental
+ * response containing a `path` property, a “No Content” error is thrown.
+ *
+ * @see {@link ExecutionResult} for the type definition of GraphQL API results.
+ */
 export const makeResult = (
   operation: Operation,
   result: ExecutionResult,
@@ -25,6 +42,24 @@ export const makeResult = (
   };
 };
 
+/** Merges an incrementally delivered `ExecutionResult` into a previous `OperationResult`.
+ *
+ * @param prevResult - The {@link OperationResult} that preceded this result.
+ * @param path - The GraphQL API’s {@link ExecutionResult} that should be patching the `prevResult`.
+ * @param response - Optionally, a raw object representing the API’s result (Typically a {@link Response}).
+ * @returns A new {@link OperationResult} patched with the incremental result.
+ *
+ * @remarks
+ * This utility should be used to merge subsequent {@link ExecutionResult | ExecutionResults} of
+ * incremental responses into a prior {@link OperationResult}.
+ *
+ * When directives like `@defer`, `@stream`, and `@live` are used, GraphQL may deliver new
+ * results that modify previous results. In these cases, it'll set a `path` property to modify
+ * the result it sent last. This utility is built to handle these cases and merge these payloads
+ * into existing {@link OperationResult | OperationResults}.
+ *
+ * @see {@link ExecutionResult} for the type definition of GraphQL API results.
+ */
 export const mergeResultPatch = (
   prevResult: OperationResult,
   patch: ExecutionResult,
@@ -64,6 +99,19 @@ export const mergeResultPatch = (
   return result;
 };
 
+/** Creates an `OperationResult` containing a network error for requests that encountered unexpected errors.
+ *
+ * @param operation - The {@link Operation} for which the API’s result is for.
+ * @param error - The network-like error that prevented an API result from being delivered.
+ * @param response - Optionally, a raw object representing the API’s result (Typically a {@link Response}).
+ * @returns An {@link OperationResult} containing only a {@link CombinedError}.
+ *
+ * @remarks
+ * This utility can be used to create {@link OperationResult | OperationResults} in the shape
+ * that `urql` expects and defines, and should be used rather than creating the results manually.
+ * This function should be used for when the {@link CombinedError.networkError} property is
+ * populated and no GraphQL execution actually occurred.
+ */
 export const makeErrorResult = (
   operation: Operation,
   error: Error,

--- a/packages/core/src/utils/streamUtils.ts
+++ b/packages/core/src/utils/streamUtils.ts
@@ -1,6 +1,11 @@
 import { Source, subscribe, pipe } from 'wonka';
 import { OperationResult, PromisifiedSource } from '../types';
 
+/** Patches a `toPromise` method onto the `Source` passed to it.
+ * @param source$ - the Wonka {@link Source} to patch.
+ * @returns The passed `source$` with a patched `toPromise` method as a {@link PromisifiedSource}.
+ * @internal
+ */
 export function withPromise<T extends OperationResult>(
   source$: Source<T>
 ): PromisifiedSource<T> {

--- a/packages/core/src/utils/stringifyVariables.ts
+++ b/packages/core/src/utils/stringifyVariables.ts
@@ -42,6 +42,20 @@ const stringify = (x: any): string => {
   return out;
 };
 
+/** A stable stringifier for GraphQL variables objects.
+ *
+ * @param x - any JSON-like data.
+ * @return A JSON string.
+ *
+ * @remarks
+ * This utility creates a stable JSON string from any passed data,
+ * and protects itself from throwing.
+ *
+ * The JSON string is stable insofar as objects’ keys are sorted,
+ * and instances of non-plain objects are replaced with random keys
+ * replacing their values, which remain stable for the objects’
+ * instance.
+ */
 export const stringifyVariables = (x: any): string => {
   seen.clear();
   return stringify(x);

--- a/packages/core/src/utils/typenames.ts
+++ b/packages/core/src/utils/typenames.ts
@@ -29,6 +29,12 @@ const collectTypes = (obj: EntityLike | EntityLike[], types: Set<string>) => {
   return types;
 };
 
+/** Finds and returns a list of `__typename` fields found in response data.
+ *
+ * @privateRemarks
+ * This is used by `@urql/core`’s document `cacheExchange` to find typenames
+ * in a given GraphQL response’s data.
+ */
 export const collectTypesFromResponse = (response: object): string[] => [
   ...collectTypes(response as EntityLike, new Set()),
 ];
@@ -63,6 +69,24 @@ const formatNode = (node: FieldNode | InlineFragmentNode) => {
 
 const formattedDocs = new Map<number, KeyedDocumentNode>();
 
+/** Adds `__typename` fields to a GraphQL `DocumentNode`.
+ *
+ * @param node - a {@link DocumentNode}.
+ * @returns a copy of the passed {@link DocumentNode} with added `__typename` introspection fields.
+ *
+ * @remarks
+ * Cache {@link Exchange | Exchanges} will require typename introspection to
+ * recognize types in a GraphQL response. To retrieve these typenames,
+ * this function is used to add the `__typename` fields to non-root
+ * selection sets of a GraphQL document.
+ *
+ * This utility also preserves the internally computed key of the
+ * document as created by {@link createRequest} to avoid any
+ * formatting from being duplicated.
+ *
+ * @see {@link https://spec.graphql.org/October2021/#sec-Type-Name-Introspection} for more information
+ * on typename introspection via the `__typename` field.
+ */
 export const formatDocument = <T extends DocumentNode>(node: T): T => {
   const query = keyDocument(node);
 


### PR DESCRIPTION
## Summary

This adds TSDoc annotations to all exported APIs.
Generally, the style guide followed is:

- The short description will not contain links
- `@param` and `@returns` tags are generally added and contain links
- The remarks will contain further functionality if this isn't obvious from `@param` or `@returns` tags
- All notes to implementors/users are marked further with `Hint:`
- `@see` links are added to refer to important, otherwise not linked, parts of the TSDocs or web links
- Examples are only added when they illustrate a non-obvious usage pattern
- `@throws` is added if it's not obvious that an API can explicitly throw an error

## Set of changes

- Add TSDocs to all `@urql/core` exports
- Hide accidentally exposed `fallbackExchangeIO` export (not considered breaking/minor since it's unlikely to be used and was never meant to be exposed)
