### PR TITLE
refactor(auth): Implement new initializer function API

### DIFF
--- a/.changeset/perfect-lobsters-kiss.md
+++ b/.changeset/perfect-lobsters-kiss.md
@@ -1,0 +1,38 @@
+---
+'@urql/exchange-auth': major
+---
+
+Implement new `authExchange` API, which removes the need for an `authState` (i.e. an internal authentication state) and removes `getAuth`, replacing it with a separate `refreshAuth` flow.
+
+The new API requires you to now pass an initializer function. This function receives a `utils`
+object with `utils.mutate` and `utils.appendHeaders` utility methods.
+It must return the configuration object, wrapped in a promise, and this configuration is similar to
+what we had before, if you're migrating to this. Its `refreshAuth` method is now only called after
+authentication errors occur and not on initialization. Instead, it's now recommended that you write
+your initialization logic in-line.
+
+```js
+authExchange(async utils => {
+  let token = localStorage.getItem('token');
+  let refreshToken = localStorage.getItem('refreshToken');
+  return {
+    addAuthToOperation(operation) {
+      return utils.appendHeaders(operation, {
+        Authorization: `Bearer ${token}`,
+      });
+    },
+    didAuthError(error) {
+      return error.graphQLErrors.some(e => e.extensions?.code === 'FORBIDDEN');
+    },
+    async refreshAuth() {
+      const result = await utils.mutate(REFRESH, { token });
+      if (result.data?.refreshLogin) {
+        token = result.data.refreshLogin.token;
+        refreshToken = result.data.refreshLogin.refreshToken;
+        localStorage.setItem('token', token);
+        localStorage.setItem('refreshToken', refreshToken);
+      }
+    },
+  };
+});
+```

--- a/docs/advanced/authentication.md
+++ b/docs/advanced/authentication.md
@@ -81,10 +81,14 @@ The initializer function must return a promise of a configuration object and hen
 opportunity to fetch your authentication state from storage.
 
 ```js
-authExchange(async utils => {
-  let token = localStorage.getItem('token');
-  let refreshToken = localStorage.getItem('refreshToken');
+async function initializeAuthState() {
+  const token = localStorage.getItem('token');
+  const refreshToken = localStorage.getItem('refreshToken');
+  return { token, refreshToken };
+}
 
+authExchange(async utils => {
+  let { token, refreshToken } = initializeAuthState();
   return {
     /* config... */
   };
@@ -92,16 +96,21 @@ authExchange(async utils => {
 ```
 
 The first step here is to retrieve our tokens from a kind of storage, which may be asynchronous as
-well.
+well, as illustrated by `initializeAuthState`.
 
 In React Native, this is very similar, but because persisted storage in React Native is always
-asynchronous and promisified, we'll need to await our tokens:
+asynchronous and promisified, we would await our tokens. This works because the
+function that `authExchange` is async, i.e. must return a `Promise`.
 
 ```js
-authExchange(async utils => {
-  let token = await AsyncStorage.getItem(TOKEN_KEY);
-  let refreshToken = await AyncStorage.getItem(REFRESH_KEY);
+async function initializeAuthState() {
+  const token = await AsyncStorage.getItem(TOKEN_KEY);
+  const refreshToken = await AyncStorage.getItem(REFRESH_KEY);
+  return { token, refreshToken };
+}
 
+authExchange(async utils => {
+  let { token, refreshToken } = initializeAuthState();
   return {
     /* config... */
   };

--- a/docs/api/auth-exchange.md
+++ b/docs/api/auth-exchange.md
@@ -32,73 +32,33 @@ const client = createClient({
   exchanges: [
     dedupExchange,
     cacheExchange,
-    authExchange({
-      /* config */
+    authExchange(async utils => {
+      return {
+        /* config... */
+      };
     }),
     fetchExchange,
   ],
 });
 ```
 
-The `authExchange` accepts an object of options, which are used to configure how your
-authentication method works. Internally, the `authExchange` keeps an authentication state, whose
-shape is determined by the functions passed to the exchange's options:
+The `authExchange` accepts an initialization function. This function is called when your exchange
+and `Client` first start up, and must return an object of options wrapped in a `Promise`, which is
+used to configure how your authentication method works.
+
+You can use this function to first retrieve your authentication state from a kind
+of local storage, or to call your API to validate your authentication state first.
+
+The relevant configuration options, returned to the `authExchange`, then determine
+how the `authExchange` behaves:
 
 - `addAuthToOperation` must be provided to tell `authExchange` how to add authentication information
   to an operation, e.g. how to add the authentication state to an operation's fetch headers.
-- `getAuth` must be provided to let the `authExchange` handle the authentication flow, including
-  token refreshes and other reauthentication. It may send mutations to the GraphQL API or make
-  out-of-band API requests using `fetch`.
-- `didAuthError` may be provided to let the `authExchange` detect authentication errors from the API
-  to trigger the `getAuth` method and reauthentication flow.
 - `willAuthError` may be provided to detect expired tokens or tell whether an operation will likely
-  fail due to an authentication error, which may trigger the `getAuth` method and reauthentication
-  flow early.
+  fail due to an authentication error.
+- `didAuthError` may be provided to let the `authExchange` detect authentication errors from the
+  API on results.
+- `refreshAuth` is called when an authentication error occurs and gives you an opportunity to update
+  your authentication state. Afterwards, the `authExchange` will retry your operation.
 
-## Options
-
-| Option               | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `addAuthToOperation` | Receives a parameter object with the current `authState` (`null \| T`) and an error ([See `CombinedError`](./core.md#combinederror)). It should return the same operation to which the authentication state has been added, e.g. as an authentication header.                                                                                                                                                                                                                          |
-| `getAuth`            | This provided method receives the `authState` (`null \| T`). It should then refresh the authentication state using either a `fetch`call or [the`mutate`method, which is similar to`client.mutation`](./core.md#clientmutation) and return a new `authState`object. In case it receives`null` it should return a stored authentication state, e.g. from local storage. It's allowed to throw an error, which will interrupt the auth flow and let the authentication error fallthrough. |
-| `didAuthError`       | May be provided and return a `boolean` that indicates whether an error is an authentication error, given `error: CombinedError` and `authState: T \| null` as parameters.                                                                                                                                                                                                                                                                                                              |
-| `willAuthError`      | May be provided and return a `boolean` that indicates whether an operation is likely to fail, e.g. due to an expired token, to trigger the authentication flow early, and is given `operation: Operation` and `authState: T \| null` as parameters.                                                                                                                                                                                                                                    |
-
-## Examples
-
-The `addAuthToOperation` method is frequently populated with a function that adds the `authState` to
-the operation's fetch headers.
-
-```js
-function addAuthToOperation: ({
-  authState,
-  operation,
-}) {
-  // the token isn't in the auth state, return the operation without changes
-  if (!authState || !authState.token) {
-    return operation;
-  }
-
-  // fetchOptions can be a function (See Client API) but you can simplify this based on usage
-  const fetchOptions =
-    typeof operation.context.fetchOptions === 'function'
-      ? operation.context.fetchOptions()
-      : operation.context.fetchOptions || {};
-
-  return {
-    ...operation,
-    context: {
-      ...operation.context,
-      fetchOptions: {
-        ...fetchOptions,
-        headers: {
-          ...fetchOptions.headers,
-          "Authorization": authState.token,
-        },
-      },
-    },
-  };
-}
-```
-
-[Read more examples in the documentation given here.](https://github.com/urql-graphql/urql/tree/main/exchanges/auth#quick-start-guide)
+[Read more examples in the documentation given here.](../advanced/authentication.md)

--- a/exchanges/auth/README.md
+++ b/exchanges/auth/README.md
@@ -26,82 +26,51 @@ const client = createClient({
   exchanges: [
     dedupExchange,
     cacheExchange,
-    authExchange({
-      addAuthToOperation: ({ authState, operation }) => {
-        // the token isn't in the auth state, return the operation without changes
-        if (!authState || !authState.token) {
-          return operation;
-        }
+    authExchange(async utils => {
+      // called on initial launch,
+      // fetch the auth state from storage (local storage, async storage etc)
+      let token = localStorage.getItem('token');
+      let refreshToken = localStorage.getItem('refreshToken');
 
-        // fetchOptions can be a function (See Client API) but you can simplify this based on usage
-        const fetchOptions =
-          typeof operation.context.fetchOptions === 'function'
-            ? operation.context.fetchOptions()
-            : operation.context.fetchOptions || {};
-
-        return makeOperation(operation.kind, operation, {
-          ...operation.context,
-          fetchOptions: {
-            ...fetchOptions,
-            headers: {
-              ...fetchOptions.headers,
-              Authorization: authState.token,
-            },
-          },
-        });
-      },
-      willAuthError: ({ authState }) => {
-        if (!authState) return true;
-        // e.g. check for expiration, existence of auth etc
-        return false;
-      },
-      didAuthError: ({ error }) => {
-        // check if the error was an auth error (this can be implemented in various ways, e.g. 401 or a special error code)
-        return error.graphQLErrors.some(e => e.extensions?.code === 'FORBIDDEN');
-      },
-      getAuth: async ({ authState, mutate }) => {
-        // for initial launch, fetch the auth state from storage (local storage, async storage etc)
-        if (!authState) {
-          const token = localStorage.getItem('token');
-          const refreshToken = localStorage.getItem('refreshToken');
-          if (token && refreshToken) {
-            return { token, refreshToken };
+      return {
+        addAuthToOperation(operation) {
+          if (token) {
+            return utils.appendHeaders(operation, {
+              Authorization: `Bearer ${token}`,
+            });
           }
-          return null;
-        }
+          return operation;
+        },
+        willAuthError(_operation) {
+          // e.g. check for expiration, existence of auth etc
+          return !token;
+        },
+        didAuthError(error, _operation) {
+          // check if the error was an auth error
+          // this can be implemented in various ways, e.g. 401 or a special error code
+          return error.graphQLErrors.some(e => e.extensions?.code === 'FORBIDDEN');
+        },
+        async refreshAuth() {
+          // called when auth error has occurred
+          // we should refresh the token with a GraphQL mutation or a fetch call,
+          // depending on what the API supports
+          const result = await mutate(refreshMutation, {
+            token: authState?.refreshToken,
+          });
 
-        /**
-         * the following code gets executed when an auth error has occurred
-         * we should refresh the token if possible and return a new auth state
-         * If refresh fails, we should log out
-         **/
-
-        // if your refresh logic is in graphQL, you must use this mutate function to call it
-        // if your refresh logic is a separate RESTful endpoint, use fetch or similar
-        const result = await mutate(refreshMutation, {
-          token: authState?.refreshToken,
-        });
-
-        if (result.data?.refreshLogin) {
-          // save the new tokens in storage for next restart
-          localStorage.setItem('token', result.data.refreshLogin.token);
-          localStorage.setItem('refreshToken', result.data.refreshLogin.refreshToken);
-
-          // return the new tokens
-          return {
-            token: result.data.refreshLogin.token,
-            refreshToken: result.data.refreshLogin.refreshToken,
-          };
-        }
-
-        // otherwise, if refresh fails, log clear storage and log out
-        localStorage.clear();
-
-        // your app logout logic should trigger here
-        logout();
-
-        return null;
-      },
+          if (result.data?.refreshLogin) {
+            // save the new tokens in storage for next restart
+            token = result.data.refreshLogin.token;
+            refreshToken = result.data.refreshLogin.refreshToken;
+            localStorage.setItem('token', token);
+            localStorage.setItem('refreshToken', refreshToken);
+          } else {
+            // otherwise, if refresh fails, log clear storage and log out
+            localStorage.clear();
+            logout();
+          }
+        },
+      };
     }),
     fetchExchange,
   ],
@@ -110,20 +79,22 @@ const client = createClient({
 
 ## Handling Errors via the errorExchange
 
-Handling the logout logic in `getAuth` is the easiest way to get started, but it means the errors will always get swallowed by the `authExchange`.
-If you want to handle errors globally, this can be done using the `errorExchange`:
+Handling the logout logic in `refreshAuth` is the easiest way to get started,
+but it means the errors will always get swallowed by the `authExchange`.
+If you want to handle errors globally, this can be done using the `mapExchange`:
 
 ```js
-import { errorExchange } from 'urql';
+import { mapExchange } from 'urql';
 
-// this needs to be placed ABOVE the authExchange in the exchanges array, otherwise the auth error will show up hear before the auth exchange has had the chance to handle it
-errorExchange({
-  onError: (error) => {
-    // we only get an auth error here when the auth exchange had attempted to refresh auth and getting an auth error again for the second time
+// this needs to be placed ABOVE the authExchange in the exchanges array, otherwise the auth error
+// will show up hear before the auth exchange has had the chance to handle it
+mapExchange({
+  onError(error) {
+    // we only get an auth error here when the auth exchange had attempted to refresh auth and
+    // getting an auth error again for the second time
     const isAuthError = error.graphQLErrors.some(
       e => e.extensions?.code === 'FORBIDDEN',
     );
-
     if (isAuthError) {
       // clear storage, log the user out etc
     }

--- a/exchanges/auth/src/authExchange.test.ts
+++ b/exchanges/auth/src/authExchange.test.ts
@@ -307,7 +307,10 @@ it('calls willAuthError on queued operations', async () => {
 
   let initialAuthResolve: ((_?: any) => void) | undefined;
 
-  const willAuthError = vi.fn().mockReturnValue(false);
+  const willAuthError = vi
+    .fn()
+    .mockReturnValueOnce(true)
+    .mockReturnValue(false);
 
   pipe(
     source,
@@ -335,7 +338,9 @@ it('calls willAuthError on queued operations', async () => {
 
   await Promise.resolve();
 
-  next(queryOperation);
+  next({ ...queryOperation, key: 1 });
+  next({ ...queryOperation, key: 2 });
+
   expect(result).toHaveBeenCalledTimes(0);
   expect(willAuthError).toHaveBeenCalledTimes(0);
 
@@ -344,10 +349,10 @@ it('calls willAuthError on queued operations', async () => {
 
   await new Promise(resolve => setTimeout(resolve));
 
-  expect(willAuthError).toHaveBeenCalledTimes(1);
-  expect(result).toHaveBeenCalledTimes(1);
+  expect(willAuthError).toHaveBeenCalledTimes(2);
+  expect(result).toHaveBeenCalledTimes(2);
 
-  expect(operations.length).toBe(1);
+  expect(operations.length).toBe(2);
   expect(operations[0]).toHaveProperty(
     'context.fetchOptions.headers.Authorization',
     'token'

--- a/exchanges/auth/src/authExchange.test.ts
+++ b/exchanges/auth/src/authExchange.test.ts
@@ -355,6 +355,11 @@ it('calls willAuthError on queued operations', async () => {
   expect(operations.length).toBe(2);
   expect(operations[0]).toHaveProperty(
     'context.fetchOptions.headers.Authorization',
-    'token'
+    'final-token'
+  );
+
+  expect(operations[1]).toHaveProperty(
+    'context.fetchOptions.headers.Authorization',
+    'final-token'
   );
 });

--- a/exchanges/auth/src/authExchange.ts
+++ b/exchanges/auth/src/authExchange.ts
@@ -225,7 +225,7 @@ export function authExchange(
               variables: Variables,
               context?: Partial<OperationContext>
             ): Promise<OperationResult<Data>> {
-              const operation = client.createRequestOperation(
+              const baseOperation = client.createRequestOperation(
                 'mutation',
                 createRequest(query, variables),
                 context
@@ -233,10 +233,11 @@ export function authExchange(
               return pipe(
                 result$,
                 onStart(() => {
+                  const operation = addAuthToOperation(baseOperation);
                   bypassQueue.add(operation);
                   retries.next(operation);
                 }),
-                filter(result => result.operation.key === operation.key),
+                filter(result => result.operation.key === baseOperation.key),
                 take(1),
                 toPromise
               );

--- a/exchanges/auth/src/authExchange.ts
+++ b/exchanges/auth/src/authExchange.ts
@@ -48,6 +48,23 @@ export interface AuthUtilities {
     variables: Variables,
     context?: Partial<OperationContext>
   ): Promise<OperationResult<Data>>;
+
+  /** Adds additional HTTP headers to an `Operation`.
+   *
+   * @param operation - An {@link Operation} to add headers to.
+   * @param headers - The HTTP headers to add to the `Operation`.
+   * @returns The passed {@link Operation} with the headers added to it.
+   *
+   * @remarks
+   * The `appendHeaders()` utility method is useful to add additional HTTP headers
+   * to an {@link Operation}. It’s a simple convenience function that takes
+   * `operation.context.fetchOptions` into account, since adding headers for
+   * authentication is common.
+   */
+  appendHeaders(
+    operation: Operation,
+    headers: Record<string, string>
+  ): Operation;
 }
 
 /** Configuration for the `authExchange` returned by the initializer function you write. */
@@ -195,6 +212,22 @@ export function authExchange(
             take(1),
             toPromise
           );
+        },
+        appendHeaders(operation: Operation, headers: Record<string, string>) {
+          const fetchOptions =
+            typeof operation.context.fetchOptions === 'function'
+              ? operation.context.fetchOptions()
+              : operation.context.fetchOptions || {};
+          return makeOperation(operation.kind, operation, {
+            ...operation.context,
+            fetchOptions: {
+              ...fetchOptions,
+              headers: {
+                ...fetchOptions.headers,
+                ...headers,
+              },
+            },
+          });
         },
       }).then(flushQueue);
 

--- a/exchanges/auth/src/authExchange.ts
+++ b/exchanges/auth/src/authExchange.ts
@@ -170,6 +170,33 @@ const addAuthAttemptToOperation = (
  * This configuration defines how you add authentication state to {@link Operation | Operations},
  * when your authentication state expires, when an {@link OperationResult} has errored
  * with an authentication error, and how to refresh your authentication state.
+ *
+ * @example
+ * ```ts
+ * authExchange(async (utils) => {
+ *   let token = localStorage.getItem('token');
+ *   let refreshToken = localStorage.getItem('refreshToken');
+ *   return {
+ *     addAuthToOperation(operation) {
+ *       return utils.appendHeaders(operation, {
+ *         Authorization: `Bearer ${token}`,
+ *       });
+ *     },
+ *     didAuthError(error) {
+ *       return error.graphQLErrors.some(e => e.extensions?.code === 'FORBIDDEN');
+ *     },
+ *     async refreshAuth() {
+ *       const result = await utils.mutate(REFRESH, { token });
+ *       if (result.data?.refreshLogin) {
+ *         token = result.data.refreshLogin.token;
+ *         refreshToken = result.data.refreshLogin.refreshToken;
+ *         localStorage.setItem('token', token);
+ *         localStorage.setItem('refreshToken', refreshToken);
+ *       }
+ *     },
+ *   };
+ * });
+ * ```
  */
 export function authExchange(
   init: (utilities: AuthUtilities) => Promise<AuthConfig>

--- a/exchanges/auth/src/authExchange.ts
+++ b/exchanges/auth/src/authExchange.ts
@@ -25,8 +25,24 @@ import {
 
 import { DocumentNode } from 'graphql';
 
+/** Utilities to use while refreshing authentication tokens. */
 export interface AuthUtilities {
-  /** The mutate() method may be used to send one-off mutations to the GraphQL API for the purpose of authentication. */
+  /** Sends a mutation to your GraphQL API, bypassing earlier exchanges and authentication.
+   *
+   * @param query - a GraphQL document containing the mutation operation that will be executed.
+   * @param variables - the variables used to execute the operation.
+   * @param context - {@link OperationContext} options that'll be used in future exchanges.
+   * @returns A `Promise` of an {@link OperationResult} for the GraphQL mutation.
+   *
+   * @remarks
+   * The `mutation()` utility method is useful when your authentication requires you to make a GraphQL mutation
+   * request to update your authentication tokens. In these cases, you likely wish to bypass prior exchanges and
+   * the authentication in the `authExchange` itself.
+   *
+   * This method bypasses the usual mutation flow of the `Client` and instead issues the mutation as directly
+   * as possible. This also means that it doesn’t carry your `Client`'s default {@link OperationContext}
+   * options, so you may have to pass them again, if needed.
+   */
   mutate<Data = any, Variables extends AnyVariables = AnyVariables>(
     query: DocumentNode | TypedDocumentNode<Data, Variables> | string,
     variables: Variables,
@@ -34,17 +50,76 @@ export interface AuthUtilities {
   ): Promise<OperationResult<Data>>;
 }
 
+/** Configuration for the `authExchange` returned by the initializer function you write. */
 export interface AuthConfig {
-  /** addAuthToOperation() must be provided to add the custom `authState` to an Operation's context, so that it may be picked up by the `fetchExchange`. */
+  /** Called for every operation to add authentication data to your operation.
+   *
+   * @param operation - An {@link Operation} that needs authentication tokens added.
+   * @returns a new {@link Operation} with added authentication tokens.
+   *
+   * @remarks
+   * The {@link authExchange} will call this function you provide and expects that you
+   * add your authentication tokens to your operation here, on the {@link Operation}
+   * that is returned.
+   *
+   * Hint: You likely want to modify your `fetchOptions.headers` here, for instance to
+   * add an `Authorization` header.
+   */
   addAuthToOperation(operation: Operation): Operation;
 
-  /** didAuthError() may be provided to tweak the detection of an authentication error that this exchange should handle. */
-  didAuthError?(error: CombinedError, operation: Operation): boolean;
-
-  /** willAuthError() may be provided to detect a potential operation that'll receive authentication error so that getAuth() can be run proactively. */
+  /** Called before an operation is forwaded onwards to make a request.
+   *
+   * @param operation - An {@link Operation} that needs authentication tokens added.
+   * @returns a boolean, if true, authentication must be refreshed.
+   *
+   * @remarks
+   * The {@link authExchange} will call this function before an {@link Operation} is
+   * forwarded onwards to your following exchanges.
+   *
+   * When this function returns `true`, the `authExchange` will call
+   * {@link AuthConfig.refreshAuth} before forwarding more operations
+   * to prompt you to update your authentication tokens.
+   *
+   * Hint: If you define this function, you can use it to check whether your authentication
+   * tokens have expired.
+   */
   willAuthError?(operation: Operation): boolean;
 
-  /** getAuth() handles how the application refreshes or reauthenticates given a stale `authState` and should return a new `authState` or `null`. */
+  /** Called after receiving an operation result to check whether it has failed with an authentication error.
+   *
+   * @param error - A {@link CombinedError} that a result has come back with.
+   * @param operation - The {@link Operation} of that has failed.
+   * @returns a boolean, if true, authentication must be refreshed.
+   *
+   * @remarks
+   * The {@link authExchange} will call this function if it sees an {@link OperationResult}
+   * with a {@link CombinedError} on it, implying that it may have failed due to an authentication
+   * error.
+   *
+   * When this function returns `true`, the `authExchange` will call
+   * {@link AuthConfig.refreshAuth} before forwarding more operations
+   * to prompt you to update your authentication tokens.
+   * Afterwards, this operation will be retried once.
+   *
+   * Hint: You should define a function that detects your API’s authentication
+   * errors, e.g. using `result.extensions`.
+   */
+  didAuthError(error: CombinedError, operation: Operation): boolean;
+
+  /** Called to refresh the authentication state.
+   *
+   * @remarks
+   * The {@link authExchange} will call this function if either {@link AuthConfig.willAuthError}
+   * or {@link AuthConfig.didAuthError} have returned `true` prior, which indicates that the
+   * authentication state you hold has expired or is out-of-date.
+   *
+   * When this function is called, you should refresh your authentication state.
+   * For instance, if you have a refresh token and an access token, you should rotate
+   * these tokens with your API by sending the refresh token.
+   *
+   * Hint: You can use the {@link fetch} API here, or use {@link AuthUtilities.mutate}
+   * if your API requires a GraphQL mutation to refresh your authentication state.
+   */
   refreshAuth(): Promise<void>;
 }
 
@@ -57,6 +132,28 @@ const addAuthAttemptToOperation = (
     authAttempt,
   });
 
+/** Creates an `Exchange` handling control flow for authentication.
+ *
+ * @param init - An initializer function that returns an {@link AuthConfig} wrapped in a `Promise`.
+ * @returns the created authentication {@link Exchange}.
+ *
+ * @remarks
+ * The `authExchange` is used to create an exchange handling authentication and
+ * the control flow of refresh authentication.
+ *
+ * You must pass an initializer function, which receives {@link AuthUtilities} and
+ * must return an {@link AuthConfig} wrapped in a `Promise`.
+ * When this exchange is used in your `Client`, it will first call your initializer
+ * function, which gives you an opportunity to get your authentication state, e.g.
+ * from local storage.
+ *
+ * You may then choose to validate this authentication state and update it, and must
+ * then return an {@link AuthConfig}.
+ *
+ * This configuration defines how you add authentication state to {@link Operation | Operations},
+ * when your authentication state expires, when an {@link OperationResult} has errored
+ * with an authentication error, and how to refresh your authentication state.
+ */
 export function authExchange(
   init: (utilities: AuthUtilities) => Promise<AuthConfig>
 ): Exchange {

--- a/exchanges/auth/src/index.ts
+++ b/exchanges/auth/src/index.ts
@@ -1,2 +1,2 @@
 export { authExchange } from './authExchange';
-export type { AuthConfig } from './authExchange';
+export type { AuthUtilities, AuthConfig } from './authExchange';


### PR DESCRIPTION
Resolves #2815

## Summary

**This is a breaking change, which updates the `authExchange` API.**

This PR eliminates the need for an `authState` (i.e. the authentication state) to be kept with the `authExchange`, and moves it into the responsibility of the user.
It also eliminates `getAuth`'s "double duty" of being called, both, to initialize the authentication state, and to refresh the authentication state after an authentication error.

The `authExchange` now accepts an initializer function, which is an async function (or a function returning a promise). This function is user-defined and will receive a utilities object and _must_ return an authentication configuration object.

This configuration object is unchanged but now contains `refreshAuth` rather than `getAuth`. Several arguments that its functions accept have been simplified.

```js
authExchange(async utils => {
  let token = localStorage.getItem('token');
  let refreshToken = localStorage.getItem('refreshToken');

  return {
    addAuthToOperation(operation) {
      return utils.appendHeaders(operation, {
        Authorization: `Bearer ${token}`,
      });
    },
    willAuthError(_operation) {
      return false;
    },
    didAuthError(error, _operation) {
      return error.graphQLErrors.some(e => e.extensions?.code === 'FORBIDDEN');
    },
    async refreshAuth() {
      const result = await utils.mutate(REFRESH, { token });
      if (result.data?.refreshLogin) {
        token = result.data.refreshLogin.token;
        refreshToken = result.data.refreshLogin.refreshToken;
        localStorage.setItem('token', token);
        localStorage.setItem('refreshToken', refreshToken);
      }
    },
  };
});
```

As we can see, the initializer function itself now initializes the authentication state, and the state is just kept in local variables (which also now makes it easier to keep the state in some "third object" outside of the `authExchange` without any hacky code)

The function returns the configuration and can use `utils.mutate` to send GraphQL mutations for authentication purposes, and now also has `utils.appendHeaders` to add headers to operations!

## Set of changes

- Simplify `addAuthToOperation`, `willAuthError`, and `didAuthError` arguments
- Remove `authState` and `getAuth` and replace with initializer
- Replace `getAuth` flow with `refreshAuth` call
- Update tests
- Add TSDocs to new exchange and APIs (generates a single `d.ts` output)
- Update documentation

**NOTE:** This isn't super final yet, but the goal here is to remove the API docs on the website and move those over to TSDocs. Hence, the website docs for the `authExchange` API are very lean now.
