### PR TITLE
docs(svelte): first draft of clarifying subscription language for svelte

### DIFF
--- a/docs/advanced/subscriptions.md
+++ b/docs/advanced/subscriptions.md
@@ -200,7 +200,7 @@ In the following example, we create a subscription that informs us of new messag
   <p>No new messages</p>
 {:else}
   <ul>
-    {#each $messages.data as message}
+    {#each $messages.data.newMessages as message}
       <li>{message.from}: "{message.text}"</li>
     {/each}
   </ul>
@@ -208,11 +208,12 @@ In the following example, we create a subscription that informs us of new messag
 
 ```
 
-As we can see, the `$messages.data` is being updated and transformed by the `handleSubscription`
-function. This works over time, so as new messages come in, we will append them to
+As we can see, the `$messages.data` is being updated and transformed by the `$messages` subscriptionStore. This works over time, so as new messages come in, we will append them to
 the list of previous messages.
 
-[Read more about the `subscription` API in the API docs for it.](../api/svelte.md#subscription)
+The subscriptionStore also optionally accepts a second argument, a handler function.
+
+[Read more about the `subscription` API in the API docs for it.](../api/svelte.md#subscriptionstore)
 
 ## Vue
 

--- a/docs/advanced/subscriptions.md
+++ b/docs/advanced/subscriptions.md
@@ -208,10 +208,10 @@ In the following example, we create a subscription that informs us of new messag
 
 ```
 
-As we can see, the `$messages.data` is being updated and transformed by the `$messages` subscriptionStore. This works over time, so as new messages come in, we will append them to
+As we can see, `$messages.data` is being updated and transformed by the `$messages` subscriptionStore. This works over time, so as new messages come in, we will append them to
 the list of previous messages.
 
-The subscriptionStore also optionally accepts a second argument, a handler function.
+`subscriptionStore` optionally accepts a second argument, a handler function, allowing custom update behavior from the subscription.
 
 [Read more about the `subscription` API in the API docs for it.](../api/svelte.md#subscriptionstore)
 


### PR DESCRIPTION
first crack at #2992 

## Summary

Updates svelte subscription docs for clarity and to remove obsolete examples.

## Set of changes

- removes the language around `handleSubscription` in svelte subscriptionStore example
- adds reference to second param for subscription handler on `subscriptionStore`
- corrects bad link to additional reading
- corrects code example in svelte subscription example to include data object
