### PR TITLE
feat(graphcache): Allow arbitrary types in updates config

### DIFF
--- a/.changeset/thirty-pears-lay.md
+++ b/.changeset/thirty-pears-lay.md
@@ -1,5 +1,10 @@
 ---
-'@urql/exchange-graphcache': patch
+'@urql/exchange-graphcache': minor
 ---
 
 Allow `updates` config to react to arbitrary type updates other than just `Mutation` and `Subscription` fields.
+You’ll now be able to write updaters that react to any entity field being written to the cache,
+which allows for more granular invalidations. **Note:** If you’ve previously used `updates.Mutation`
+and `updated.Subscription` with a custom schema with custom root names, you‘ll get a warning since
+you’ll have to update your `updates` config to reflect this. This was a prior implementation
+mistake!

--- a/.changeset/thirty-pears-lay.md
+++ b/.changeset/thirty-pears-lay.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Allow `updates` config to react to arbitrary type updates other than just `Mutation` and `Subscription` fields.

--- a/docs/graphcache/errors.md
+++ b/docs/graphcache/errors.md
@@ -308,26 +308,28 @@ This error occurs when an unknown type is found in `opts.keys`.
 Check whether your schema is up-to-date, or whether you're using an invalid
 typename in `opts.keys`, maybe due to a typo.
 
-## (21) Invalid mutation
+## (21) Invalid updates type
 
-> Invalid mutation field `???` is not in the defined schema, but the `updates` option is referencing it.
-
-When you're passing an introspected schema to the cache exchange, it is
-able to check whether your `opts.updates.Mutation` is valid.
-This error occurs when an unknown mutation field is found in `opts.updates.Mutation`.
-
-Check whether your schema is up-to-date, or whether you've got a typo in `opts.updates.Mutation`.
-
-## (22) Invalid subscription
-
-> Invalid subscription field: `???` is not in the defined schema, but the `updates` option is referencing it.
+> Invalid updates field: The type `???` is not an object in the defined schema,
+> but the `updates` config is referencing it.
 
 When you're passing an introspected schema to the cache exchange, it is
-able to check whether your `opts.updates.Subscription` is valid.
-This error occurs when an unknown subscription field is found in `opts.updates.Subscription`.
+able to check whether your `opts.updates` config is valid.
+This error occurs when an unknown type is found in the `opts.updates` config.
+
+Check whether your schema is up-to-date, or whether you've got a typo in `opts.updates`.
+
+## (22) Invalid updates field
+
+> Invalid updates field: `???` on `???` is not in the defined schema,
+> but the `updates` config is referencing it.
+
+When you're passing an introspected schema to the cache exchange, it is
+able to check whether your `opts.updates` config is valid.
+This error occurs when an unknown field is found in `opts.updates[typename]`.
 
 Check whether your schema is up-to-date, or whether you're using an invalid
-subscription name in `opts.updates.Subscription`, maybe due to a typo.
+field name in `opts.updates`, maybe due to a typo.
 
 ## (23) Invalid resolver
 

--- a/exchanges/graphcache/src/ast/schemaPredicates.ts
+++ b/exchanges/graphcache/src/ast/schemaPredicates.ts
@@ -146,6 +146,8 @@ export function expectValidUpdatesConfig(
   }
 
   for (const updateName in updates) {
+    if (!updates[updateName]) continue;
+
     let typename: string;
     if (updateName === 'Query') {
       typename = schema.query || updateName;
@@ -167,14 +169,14 @@ export function expectValidUpdatesConfig(
     }
 
     const fields = (schema.types!.get(typename)! as SchemaObject).fields();
-    for (const fieldName in fields) {
-      if (fields[fieldName] === undefined) {
+    for (const fieldName in updates[updateName]!) {
+      if (!fields[fieldName]) {
         warn(
           'Invalid updates field: `' +
             fieldName +
             '` on `' +
             typename +
-            ' ` is not in the defined schema, but the `updates` config is referencing it.',
+            '` is not in the defined schema, but the `updates` config is referencing it.',
           22
         );
       }

--- a/exchanges/graphcache/src/ast/schemaPredicates.ts
+++ b/exchanges/graphcache/src/ast/schemaPredicates.ts
@@ -145,31 +145,39 @@ export function expectValidUpdatesConfig(
     return;
   }
 
-  for (const updateName in updates) {
-    if (!updates[updateName]) continue;
+  for (const typename in updates) {
+    if (!updates[typename]) {
+      continue;
+    } else if (!schema.types!.has(typename)) {
+      let addition = '';
 
-    let typename: string;
-    if (updateName === 'Query') {
-      typename = schema.query || updateName;
-    } else if (updateName === 'Subscription') {
-      typename = schema.subscription || updateName;
-    } else if (updateName === 'Mutation') {
-      typename = schema.mutation || updateName;
-    } else {
-      typename = updateName;
-    }
+      if (
+        typename === 'Mutation' &&
+        schema.mutation &&
+        schema.mutation !== 'Mutation'
+      ) {
+        addition +=
+          '\nMaybe your config should reference `' + schema.mutation + '`?';
+      } else if (
+        typename === 'Subscription' &&
+        schema.subscription &&
+        schema.subscription !== 'Subscription'
+      ) {
+        addition +=
+          '\nMaybe your config should reference `' + schema.subscription + '`?';
+      }
 
-    if (!schema.types!.has(typename)) {
       return warn(
         'Invalid updates type: The type `' +
           typename +
-          '` is not an object in the defined schema, but the `updates` config is referencing it.',
+          '` is not an object in the defined schema, but the `updates` config is referencing it.' +
+          addition,
         21
       );
     }
 
     const fields = (schema.types!.get(typename)! as SchemaObject).fields();
-    for (const fieldName in updates[updateName]!) {
+    for (const fieldName in updates[typename]!) {
       if (!fields[fieldName]) {
         warn(
           'Invalid updates field: `' +

--- a/exchanges/graphcache/src/operations/query.ts
+++ b/exchanges/graphcache/src/operations/query.ts
@@ -284,7 +284,7 @@ const readSelection = (
   result?: Data
 ): Data | undefined => {
   const { store } = ctx;
-  const isQuery = key === store.rootFields['query'];
+  const isQuery = key === store.rootFields.query;
 
   const entityKey = (result && store.keyOfEntity(result)) || key;
   if (!isQuery && !!ctx.store.rootNames[entityKey]) {
@@ -321,6 +321,7 @@ const readSelection = (
     return;
   }
 
+  const resolvers = store.resolvers[typename];
   const iterate = makeSelectionIterator(typename, entityKey, select, ctx);
 
   let hasFields = false;
@@ -337,7 +338,6 @@ const readSelection = (
     const key = joinKeys(entityKey, fieldKey);
     const fieldValue = InMemoryData.readRecord(entityKey, fieldKey);
     const resultValue = result ? result[fieldName] : undefined;
-    const resolvers = store.resolvers[typename];
 
     if (process.env.NODE_ENV !== 'production' && store.schema && typename) {
       isFieldAvailableOnType(store.schema, typename, fieldName);

--- a/exchanges/graphcache/src/operations/query.ts
+++ b/exchanges/graphcache/src/operations/query.ts
@@ -358,7 +358,7 @@ const readSelection = (
     } else if (
       getCurrentOperation() === 'read' &&
       resolvers &&
-      typeof resolvers[fieldName] === 'function'
+      resolvers[fieldName]
     ) {
       // We have to update the information in context to reflect the info
       // that the resolver will receive
@@ -370,7 +370,7 @@ const readSelection = (
         output[fieldAlias] = fieldValue;
       }
 
-      dataFieldValue = resolvers[fieldName](
+      dataFieldValue = resolvers[fieldName]!(
         output,
         fieldArgs || ({} as Variables),
         store,

--- a/exchanges/graphcache/src/operations/write.ts
+++ b/exchanges/graphcache/src/operations/write.ts
@@ -311,24 +311,23 @@ const writeSelection = (
       );
     }
 
-    if (isRoot) {
-      // We run side-effect updates after the default, normalized updates
-      // so that the data is already available in-store if necessary
-      const updater = ctx.store.updates[typename][fieldName];
-      if (updater) {
-        // We have to update the context to reflect up-to-date ResolveInfo
-        updateContext(
-          ctx,
-          data,
-          typename,
-          typename,
-          joinKeys(typename, fieldKey),
-          fieldName
-        );
+    // We run side-effect updates after the default, normalized updates
+    // so that the data is already available in-store if necessary
+    const updater =
+      ctx.store.updates[typename] && ctx.store.updates[typename][fieldName];
+    if (updater) {
+      // We have to update the context to reflect up-to-date ResolveInfo
+      updateContext(
+        ctx,
+        data,
+        typename,
+        typename,
+        joinKeys(typename, fieldKey),
+        fieldName
+      );
 
-        data[fieldName] = fieldValue;
-        updater(data, fieldArgs || {}, ctx.store, ctx);
-      }
+      data[fieldName] = fieldValue;
+      updater(data, fieldArgs || {}, ctx.store, ctx);
     }
 
     // After processing the field, remove the current alias from the path again

--- a/exchanges/graphcache/src/operations/write.ts
+++ b/exchanges/graphcache/src/operations/write.ts
@@ -198,9 +198,14 @@ const writeSelection = (
   select: SelectionSet,
   data: Data
 ) => {
-  const isQuery = ctx.store.rootFields.query === entityKey;
-  const isRoot = !isQuery && !!ctx.store.rootNames[entityKey!];
-  const typename = isRoot || isQuery ? entityKey : data.__typename;
+  // These fields determine how we write. The `Query` root type is written
+  // like a normal entity, hence, we use `rootField` with a default to determine
+  // this. All other root names (Subscription & Mutation) are in a different
+  // write mode
+  const rootField = ctx.store.rootNames[entityKey!] || 'query';
+  const isRoot = !!ctx.store.rootNames[entityKey!];
+
+  const typename = isRoot ? entityKey : data.__typename;
   if (!typename) {
     warn(
       "Couldn't find __typename when writing.\n" +
@@ -208,7 +213,7 @@ const writeSelection = (
       14
     );
     return;
-  } else if (!isRoot && !isQuery && entityKey) {
+  } else if (!isRoot && entityKey) {
     InMemoryData.writeRecord(entityKey, '__typename', typename);
   }
 
@@ -231,7 +236,7 @@ const writeSelection = (
     // Development check of undefined fields
     if (process.env.NODE_ENV !== 'production') {
       if (
-        !isRoot &&
+        rootField === 'query' &&
         fieldValue === undefined &&
         !deferRef.current &&
         !ctx.optimistic
@@ -262,7 +267,7 @@ const writeSelection = (
       // Fields marked as deferred that aren't defined must be skipped
       // Otherwise, we also ignore undefined values in optimistic updaters
       (fieldValue === undefined &&
-        (deferRef.current || (ctx.optimistic && !isRoot)))
+        (deferRef.current || (ctx.optimistic && rootField === 'query')))
     ) {
       continue;
     }
@@ -273,7 +278,7 @@ const writeSelection = (
     // Execute optimistic mutation functions on root fields, or execute recursive functions
     // that have been returned on optimistic objects
     let resolver: OptimisticMutationResolver | void;
-    if (ctx.optimistic && isRoot) {
+    if (ctx.optimistic && rootField === 'mutation') {
       resolver = ctx.store.optimisticMutations[fieldName];
       if (!resolver) continue;
     } else if (ctx.optimistic && typeof fieldValue === 'function') {
@@ -289,7 +294,7 @@ const writeSelection = (
 
     if (node.selectionSet) {
       // Process the field and write links for the child entities that have been written
-      if (entityKey && !isRoot) {
+      if (entityKey && rootField === 'query') {
         const key = joinKeys(entityKey, fieldKey);
         const link = writeField(
           ctx,
@@ -301,7 +306,7 @@ const writeSelection = (
       } else {
         writeField(ctx, getSelectionSet(node), ensureData(fieldValue));
       }
-    } else if (entityKey && !isRoot) {
+    } else if (entityKey && rootField === 'query') {
       // This is a leaf node, so we're setting the field's value directly
       InMemoryData.writeRecord(
         entityKey || typename,

--- a/exchanges/graphcache/src/operations/write.ts
+++ b/exchanges/graphcache/src/operations/write.ts
@@ -198,9 +198,8 @@ const writeSelection = (
   select: SelectionSet,
   data: Data
 ) => {
-  const isQuery = entityKey === ctx.store.rootFields['query'];
-  const isRoot = !isQuery && !!ctx.store.rootNames[entityKey!];
-  const typename = isRoot || isQuery ? entityKey : data.__typename;
+  const isRoot = !!ctx.store.rootNames[entityKey!];
+  const typename = isRoot ? entityKey : data.__typename;
   if (!typename) {
     warn(
       "Couldn't find __typename when writing.\n" +
@@ -208,7 +207,7 @@ const writeSelection = (
       14
     );
     return;
-  } else if (!isRoot && !isQuery && entityKey) {
+  } else if (!isRoot && entityKey) {
     InMemoryData.writeRecord(entityKey, '__typename', typename);
   }
 

--- a/exchanges/graphcache/src/store/__snapshots__/store.test.ts.snap
+++ b/exchanges/graphcache/src/store/__snapshots__/store.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Store with storage > should be able to persist embedded data 1`] = `
 {

--- a/exchanges/graphcache/src/store/store.test.ts
+++ b/exchanges/graphcache/src/store/store.test.ts
@@ -123,13 +123,6 @@ describe('Store with UpdatesConfig', () => {
     expect(store.updates.Subscription).toBe(updatesOption.Subscription);
   });
 
-  it("sets the store's updates field to an empty default if not provided", () => {
-    const store = new Store({});
-
-    expect(store.updates.Mutation).toEqual({});
-    expect(store.updates.Subscription).toEqual({});
-  });
-
   it('should not warn if Mutation/Subscription operations do exist in the schema', function () {
     new Store({
       schema: minifyIntrospectionQuery(
@@ -163,9 +156,9 @@ describe('Store with UpdatesConfig', () => {
     expect(console.warn).toBeCalledTimes(1);
     const warnMessage = mocked(console.warn).mock.calls[0][0];
     expect(warnMessage).toContain(
-      'Invalid mutation field: `doTheChaChaSlide` is not in the defined schema, but the `updates.Mutation` option is referencing it.'
+      'Invalid updates field: `doTheChaChaSlide` on `Mutation` is not in the defined schema'
     );
-    expect(warnMessage).toContain('https://bit.ly/2XbVrpR#21');
+    expect(warnMessage).toContain('https://bit.ly/2XbVrpR#22');
   });
 
   it("should warn if Subscription operations don't exist in the schema", function () {
@@ -183,7 +176,7 @@ describe('Store with UpdatesConfig', () => {
     expect(console.warn).toBeCalledTimes(1);
     const warnMessage = mocked(console.warn).mock.calls[0][0];
     expect(warnMessage).toContain(
-      'Invalid subscription field: `someoneDidTheChaChaSlide` is not in the defined schema, but the `updates.Subscription` option is referencing it.'
+      'Invalid updates field: `someoneDidTheChaChaSlide` on `Subscription` is not in the defined schema'
     );
     expect(warnMessage).toContain('https://bit.ly/2XbVrpR#22');
   });
@@ -1030,7 +1023,6 @@ describe('Store with storage', () => {
     });
 
     const mutationData = {
-      __typename: 'mutation_root',
       toggleTodo: {
         __typename: 'Todo',
         id: 1,

--- a/exchanges/graphcache/src/store/store.test.ts
+++ b/exchanges/graphcache/src/store/store.test.ts
@@ -998,7 +998,7 @@ describe('Store with storage', () => {
     expect(warnMessage).toContain('https://bit.ly/2XbVrpR#24');
   });
 
-  it('should use different rootConfigs', function () {
+  it('should use different rootConfigs', () => {
     const fakeUpdater = vi.fn();
 
     const store = new Store({
@@ -1040,7 +1040,7 @@ describe('Store with storage', () => {
           }
         `,
       },
-      mutationData
+      mutationData as any
     );
 
     expect(fakeUpdater).toBeCalledTimes(1);

--- a/exchanges/graphcache/src/store/store.test.ts
+++ b/exchanges/graphcache/src/store/store.test.ts
@@ -1016,7 +1016,7 @@ describe('Store with storage', () => {
         },
       },
       updates: {
-        Mutation: {
+        mutation_root: {
           toggleTodo: fakeUpdater,
         },
       },

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -11,7 +11,7 @@ import {
   Link,
   Data,
   QueryInput,
-  UpdateResolver,
+  UpdatesConfig,
   OptimisticMutationConfig,
   KeyingConfig,
   Entity,
@@ -43,7 +43,7 @@ export class Store<
   data: InMemoryData.InMemoryData;
 
   resolvers: ResolverConfig;
-  updates: Record<string, Record<string, UpdateResolver | undefined>>;
+  updates: UpdatesConfig;
   optimisticMutations: OptimisticMutationConfig;
   keys: KeyingConfig;
   schema?: SchemaIntrospector;
@@ -70,10 +70,7 @@ export class Store<
       if (schema.types) this.schema = schema;
     }
 
-    this.updates = {
-      [mutationName]: (opts.updates && opts.updates.Mutation) || {},
-      [subscriptionName]: (opts.updates && opts.updates.Subscription) || {},
-    };
+    this.updates = opts.updates || {};
 
     this.rootFields = {
       query: queryName,

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -49,7 +49,7 @@ export class Store<
   schema?: SchemaIntrospector;
 
   rootFields: { query: string; mutation: string; subscription: string };
-  rootNames: { [name: string]: RootField };
+  rootNames: { [name: string]: RootField | void };
 
   constructor(opts?: C) {
     if (!opts) opts = {} as C;

--- a/exchanges/graphcache/src/types.ts
+++ b/exchanges/graphcache/src/types.ts
@@ -138,7 +138,7 @@ type ResolverResult =
   | undefined;
 
 export type CacheExchangeOpts = {
-  updates?: Partial<UpdatesConfig>;
+  updates?: UpdatesConfig;
   resolvers?: ResolverConfig;
   optimistic?: OptimisticMutationConfig;
   keys?: KeyingConfig;
@@ -180,8 +180,8 @@ export type KeyGenerator = {
 }['bivarianceHack'];
 
 export type UpdatesConfig = {
-  [typeName: string | 'Query' | 'Mutation']: {
-    [fieldName: string]: UpdateResolver;
+  [typeName: string | 'Query' | 'Mutation' | 'Subscription']: {
+    [fieldName: string]: UpdateResolver | void;
   } | void;
 };
 

--- a/exchanges/graphcache/src/types.ts
+++ b/exchanges/graphcache/src/types.ts
@@ -162,8 +162,8 @@ export type Resolver<
 
 export type ResolverConfig = {
   [typeName: string]: {
-    [fieldName: string]: Resolver;
-  };
+    [fieldName: string]: Resolver | void;
+  } | void;
 };
 
 export type UpdateResolver<ParentData = DataFields, Args = Variables> = {
@@ -180,12 +180,9 @@ export type KeyGenerator = {
 }['bivarianceHack'];
 
 export type UpdatesConfig = {
-  Mutation: {
+  [typeName: string | 'Query' | 'Mutation']: {
     [fieldName: string]: UpdateResolver;
-  };
-  Subscription: {
-    [fieldName: string]: UpdateResolver;
-  };
+  } | void;
 };
 
 export type MakeFunctional<T> = T extends { __typename: string }


### PR DESCRIPTION
Resolves #2977 

## Summary

This allows arbitrary `updates` configurations to react to any type and not just `Mutation` and `Subscription`.

Users will now be able to write updaters that react to arbitrary entity field updates. Since this is now permissible, but a very nieche use-case, we currently don't foresee documenting this just yet. It's useful when a schema isn't built to touch on related data invalidating, and when the UI can't compensate for this, but this can also sometimes be a footgun.

**Important Note:** Due to an implementation mistake in the past, we never used `updates[rootName]` and instead normalised `updates.Mutation` and `updates.Subscription` according to the `schema` (partial or not) that is passed to the `cacheExchange`.
Instead, we now expect that `updates[rootName]` is passed (e.g. `updates.mutation_root` if `mutation_root` is the custom Mutation root type name).
I've currently ad-hoc decided not to mark this as major/breaking, since a) this is a mistake, and b) it's quite an uncommon use-case and users should get warnings in dev-time.

## Set of changes

- Lift check limitation in `writeSelection`
- Remove normalisation of `updates` in `Store`
- Widen `updates` types
- Update schema predicates warnings appropriately
- Apply tiny refactor to `writeSelection` root mode switch
