### PR TITLE
chore(core): Update default Accept header

### DIFF
--- a/.changeset/nine-dancers-film.md
+++ b/.changeset/nine-dancers-film.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': minor
+---
+
+Update default `Accept` header to include `multipart/mixed` and `application/graphql-response+json`. The former seems to now be a defactor standard-accepted indication for support of the "Incremental Delivery" GraphQL over HTTP spec addition/RFC, and the latter is an updated form of the older `Content-Type` of GraphQL responses, so both the old and new one should now be included.

--- a/packages/core/src/__snapshots__/client.test.ts.snap
+++ b/packages/core/src/__snapshots__/client.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`createClient / Client > passes snapshot 1`] = `
 Client2 {

--- a/packages/core/src/exchanges/__snapshots__/fetch.test.ts.snap
+++ b/packages/core/src/exchanges/__snapshots__/fetch.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`on error > returns error data 1`] = `
 {

--- a/packages/core/src/exchanges/__snapshots__/subscription.test.ts.snap
+++ b/packages/core/src/exchanges/__snapshots__/subscription.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`should return response data from forwardSubscription observable 1`] = `
 {

--- a/packages/core/src/internal/__snapshots__/fetchSource.test.ts.snap
+++ b/packages/core/src/internal/__snapshots__/fetchSource.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`on error > ignores the error when a result is available 1`] = `
 {

--- a/packages/core/src/internal/fetchOptions.ts
+++ b/packages/core/src/internal/fetchOptions.ts
@@ -57,7 +57,8 @@ export const makeFetchOptions = (
   const useGETMethod =
     operation.kind === 'query' && !!operation.context.preferGetMethod;
   const headers: HeadersInit = {
-    accept: 'application/graphql+json, application/json',
+    accept:
+      'multipart/mixed, application/graphql-response+json, application/graphql+json, application/json',
   };
   if (!useGETMethod) headers['content-type'] = 'application/json';
   const extraOptions =

--- a/packages/core/src/internal/fetchSource.test.ts
+++ b/packages/core/src/internal/fetchSource.test.ts
@@ -236,8 +236,12 @@ describe('on multipart/mixed', () => {
               done: false,
               value: Buffer.from(
                 wrap({
-                  path: ['author', 'todos', 1],
-                  data: { id: '2', text: 'defer', __typename: 'Todo' },
+                  incremental: [
+                    {
+                      path: ['author', 'todos', 1],
+                      data: { id: '2', text: 'defer', __typename: 'Todo' },
+                    },
+                  ],
                   hasNext: true,
                 })
               ),
@@ -360,8 +364,12 @@ describe('on multipart/mixed', () => {
               done: false,
               value: Buffer.from(
                 wrap({
-                  path: ['author'],
-                  data: { name: 'Steve' },
+                  incremental: [
+                    {
+                      path: ['author'],
+                      data: { name: 'Steve' },
+                    },
+                  ],
                   hasNext: true,
                 })
               ),
@@ -483,8 +491,12 @@ describe('on multipart/mixed', () => {
               done: false,
               value: Buffer.from(
                 wrap({
-                  path: ['author', 'address'],
-                  data: { street: 'home' },
+                  incremental: [
+                    {
+                      path: ['author', 'address'],
+                      data: { street: 'home' },
+                    },
+                  ],
                   hasNext: true,
                 })
               ),

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -18,23 +18,25 @@ export interface TypedDocumentNode<
   __apiType?: (variables: Variables) => Result;
 }
 
-export type ExecutionResult =
-  | {
-      errors?:
-        | Array<Partial<GraphQLError> | string | Error>
-        | readonly GraphQLError[];
-      data?: null | Record<string, any>;
-      extensions?: Record<string, any>;
-      hasNext?: boolean;
-    }
-  | {
-      errors?:
-        | Array<Partial<GraphQLError> | string | Error>
-        | readonly GraphQLError[];
-      data: any;
-      path: (string | number)[];
-      hasNext?: boolean;
-    };
+type ErrorLike = Partial<GraphQLError> | Error | string;
+type Extensions = Record<string, any>;
+
+interface IncrementalPayload {
+  label?: string | null;
+  path: readonly (string | number)[];
+  data?: Record<string, unknown> | null;
+  items?: readonly unknown[] | null;
+  errors?: ErrorLike[] | readonly ErrorLike[];
+  extensions?: Extensions;
+}
+
+export interface ExecutionResult {
+  incremental?: IncrementalPayload[];
+  data?: null | Record<string, any>;
+  errors?: ErrorLike[] | readonly ErrorLike[];
+  extensions?: Extensions;
+  hasNext?: boolean;
+}
 
 export type PromisifiedSource<T = any> = Source<T> & {
   toPromise: () => Promise<T>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -21,7 +21,7 @@ export interface TypedDocumentNode<
 type ErrorLike = Partial<GraphQLError> | Error | string;
 type Extensions = Record<string, any>;
 
-interface IncrementalPayload {
+export interface IncrementalPayload {
   label?: string | null;
   path: readonly (string | number)[];
   data?: Record<string, unknown> | null;

--- a/packages/core/src/utils/__snapshots__/error.test.ts.snap
+++ b/packages/core/src/utils/__snapshots__/error.test.ts.snap
@@ -1,3 +1,3 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`CombinedError > behaves like a normal Error 1`] = `"[Network] test"`;

--- a/packages/core/src/utils/result.test.ts
+++ b/packages/core/src/utils/result.test.ts
@@ -250,4 +250,40 @@ describe('mergeResultPatch', () => {
       __typename: 'Query',
     });
   });
+
+  it('handles the old version of the incremental payload spec (DEPRECATED)', () => {
+    const prevResult: OperationResult = {
+      operation: queryOperation,
+      data: {
+        __typename: 'Query',
+        items: [
+          {
+            __typename: 'Item',
+            id: 'id',
+            child: undefined,
+          },
+        ],
+      },
+    };
+
+    const patch = { __typename: 'Child' };
+
+    const merged = mergeResultPatch(prevResult, {
+      data: patch,
+      path: ['items', 0, 'child'],
+    } as any);
+
+    expect(merged.data.items[0]).not.toBe(prevResult.data.items[0]);
+    expect(merged.data.items[0].child).toBe(patch);
+    expect(merged.data).toStrictEqual({
+      __typename: 'Query',
+      items: [
+        {
+          __typename: 'Item',
+          id: 'id',
+          child: patch,
+        },
+      ],
+    });
+  });
 });

--- a/packages/core/src/utils/result.test.ts
+++ b/packages/core/src/utils/result.test.ts
@@ -230,4 +230,24 @@ describe('mergeResultPatch', () => {
       [GraphQL] patch]
     `);
   });
+
+  it('should preserve all data for noop patches', () => {
+    const prevResult: OperationResult = {
+      operation: queryOperation,
+      data: {
+        __typename: 'Query',
+      },
+      extensions: {
+        base: true,
+      },
+    };
+
+    const merged = mergeResultPatch(prevResult, {
+      hasNext: false,
+    });
+
+    expect(merged.data).toStrictEqual({
+      __typename: 'Query',
+    });
+  });
 });

--- a/packages/core/src/utils/result.test.ts
+++ b/packages/core/src/utils/result.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
+import { OperationResult } from '../types';
 import { queryOperation } from '../test-utils';
-import { makeResult } from './result';
+import { makeResult, mergeResultPatch } from './result';
 
 describe('makeResult', () => {
   it('adds extensions and errors correctly', () => {
@@ -21,5 +22,212 @@ describe('makeResult', () => {
     expect(result.error).toMatchInlineSnapshot(
       `[CombinedError: [GraphQL] error message]`
     );
+  });
+});
+
+describe('mergeResultPatch', () => {
+  it('should ignore invalid patches', () => {
+    const prevResult: OperationResult = {
+      operation: queryOperation,
+      data: {
+        __typename: 'Query',
+        items: [
+          {
+            __typename: 'Item',
+            id: 'id',
+          },
+        ],
+      },
+    };
+
+    const merged = mergeResultPatch(prevResult, {
+      incremental: [
+        {
+          data: undefined,
+          path: ['a'],
+        },
+        {
+          items: null,
+          path: ['b'],
+        },
+      ],
+    });
+
+    expect(merged.data).toStrictEqual({
+      __typename: 'Query',
+      items: [
+        {
+          __typename: 'Item',
+          id: 'id',
+        },
+      ],
+    });
+  });
+
+  it('should apply incremental defer patches', () => {
+    const prevResult: OperationResult = {
+      operation: queryOperation,
+      data: {
+        __typename: 'Query',
+        items: [
+          {
+            __typename: 'Item',
+            id: 'id',
+            child: undefined,
+          },
+        ],
+      },
+    };
+
+    const patch = { __typename: 'Child' };
+
+    const merged = mergeResultPatch(prevResult, {
+      incremental: [
+        {
+          data: patch,
+          path: ['items', 0, 'child'],
+        },
+      ],
+    });
+
+    expect(merged.data.items[0]).not.toBe(prevResult.data.items[0]);
+    expect(merged.data.items[0].child).toBe(patch);
+    expect(merged.data).toStrictEqual({
+      __typename: 'Query',
+      items: [
+        {
+          __typename: 'Item',
+          id: 'id',
+          child: patch,
+        },
+      ],
+    });
+  });
+
+  it('should handle null incremental defer patches', () => {
+    const prevResult: OperationResult = {
+      operation: queryOperation,
+      data: {
+        __typename: 'Query',
+        item: undefined,
+      },
+    };
+
+    const merged = mergeResultPatch(prevResult, {
+      incremental: [
+        {
+          data: null,
+          path: ['item'],
+        },
+      ],
+    });
+
+    expect(merged.data).not.toBe(prevResult.data);
+    expect(merged.data.item).toBe(null);
+  });
+
+  it('should apply incremental stream patches', () => {
+    const prevResult: OperationResult = {
+      operation: queryOperation,
+      data: {
+        __typename: 'Query',
+        items: [{ __typename: 'Item' }],
+      },
+    };
+
+    const patch = { __typename: 'Item' };
+
+    const merged = mergeResultPatch(prevResult, {
+      incremental: [
+        {
+          items: [patch],
+          path: ['items', 1],
+        },
+      ],
+    });
+
+    expect(merged.data.items).not.toBe(prevResult.data.items);
+    expect(merged.data.items[0]).toBe(prevResult.data.items[0]);
+    expect(merged.data.items[1]).toBe(patch);
+    expect(merged.data).toStrictEqual({
+      __typename: 'Query',
+      items: [{ __typename: 'Item' }, { __typename: 'Item' }],
+    });
+  });
+
+  it('should handle null incremental stream patches', () => {
+    const prevResult: OperationResult = {
+      operation: queryOperation,
+      data: {
+        __typename: 'Query',
+        items: [{ __typename: 'Item' }],
+      },
+    };
+
+    const merged = mergeResultPatch(prevResult, {
+      incremental: [
+        {
+          items: null,
+          path: ['items', 1],
+        },
+      ],
+    });
+
+    expect(merged.data.items).not.toBe(prevResult.data.items);
+    expect(merged.data.items[0]).toBe(prevResult.data.items[0]);
+    expect(merged.data).toStrictEqual({
+      __typename: 'Query',
+      items: [{ __typename: 'Item' }],
+    });
+  });
+
+  it('should merge extensions from each patch', () => {
+    const prevResult: OperationResult = {
+      operation: queryOperation,
+      data: {
+        __typename: 'Query',
+      },
+      extensions: {
+        base: true,
+      },
+    };
+
+    const merged = mergeResultPatch(prevResult, {
+      incremental: [
+        {
+          data: null,
+          path: ['item'],
+          extensions: {
+            patch: true,
+          },
+        },
+      ],
+    });
+
+    expect(merged.extensions).toStrictEqual({
+      base: true,
+      patch: true,
+    });
+  });
+
+  it('should combine errors from each patch', () => {
+    const prevResult: OperationResult = makeResult(queryOperation, {
+      errors: ['base'],
+    });
+
+    const merged = mergeResultPatch(prevResult, {
+      incremental: [
+        {
+          data: null,
+          path: ['item'],
+          errors: ['patch'],
+        },
+      ],
+    });
+
+    expect(merged.error).toMatchInlineSnapshot(`
+      [CombinedError: [GraphQL] base
+      [GraphQL] patch]
+    `);
   });
 });

--- a/packages/core/src/utils/result.ts
+++ b/packages/core/src/utils/result.ts
@@ -70,7 +70,7 @@ export const mergeResultPatch = (
       }
     }
   } else {
-    data = nextResult.data;
+    data = nextResult.data || prevResult.data;
   }
 
   return {

--- a/packages/core/src/utils/result.ts
+++ b/packages/core/src/utils/result.ts
@@ -44,10 +44,15 @@ export const mergeResultPatch = (
   const errors = prevResult.error ? prevResult.error.graphQLErrors : [];
 
   let incremental = nextResult.incremental;
+
   // NOTE: We handle the old version of the incremental delivery payloads as well
   if ('path' in nextResult) {
-    errors.length = 0;
-    incremental = [nextResult as IncrementalPayload];
+    incremental = [
+      {
+        data: nextResult.data,
+        path: nextResult.path,
+      } as IncrementalPayload,
+    ];
   }
 
   if (incremental) {
@@ -71,7 +76,7 @@ export const mergeResultPatch = (
       }
 
       if (Array.isArray(patch.items)) {
-        const startIndex = typeof prop == 'number' && prop >= 0 ? prop : 0;
+        const startIndex = +prop >= 0 ? (prop as number) : 0;
         for (let i = 0, l = patch.items.length; i < l; i++)
           part[startIndex + i] = patch.items[i];
       } else if (patch.data !== undefined) {

--- a/packages/core/src/utils/result.ts
+++ b/packages/core/src/utils/result.ts
@@ -1,12 +1,15 @@
 import { ExecutionResult, Operation, OperationResult } from '../types';
-import { CombinedError } from './error';
+import { CombinedError, rehydrateGraphQlError } from './error';
 
 export const makeResult = (
   operation: Operation,
   result: ExecutionResult,
   response?: any
 ): OperationResult => {
-  if ((!('data' in result) && !('errors' in result)) || 'path' in result) {
+  if (
+    (!('data' in result) && !('errors' in result)) ||
+    'incremental' in result
+  ) {
     throw new Error('No Content');
   }
 
@@ -27,41 +30,58 @@ export const makeResult = (
 
 export const mergeResultPatch = (
   prevResult: OperationResult,
-  patch: ExecutionResult,
+  nextResult: ExecutionResult,
   response?: any
 ): OperationResult => {
-  const result = { ...prevResult };
-  result.hasNext = !!patch.hasNext;
+  let data: ExecutionResult['data'];
+  let hasExtensions = !!prevResult.extensions || !!nextResult.extensions;
+  const extensions = { ...prevResult.extensions, ...nextResult.extensions };
+  const errors = prevResult.error ? prevResult.error.graphQLErrors : [];
 
-  if (!('path' in patch)) {
-    if ('data' in patch) result.data = patch.data;
-    return result;
+  if (nextResult.incremental) {
+    data = { ...prevResult.data };
+    for (const patch of nextResult.incremental) {
+      if (Array.isArray(patch.errors)) {
+        errors.push(...patch.errors.map(rehydrateGraphQlError));
+      }
+
+      if (patch.extensions) {
+        Object.assign(extensions, patch.extensions);
+        hasExtensions = true;
+      }
+
+      let prop: string | number = patch.path[0];
+      let part: Record<string, any> | Array<any> = data as object;
+      for (let i = 1, l = patch.path.length; i < l; prop = patch.path[i++]) {
+        part = part[prop] = Array.isArray(part[prop])
+          ? [...part[prop]]
+          : { ...part[prop] };
+      }
+
+      if (Array.isArray(patch.items)) {
+        const startIndex = typeof prop == 'number' && prop >= 0 ? prop : 0;
+        for (let i = 0, l = patch.items.length; i < l; i++)
+          part[startIndex + i] = patch.items[i];
+      } else if (patch.data !== undefined) {
+        part[prop] =
+          part[prop] && patch.data
+            ? { ...part[prop], ...patch.data }
+            : patch.data;
+      }
+    }
+  } else {
+    data = nextResult.data;
   }
 
-  if (Array.isArray(patch.errors)) {
-    result.error = new CombinedError({
-      graphQLErrors: result.error
-        ? [...result.error.graphQLErrors, ...patch.errors]
-        : patch.errors,
-      response,
-    });
-  }
-
-  let part: Record<string, any> | Array<any> = (result.data = {
-    ...result.data,
-  });
-
-  let i = 0;
-  let prop: string | number;
-  while (i < patch.path.length) {
-    prop = patch.path[i++];
-    part = part[prop] = Array.isArray(part[prop])
-      ? [...part[prop]]
-      : { ...part[prop] };
-  }
-
-  Object.assign(part, patch.data);
-  return result;
+  return {
+    operation: prevResult.operation,
+    data,
+    error: errors.length
+      ? new CombinedError({ graphQLErrors: errors, response })
+      : undefined,
+    extensions: hasExtensions ? extensions : undefined,
+    hasNext: !!nextResult.hasNext,
+  };
 };
 
 export const makeErrorResult = (


### PR DESCRIPTION
**Note:** Marked as a draft. I meant to submit this a while ago, but didn't get to it. Spec-wise, we're currently in an awkward place with this, but it seems like this _should_ be the defacto standard now.

## Summary

Update default `Accept` header to include `multipart/mixed` and `application/graphql-response+json`.

The former seems to now be a defactor standard-accepted indication for support of the "Incremental Delivery" GraphQL over HTTP spec addition/RFC,
and the latter is an updated form of the older `Content-Type` of GraphQL responses, so both the old and new one should now be included.

## Set of changes

- Update `Accept` header in `@urql/core/internal`
