### PR TITLE
Update retryExchange.ts

### DIFF
--- a/exchanges/retry/src/retryExchange.ts
+++ b/exchanges/retry/src/retryExchange.ts
@@ -43,7 +43,7 @@ export const retryExchange = ({
 }: RetryExchangeOptions): Exchange => {
   const MIN_DELAY = initialDelayMs || 1000;
   const MAX_DELAY = maxDelayMs || 15000;
-  const MAX_ATTEMPTS = maxNumberAttempts || 2;
+  const MAX_ATTEMPTS = maxNumberAttempts;
   const RANDOM_DELAY = randomDelay !== undefined ? !!randomDelay : true;
 
   return ({ forward, dispatchDebug }) => ops$ => {
@@ -120,7 +120,7 @@ export const retryExchange = ({
           return true;
         }
 
-        const maxNumberAttemptsExceeded =
+        const maxNumberAttemptsExceeded = Boolean(MAX_ATTEMPTS) &&
           (res.operation.context.retryCount || 0) >= MAX_ATTEMPTS - 1;
 
         if (!maxNumberAttemptsExceeded) {


### PR DESCRIPTION
## Summary

https://formidable.com/open-source/urql/docs/advanced/retry-operations/#:~:text=don%27t%20want%20to-,infinitely%20attempt,-an

The documentation implies that not passing in a `maxNumberAttempts` will result in retries occurring indefinitely. This is actually behaviour that I'm trying to get, but can't get because the code is not actually doing that - it defaults to `2`.

This simple modification allows for that behavior and is also consistent with the documentation.

## Set of changes

- Removed default of '2' to `maxNumberAttempts`
- If `maxNumberAttempts` is omitted, it will always proceed to retry

Note: People relying on the original behaviour might see have issues with their, so I guess this is a breaking change, though I believe it is more in line with what is expected.