### PR TITLE
fix(core): Set default hasNext for subscription results

### DIFF
--- a/.changeset/silent-emus-brake.md
+++ b/.changeset/silent-emus-brake.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Fix subscriptions not being duplicated when `hasNext` isn't set. The `hasNext` field is an upcoming "Incremental Delivery" field. When a subscription result doesn't set it we now set it to `true` manually. This indicates to the `dedupExchange` that no duplicate subscription operations should be started.

--- a/packages/core/src/exchanges/__snapshots__/subscription.test.ts.snap
+++ b/packages/core/src/exchanges/__snapshots__/subscription.test.ts.snap
@@ -5,7 +5,7 @@ exports[`should return response data from forwardSubscription observable 1`] = `
   "data": {},
   "error": undefined,
   "extensions": undefined,
-  "hasNext": false,
+  "hasNext": true,
   "operation": {
     "context": {
       "fetchOptions": {

--- a/packages/core/src/exchanges/subscription.ts
+++ b/packages/core/src/exchanges/subscription.ts
@@ -70,8 +70,6 @@ export const subscriptionExchange = ({
   const createSubscriptionSource = (
     operation: Operation
   ): Source<OperationResult> => {
-    const defaultHasNext = operation.kind === 'subscription';
-
     // This excludes the query's name as a field although subscription-transport-ws does accept it since it's optional
     const observableish = forwardSubscription({
       key: operation.key.toString(36),
@@ -88,11 +86,7 @@ export const subscriptionExchange = ({
         if (isComplete) return;
 
         sub = observableish.subscribe({
-          next: result => {
-            // If `hasNext` isn't set, we assume it should be set to true
-            if (result.hasNext == null) result.hasNext = defaultHasNext;
-            return next(makeResult(operation, result));
-          },
+          next: result => next(makeResult(operation, result)),
           error: err => next(makeErrorResult(operation, err)),
           complete: () => {
             if (!isComplete) {

--- a/packages/core/src/utils/result.ts
+++ b/packages/core/src/utils/result.ts
@@ -18,6 +18,7 @@ export const makeResult = (
     throw new Error('No Content');
   }
 
+  const defaultHasNext = operation.kind === 'subscription';
   return {
     operation,
     data: result.data,
@@ -29,7 +30,7 @@ export const makeResult = (
       : undefined,
     extensions:
       (typeof result.extensions === 'object' && result.extensions) || undefined,
-    hasNext: !!result.hasNext,
+    hasNext: result.hasNext == null ? defaultHasNext : result.hasNext,
   };
 };
 


### PR DESCRIPTION
## Summary

Not all subscription transports have a built-in way of deduplicating subscriptions, since this may not be desireable. However, the presence of this in some transports has previously masked this issue.

The `dedupExchange` can prevent multiple identical operations. However, it backs off when a result comes in that has `hasNext === false` set.

The issue here is that `subscriptionExchange`s need to set `hasNext` to `true` by default for subscription operations to ensure that no duplicate subscriptions are triggered

## Set of changes

- Set default `hasNext` field to `true` for subscriptions in `makeResult`