### PR TITLE
fix(graphcache): Fix regressed stale flag for looping protection

### DIFF
--- a/.changeset/afraid-gorillas-hope.md
+++ b/.changeset/afraid-gorillas-hope.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix regression which caused partial results, whose refetches were blocked by the looping protection, to not have a `stale: true` flag added to them. This is a regression from https://github.com/urql-graphql/urql/pull/2831 and only applies to `cacheExchange`s that had the `schema` option set.

--- a/exchanges/graphcache/e2e-tests/query.spec.tsx
+++ b/exchanges/graphcache/e2e-tests/query.spec.tsx
@@ -128,7 +128,7 @@ describe('Graphcache Queries', () => {
     });
 
     const FirstComponent = () => {
-      const [{ fetching, data, error }] = useQuery({
+      const [{ fetching, data, error, stale }] = useQuery({
         query: `{
           movie {
             id
@@ -149,6 +149,7 @@ describe('Graphcache Queries', () => {
               <div>First Component</div>
               <div id="first-data">{`Data: ${data.movie?.title}`}</div>
               <div id="first-error">{`Error: ${error?.message}`}</div>
+              <div id="first-stale">{`Stale: ${!!stale}`}</div>
             </div>
           )}
         </div>
@@ -156,7 +157,7 @@ describe('Graphcache Queries', () => {
     };
 
     const SecondComponent = () => {
-      const [{ error, data, fetching }] = useQuery({
+      const [{ error, data, fetching, stale }] = useQuery({
         query: `{
           movie {
             id
@@ -176,6 +177,7 @@ describe('Graphcache Queries', () => {
           <div>Second Component</div>
           <div id="second-data">{`Data: ${data.movie.id}`}</div>
           <div id="second-error">{`Error: ${error?.message}`}</div>
+          <div id="second-stale">{`Stale: ${!!stale}`}</div>
         </div>
       );
     };
@@ -189,6 +191,7 @@ describe('Graphcache Queries', () => {
 
     cy.get('#first-data').should('have.text', 'Data: title');
     cy.get('#second-data').should('have.text', 'Data: foo');
+    cy.get('#second-stale').should('have.text', 'Stale: true');
     // TODO: ideally we would be able to keep the error here but...
     // cy.get('#first-error').should('have.text', 'Error: [GraphQL] Test');
     // cy.get('#second-error').should('have.text', 'Error: [GraphQL] Test');

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -328,17 +328,19 @@ export const cacheExchange = <C extends Partial<CacheExchangeOpts>>(
             (operation.context.requestPolicy === 'cache-first' &&
               outcome === 'partial')
           ) {
-            result.stale = true;
             if (reexecutingOperations.has(res.operation.key)) {
-              /*noop*/
-            } else if (!isBlockedByOptimisticUpdate(dependencies)) {
-              client.reexecuteOperation(
-                toRequestPolicy(operation, 'network-only')
-              );
-            } else if (
-              operation.context.requestPolicy === 'cache-and-network'
-            ) {
-              requestedRefetch.add(operation.key);
+              result.stale = outcome === 'partial';
+            } else {
+              result.stale = true;
+              if (!isBlockedByOptimisticUpdate(dependencies)) {
+                client.reexecuteOperation(
+                  toRequestPolicy(operation, 'network-only')
+                );
+              } else if (
+                operation.context.requestPolicy === 'cache-and-network'
+              ) {
+                requestedRefetch.add(operation.key);
+              }
             }
           }
 

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -326,11 +326,12 @@ export const cacheExchange = <C extends Partial<CacheExchangeOpts>>(
           if (
             operation.context.requestPolicy === 'cache-and-network' ||
             (operation.context.requestPolicy === 'cache-first' &&
-              outcome === 'partial' &&
-              !reexecutingOperations.has(res.operation.key))
+              outcome === 'partial')
           ) {
             result.stale = true;
-            if (!isBlockedByOptimisticUpdate(dependencies)) {
+            if (reexecutingOperations.has(res.operation.key)) {
+              /*noop*/
+            } else if (!isBlockedByOptimisticUpdate(dependencies)) {
               client.reexecuteOperation(
                 toRequestPolicy(operation, 'network-only')
               );

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -315,33 +315,38 @@ export const cacheExchange = <C extends Partial<CacheExchangeOpts>>(
       ),
       map(
         (res: OperationResultWithMeta): OperationResult => {
-          const { operation, outcome, dependencies } = res;
+          const { requestPolicy } = res.operation.context;
+
+          // We don't mark cache-only responses as partial, as this would indicate
+          // that we expect a new result to come from the network, which cannot
+          // happen
+          const isPartial =
+            res.outcome === 'partial' && requestPolicy !== 'cache-only';
+
+          // We reexecute requests marked as `cache-and-network`, and partial responses,
+          // if we wouldn't cause a request loop
+          const shouldReexecute =
+            requestPolicy === 'cache-and-network' ||
+            (requestPolicy === 'cache-first' &&
+              isPartial &&
+              !reexecutingOperations.has(res.operation.key));
+
           const result: OperationResult = {
-            operation: addCacheOutcome(operation, outcome),
+            operation: addCacheOutcome(res.operation, res.outcome),
             data: res.data,
             error: res.error,
             extensions: res.extensions,
+            stale: shouldReexecute || isPartial,
           };
 
-          if (
-            operation.context.requestPolicy === 'cache-and-network' ||
-            (operation.context.requestPolicy === 'cache-first' &&
-              outcome === 'partial')
-          ) {
-            if (reexecutingOperations.has(res.operation.key)) {
-              result.stale = outcome === 'partial';
-            } else {
-              result.stale = true;
-              if (!isBlockedByOptimisticUpdate(dependencies)) {
-                client.reexecuteOperation(
-                  toRequestPolicy(operation, 'network-only')
-                );
-              } else if (
-                operation.context.requestPolicy === 'cache-and-network'
-              ) {
-                requestedRefetch.add(operation.key);
-              }
-            }
+          if (!shouldReexecute) {
+            /*noop*/
+          } else if (!isBlockedByOptimisticUpdate(res.dependencies)) {
+            client.reexecuteOperation(
+              toRequestPolicy(res.operation, 'network-only')
+            );
+          } else if (requestPolicy === 'cache-and-network') {
+            requestedRefetch.add(res.operation.key);
           }
 
           dispatchDebug({

--- a/exchanges/graphcache/src/offlineExchange.test.ts
+++ b/exchanges/graphcache/src/offlineExchange.test.ts
@@ -218,6 +218,7 @@ describe('offline', () => {
       error: undefined,
       extensions: undefined,
       operation: expect.any(Object),
+      stale: false,
     });
 
     expect(result.mock.calls[0][0]).toHaveProperty(

--- a/exchanges/graphcache/src/store/__snapshots__/store.test.ts.snap
+++ b/exchanges/graphcache/src/store/__snapshots__/store.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Store with storage > should be able to persist embedded data 1`] = `
 {


### PR DESCRIPTION
Resolves #2937

## Summary

This fixes `stale: true` not being set on partial responses that had been blocked by the looping protection. Even if we detect that a partial response may lead to a loop, the `stale` flag should still be set to indicate that the response is incomplete/partial, as per the documentation.

This is a regression from #2831

## Set of changes

- Add `result.stale` for partial results, even if the reexecution is blockd