### PR TITLE
fix(multipart-fetch): support passing in custom file detector function to `multipartFetchExchange`

### DIFF
--- a/docs/api/multipart-fetch-exchange.md
+++ b/docs/api/multipart-fetch-exchange.md
@@ -17,7 +17,7 @@ This exchange uses the same fetch logic as the [`fetchExchange`](./core.md#fetch
 The `multipartFetchExchange` is a drop-in replacement for the default
 [`fetchExchange`](./core.md#fetchexchange) and will act exactly like the `fetchExchange` unless the
 `variables` that it receives for mutations contain any `File`s as detected by the `extract-files` package.
-If the files are stored in anoy other type, such as a polyfill `File` or node `Blob` object then use `multipartFetchExchangeWithOptions()` instead, passing in a function to the `customFileCheck` option that returns a boolean if the given value is one of those custom file objects. Note that the `FormData` polyfill used must also support these file types.
+If the files are stored in any other type, such as a polyfill `File` or Node `Blob` object then use `multipartFetchExchangeWithOptions()` instead, passing in a function to the `customFileCheck` option that returns a boolean if the given value is one of those custom file objects. Note that the `FormData` polyfill used must also support these file types.
 
 ## Installation and Setup
 

--- a/docs/api/multipart-fetch-exchange.md
+++ b/docs/api/multipart-fetch-exchange.md
@@ -17,6 +17,7 @@ This exchange uses the same fetch logic as the [`fetchExchange`](./core.md#fetch
 The `multipartFetchExchange` is a drop-in replacement for the default
 [`fetchExchange`](./core.md#fetchexchange) and will act exactly like the `fetchExchange` unless the
 `variables` that it receives for mutations contain any `File`s as detected by the `extract-files` package.
+If the files are stored in anoy other type, such as a polyfill `File` or node `Blob` object then use `multipartFetchExchangeWithOptions()` instead, passing in a function to the `customFileCheck` option that returns a boolean if the given value is one of those custom file objects. Note that the `FormData` polyfill used must also support these file types.
 
 ## Installation and Setup
 
@@ -38,5 +39,29 @@ import { multipartFetchExchange } from '@urql/exchange-multipart-fetch';
 const client = createClient({
   url: 'http://localhost:3000/graphql',
   exchanges: [dedupExchange, cacheExchange, multipartFetchExchange],
+});
+```
+
+Or when using a custom `File` polyfill or ponyfill:
+
+```typescript
+import { createClient, dedupExchange, cacheExchange } from 'urql';
+import { multipartFetchExchange } from '@urql/exchange-multipart-fetch';
+
+export class CustomFile extends Blob {
+  constructor(sources: Array<Blob>, public readonly name: string) {
+    super(sources);
+  }
+}
+export const isCustomFile = (value: unknown | undefined) =>
+  value instanceof CustomFile;
+
+const client = createClient({
+  url: 'http://localhost:3000/graphql',
+  exchanges: [
+    dedupExchange, 
+    cacheExchange, 
+    multipartFetchExchangeWithOptions({ customFileCheck: isCustomFile })
+  ],
 });
 ```

--- a/exchanges/multipart-fetch/src/__snapshots__/multipartFetchExchange.test.ts.snap
+++ b/exchanges/multipart-fetch/src/__snapshots__/multipartFetchExchange.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`on error > returns error data 1`] = `
 {
@@ -457,6 +457,149 @@ exports[`on success > returns response data 1`] = `
 
 exports[`on success > returns response data 2`] = `"{\\"query\\":\\"query getUser($name: String) {\\\\n  user(name: $name) {\\\\n    id\\\\n    firstName\\\\n    lastName\\\\n  }\\\\n}\\",\\"operationName\\":\\"getUser\\",\\"variables\\":{\\"name\\":\\"Clara\\"}}"`;
 
+exports[`on success > uses a custom file when given 1`] = `
+{
+  "data": {
+    "data": {
+      "user": 1200,
+    },
+  },
+  "error": undefined,
+  "extensions": undefined,
+  "hasNext": false,
+  "operation": {
+    "context": {
+      "fetchOptions": [MockFunction spy] {
+        "calls": [
+          [],
+        ],
+        "results": [
+          {
+            "type": "return",
+            "value": {},
+          },
+        ],
+      },
+      "requestPolicy": "cache-first",
+      "url": "http://localhost:3000/graphql",
+    },
+    "key": 3,
+    "kind": "mutation",
+    "query": {
+      "__key": 8029062428,
+      "definitions": [
+        {
+          "directives": [],
+          "kind": "OperationDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "uploadProfilePicture",
+          },
+          "operation": "mutation",
+          "selectionSet": {
+            "kind": "SelectionSet",
+            "selections": [
+              {
+                "alias": undefined,
+                "arguments": [
+                  {
+                    "kind": "Argument",
+                    "name": {
+                      "kind": "Name",
+                      "value": "picture",
+                    },
+                    "value": {
+                      "kind": "Variable",
+                      "name": {
+                        "kind": "Name",
+                        "value": "picture",
+                      },
+                    },
+                  },
+                ],
+                "directives": [],
+                "kind": "Field",
+                "name": {
+                  "kind": "Name",
+                  "value": "uploadProfilePicture",
+                },
+                "selectionSet": {
+                  "kind": "SelectionSet",
+                  "selections": [
+                    {
+                      "alias": undefined,
+                      "arguments": [],
+                      "directives": [],
+                      "kind": "Field",
+                      "name": {
+                        "kind": "Name",
+                        "value": "location",
+                      },
+                      "selectionSet": undefined,
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          "variableDefinitions": [
+            {
+              "defaultValue": undefined,
+              "directives": [],
+              "kind": "VariableDefinition",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "File",
+                },
+              },
+              "variable": {
+                "kind": "Variable",
+                "name": {
+                  "kind": "Name",
+                  "value": "picture",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      "kind": "Document",
+      "loc": {
+        "end": 110,
+        "source": {
+          "body": "mutation uploadProfilePicture($picture: File) {
+  uploadProfilePicture(picture: $picture) {
+    location
+  }
+}",
+          "locationOffset": {
+            "column": 1,
+            "line": 1,
+          },
+          "name": "gql",
+        },
+        "start": 0,
+      },
+    },
+    "variables": {
+      "picture": CustomFile {
+        "name": "index.ts",
+      },
+    },
+  },
+}
+`;
+
+exports[`on success > uses a custom file when given 2`] = `
+{
+  "accept": "application/graphql+json, application/json",
+}
+`;
+
+exports[`on success > uses a custom file when given 3`] = `FormData {}`;
+
 exports[`on success > uses a file when given 1`] = `
 {
   "data": {
@@ -597,6 +740,157 @@ exports[`on success > uses a file when given 2`] = `
 `;
 
 exports[`on success > uses a file when given 3`] = `FormData {}`;
+
+exports[`on success > uses multiple custom files when given 1`] = `
+{
+  "data": {
+    "data": {
+      "user": 1200,
+    },
+  },
+  "error": undefined,
+  "extensions": undefined,
+  "hasNext": false,
+  "operation": {
+    "context": {
+      "fetchOptions": [MockFunction spy] {
+        "calls": [
+          [],
+        ],
+        "results": [
+          {
+            "type": "return",
+            "value": {},
+          },
+        ],
+      },
+      "requestPolicy": "cache-first",
+      "url": "http://localhost:3000/graphql",
+    },
+    "key": 3,
+    "kind": "mutation",
+    "query": {
+      "__key": -6039055341,
+      "definitions": [
+        {
+          "directives": [],
+          "kind": "OperationDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "uploadProfilePictures",
+          },
+          "operation": "mutation",
+          "selectionSet": {
+            "kind": "SelectionSet",
+            "selections": [
+              {
+                "alias": undefined,
+                "arguments": [
+                  {
+                    "kind": "Argument",
+                    "name": {
+                      "kind": "Name",
+                      "value": "pictures",
+                    },
+                    "value": {
+                      "kind": "Variable",
+                      "name": {
+                        "kind": "Name",
+                        "value": "pictures",
+                      },
+                    },
+                  },
+                ],
+                "directives": [],
+                "kind": "Field",
+                "name": {
+                  "kind": "Name",
+                  "value": "uploadProfilePicture",
+                },
+                "selectionSet": {
+                  "kind": "SelectionSet",
+                  "selections": [
+                    {
+                      "alias": undefined,
+                      "arguments": [],
+                      "directives": [],
+                      "kind": "Field",
+                      "name": {
+                        "kind": "Name",
+                        "value": "location",
+                      },
+                      "selectionSet": undefined,
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          "variableDefinitions": [
+            {
+              "defaultValue": undefined,
+              "directives": [],
+              "kind": "VariableDefinition",
+              "type": {
+                "kind": "ListType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "File",
+                  },
+                },
+              },
+              "variable": {
+                "kind": "Variable",
+                "name": {
+                  "kind": "Name",
+                  "value": "pictures",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      "kind": "Document",
+      "loc": {
+        "end": 116,
+        "source": {
+          "body": "mutation uploadProfilePictures($pictures: [File]) {
+  uploadProfilePicture(pictures: $pictures) {
+    location
+  }
+}",
+          "locationOffset": {
+            "column": 1,
+            "line": 1,
+          },
+          "name": "gql",
+        },
+        "start": 0,
+      },
+    },
+    "variables": {
+      "picture": [
+        CustomFile {
+          "name": "index.ts",
+        },
+        CustomFile {
+          "name": "index.ts",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`on success > uses multiple custom files when given 2`] = `
+{
+  "accept": "application/graphql+json, application/json",
+}
+`;
+
+exports[`on success > uses multiple custom files when given 3`] = `FormData {}`;
 
 exports[`on success > uses multiple files when given 1`] = `
 {

--- a/exchanges/multipart-fetch/src/multipartFetchExchange.test.ts
+++ b/exchanges/multipart-fetch/src/multipartFetchExchange.test.ts
@@ -12,12 +12,18 @@ import {
   afterAll,
 } from 'vitest';
 
-import { multipartFetchExchange } from './multipartFetchExchange';
+import {
+  multipartFetchExchange,
+  multipartFetchExchangeWithOptions,
+} from './multipartFetchExchange';
 
 import {
   uploadOperation,
   queryOperation,
   multipleUploadOperation,
+  uploadCustomOperation,
+  multipleUploadCustomOperation,
+  isCustomFile,
 } from './test-utils';
 
 const fetch = (global as any).fetch as Mock;
@@ -84,6 +90,31 @@ describe('on success', () => {
     expect(fetchOptions).toHaveBeenCalled();
     expect(fetch.mock.calls[0][1].headers).toMatchSnapshot();
     expect(fetch.mock.calls[0][1].body).toMatchSnapshot();
+    expect(fetch.mock.calls[0][1].body).toBeInstanceOf(FormData);
+  });
+
+  it('uses a custom file when given', async () => {
+    const fetchOptions = vi.fn().mockReturnValue({});
+
+    const data = await pipe(
+      fromValue({
+        ...uploadCustomOperation,
+        context: {
+          ...uploadCustomOperation.context,
+          fetchOptions,
+        },
+      }),
+      multipartFetchExchangeWithOptions({ customFileCheck: isCustomFile })(
+        exchangeArgs
+      ),
+      toPromise
+    );
+
+    expect(data).toMatchSnapshot();
+    expect(fetchOptions).toHaveBeenCalled();
+    expect(fetch.mock.calls[0][1].headers).toMatchSnapshot();
+    expect(fetch.mock.calls[0][1].body).toMatchSnapshot();
+    expect(fetch.mock.calls[0][1].body).toBeInstanceOf(FormData);
   });
 
   it('uses multiple files when given', async () => {
@@ -105,6 +136,31 @@ describe('on success', () => {
     expect(fetchOptions).toHaveBeenCalled();
     expect(fetch.mock.calls[0][1].headers).toMatchSnapshot();
     expect(fetch.mock.calls[0][1].body).toMatchSnapshot();
+    expect(fetch.mock.calls[0][1].body).toBeInstanceOf(FormData);
+  });
+
+  it('uses multiple custom files when given', async () => {
+    const fetchOptions = vi.fn().mockReturnValue({});
+
+    const data = await pipe(
+      fromValue({
+        ...multipleUploadCustomOperation,
+        context: {
+          ...multipleUploadCustomOperation.context,
+          fetchOptions,
+        },
+      }),
+      multipartFetchExchangeWithOptions({ customFileCheck: isCustomFile })(
+        exchangeArgs
+      ),
+      toPromise
+    );
+
+    expect(data).toMatchSnapshot();
+    expect(fetchOptions).toHaveBeenCalled();
+    expect(fetch.mock.calls[0][1].headers).toMatchSnapshot();
+    expect(fetch.mock.calls[0][1].body).toMatchSnapshot();
+    expect(fetch.mock.calls[0][1].body).toBeInstanceOf(FormData);
   });
 
   it('returns response data', async () => {

--- a/exchanges/multipart-fetch/src/multipartFetchExchange.ts
+++ b/exchanges/multipart-fetch/src/multipartFetchExchange.ts
@@ -9,7 +9,13 @@ import {
   makeFetchSource,
 } from '@urql/core/internal';
 
-export const multipartFetchExchange: Exchange = ({
+export interface MultipartFetchExchangeOpts {
+  customFileCheck?: (maybeFile: unknown | undefined) => boolean;
+}
+
+export const multipartFetchExchangeWithOptions = ({
+  customFileCheck,
+}: MultipartFetchExchangeOpts = {}): Exchange => ({
   forward,
   dispatchDebug,
 }) => ops$ => {
@@ -26,9 +32,13 @@ export const multipartFetchExchange: Exchange = ({
       );
 
       // Spreading operation.variables here in case someone made a variables with Object.create(null).
-      const { files, clone: variables } = extractFiles({
-        ...operation.variables,
-      });
+      const { files, clone: variables } = extractFiles(
+        {
+          ...operation.variables,
+        },
+        '',
+        customFileCheck
+      );
       const body = makeFetchBody({ query: operation.query, variables });
 
       let url: string;
@@ -104,3 +114,5 @@ export const multipartFetchExchange: Exchange = ({
 
   return merge([fetchResults$, forward$]);
 };
+
+export const multipartFetchExchange: Exchange = multipartFetchExchangeWithOptions();

--- a/exchanges/multipart-fetch/src/test-utils.ts
+++ b/exchanges/multipart-fetch/src/test-utils.ts
@@ -37,6 +37,20 @@ const file = new File(
 );
 const files = [file, file];
 
+export class CustomFile extends Blob {
+  constructor(sources: Array<Blob>, public readonly name: string) {
+    super(sources);
+  }
+}
+export const isCustomFile = (value: unknown | undefined) =>
+  value instanceof CustomFile;
+
+const customFile = new CustomFile(
+  [new Blob([JSON.stringify(obj, null, 2)], { type: 'application/json' })],
+  'index.ts'
+);
+const customFiles = [customFile, customFile];
+
 const upload: GraphQLRequest = {
   key: 3,
   query: gql`
@@ -48,6 +62,20 @@ const upload: GraphQLRequest = {
   `,
   variables: {
     picture: file,
+  },
+};
+
+const uploadCustom: GraphQLRequest = {
+  key: 3,
+  query: gql`
+    mutation uploadProfilePicture($picture: File) {
+      uploadProfilePicture(picture: $picture) {
+        location
+      }
+    }
+  `,
+  variables: {
+    picture: customFile,
   },
 };
 
@@ -65,15 +93,41 @@ const uploads: GraphQLRequest = {
   },
 };
 
+const uploadsCustom: GraphQLRequest = {
+  key: 3,
+  query: gql`
+    mutation uploadProfilePictures($pictures: [File]) {
+      uploadProfilePicture(pictures: $pictures) {
+        location
+      }
+    }
+  `,
+  variables: {
+    picture: customFiles,
+  },
+};
+
 export const uploadOperation: Operation = makeOperation(
   'mutation',
   upload,
   context
 );
 
+export const uploadCustomOperation: Operation = makeOperation(
+  'mutation',
+  uploadCustom,
+  context
+);
+
 export const multipleUploadOperation: Operation = makeOperation(
   'mutation',
   uploads,
+  context
+);
+
+export const multipleUploadCustomOperation: Operation = makeOperation(
+  'mutation',
+  uploadsCustom,
   context
 );
 


### PR DESCRIPTION
## Summary

Making a client in a VSCode extension, which runs in the node environment where `File` and `FormData` don't exist, the `multipartFetchExchange` uses the default `extract-files` call `extractFiles` without passing in a `isExtractable` function, which leaves the default one in place, where neither `File` nor `Blob` are available globally (again, in the Node environment).

## Set of changes

In the patch I adjusted `multipartFetchExchange` to be `multipartFetchExchangeWithOptions()`, with a new optional parameters list. Old code will work as-is since `multipartFetchExchange` still yields the same results, but now you can pass in a function that tests for extractable file objects (from the updated docs):

```typescript
import { createClient, dedupExchange, cacheExchange } from 'urql';
import { multipartFetchExchange } from '@urql/exchange-multipart-fetch';

export class CustomFile extends Blob {
  constructor(sources: Array<Blob>, public readonly name: string) {
    super(sources);
  }
}
export const isCustomFile = (value: unknown | undefined) =>
  value instanceof CustomFile;

const client = createClient({
  url: 'http://localhost:3000/graphql',
  exchanges: [
    dedupExchange, 
    cacheExchange, 
    multipartFetchExchangeWithOptions({ customFileCheck: isCustomFile })
  ],
});
```

I also adjusted the tests to include the new functionality (leaving the old tests in place, no regressions here 😄), and updated the docs as well. The tests were only using snapshots and didn't catch that the resulting `body` was not a proper `FromData` object so I added that test as well.