### PR TITLE
fix(graphcache): Prevent cache writes during query operations

### DIFF
--- a/.changeset/wet-buses-hide.md
+++ b/.changeset/wet-buses-hide.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Add `invariant` to data layer that prevents cache writes during cache query operations. This prevents `cache.writeFragment`, `cache.updateQuery`, and `cache.link` from being called in `resolvers` for instance.

--- a/docs/graphcache/errors.md
+++ b/docs/graphcache/errors.md
@@ -395,3 +395,17 @@ This error occurs when you are using an `interface` or `union` rather than an
 implemented type for these.
 
 Check the type mentioned and change it to one of the specific types.
+
+## (27) Invalid Cache write
+
+> Invalid Cache write: You may not write to the cache during cache reads.
+> Accesses to `cache.writeFragment`, `cache.updateQuery`, and `cache.link` may
+> not be made inside `resolvers` for instance.
+
+If you're using the `Cache` inside your `cacheExchange` config you receive it
+either inside callbacks that are called when the cache is queried (e.g.
+`resolvers`) or when data is written to the cache (e.g. `updates`). You may not
+write to the cache when it's being queried.
+
+Please make sure that you're not calling `cache.updateQuery`,
+`cache.writeFragment`, or `cache.link` inside `resolvers`.

--- a/docs/graphcache/normalized-caching.md
+++ b/docs/graphcache/normalized-caching.md
@@ -445,6 +445,10 @@ As we can see, we may perform manual changes inside of `updates` functions, whic
 affect other parts of the cache (like `Query.todos` here) beyond the automatic updates that a
 normalized cache is expected to perform.
 
+We get methods like `cache.updateQuery`, `cache.writeFragment`, and `cache.link` in our updater
+functions, which aren't available to us in local resolvers, and can only be used in these `updates`
+entries to change the data that the cache holds.
+
 [Read more about writing cache updates on the "Cache Updates" page.](./cache-updates.md)
 
 ## Deterministic Cache Updates

--- a/exchanges/graphcache/src/helpers/help.ts
+++ b/exchanges/graphcache/src/helpers/help.ts
@@ -31,7 +31,8 @@ export type ErrorCode =
   | 23
   | 24
   | 25
-  | 26;
+  | 26
+  | 27;
 
 type DebugNode = ExecutableDefinitionNode | InlineFragmentNode;
 

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -255,6 +255,16 @@ const setNode = <T>(
   fieldKey: string,
   value: T
 ) => {
+  if (process.env.NODE_ENV !== 'production') {
+    invariant(
+      currentOperation !== 'read',
+      'Invalid Cache write: You may not write to the cache during cache reads. ' +
+        ' Accesses to `cache.writeFragment`, `cache.updateQuery`, and `cache.link` may ' +
+        ' not be made inside `resolvers` for instance.',
+      27
+    );
+  }
+
   // Optimistic values are written to a map in the optimistic dict
   // All other values are written to the base map
   const keymap: KeyMap<Dict<T | undefined>> = currentOptimisticKey
@@ -550,6 +560,7 @@ const squashLayer = (layerKey: number) => {
   // Hide current dependencies from squashing operations
   const previousDependencies = currentDependencies;
   currentDependencies = new Set();
+  currentOperation = 'write';
 
   const links = currentData!.links.optimistic.get(layerKey);
   if (links) {

--- a/exchanges/graphcache/src/store/store.test.ts
+++ b/exchanges/graphcache/src/store/store.test.ts
@@ -468,7 +468,7 @@ describe('Store with OptimisticMutationConfig', () => {
     );
     let { data } = query(store, { query: connection });
 
-    InMemoryData.initDataState('read', store.data, null);
+    InMemoryData.initDataState('write', store.data, null);
     expect((data as any).exercisesConnection).toEqual(null);
     const fields = store.inspectFields({ __typename: 'Query' });
     fields.forEach(({ fieldName, arguments: args }) => {
@@ -483,7 +483,7 @@ describe('Store with OptimisticMutationConfig', () => {
   });
 
   it('should be able to write a fragment', () => {
-    InMemoryData.initDataState('read', store.data, null);
+    InMemoryData.initDataState('write', store.data, null);
 
     store.writeFragment(
       gql`
@@ -520,7 +520,7 @@ describe('Store with OptimisticMutationConfig', () => {
   });
 
   it('should be able to write a fragment by name', () => {
-    InMemoryData.initDataState('read', store.data, null);
+    InMemoryData.initDataState('write', store.data, null);
 
     store.writeFragment(
       gql`
@@ -626,7 +626,7 @@ describe('Store with OptimisticMutationConfig', () => {
   });
 
   it('should be able to update a query', () => {
-    InMemoryData.initDataState('read', store.data, null);
+    InMemoryData.initDataState('write', store.data, null);
     store.updateQuery({ query: Todos }, data => ({
       ...data,
       todos: [
@@ -686,7 +686,7 @@ describe('Store with OptimisticMutationConfig', () => {
       }
     );
 
-    InMemoryData.initDataState('read', store.data, null);
+    InMemoryData.initDataState('write', store.data, null);
     store.updateQuery({ query: Appointment, variables: { id: '1' } }, data => ({
       ...data,
       appointment: {
@@ -827,6 +827,7 @@ describe('Store with OptimisticMutationConfig', () => {
 
   describe('Invalidating an entity', () => {
     it('removes an entity from a list.', () => {
+      InMemoryData.initDataState('write', store.data, null);
       store.invalidate(todosData.todos[1]);
       const { data } = query(store, { query: Todos });
       expect(data).toBe(null);


### PR DESCRIPTION
Resolves #2977 

## Summary

This adds the missing invariants to `data.ts` that prevent cache writes during read/query operations, since users are not allowed to modify the cache during read operations.

## Set of changes

- Add dev-only invariant to prevent writes inside cache reads
- Exclude `squashLayer` operations from this restriction
- Update tests accordingly
