### PR TITLE
docs: Fix typo in cache-updates doc about optimistic updates

### DIFF
--- a/docs/graphcache/cache-updates.md
+++ b/docs/graphcache/cache-updates.md
@@ -475,7 +475,7 @@ that imitates the result that the API is assumed to send back:
 ```js
 const cache = cacheExchange({
   optimistic: {
-    favoriteTodo(args, cache, info) {
+    favoriteTodo(variables, cache, info) {
       return {
         __typename: 'Todo',
         id: variables.id,

--- a/docs/graphcache/cache-updates.md
+++ b/docs/graphcache/cache-updates.md
@@ -475,10 +475,10 @@ that imitates the result that the API is assumed to send back:
 ```js
 const cache = cacheExchange({
   optimistic: {
-    favoriteTodo(variables, cache, info) {
+    favoriteTodo(args, cache, info) {
       return {
         __typename: 'Todo',
-        id: variables.id,
+        id: args.id,
         favorite: true,
       };
     },
@@ -504,11 +504,11 @@ functions in our optimistic object, like so:
 ```js
 const cache = cacheExchange({
   optimistic: {
-    favoriteTodo(variables, cache, info) {
+    favoriteTodo(args, cache, info) {
       return {
         __typename: 'Todo',
-        id: variables.id,
-        favorite(args, cache, info) {
+        id: args.id,
+        favorite(_args, cache, info) {
           return true;
         },
       },


### PR DESCRIPTION
Hello :)

## Summary

There is a little typo in an optimistic update in a code example

## Set of changes

Just update param name.

Thanks
