### PR TITLE
docs(core): Update subscriptions instructions for graphql-ws

### DIFF
--- a/docs/advanced/subscriptions.md
+++ b/docs/advanced/subscriptions.md
@@ -59,7 +59,10 @@ const client = createClient({
     subscriptionExchange({
       forwardSubscription: (operation) => ({
         subscribe: (sink) => ({
-          unsubscribe: wsClient.subscribe(operation, sink),
+          unsubscribe: wsClient.subscribe(
+            { query: operation.query, variables: operation.variables },
+            sink
+          ),
         }),
       }),
     }),


### PR DESCRIPTION
See: https://github.com/urql-graphql/urql/discussions/2984

`graphql-ws` doesn't seem to filter the input payload anymore (or never has?) which causes some GraphQL APIs to obviously fail on the extra properties we're passing in our operation abstraction.