### PR TITLE
fix(auth): Fix willAuthError not being called on waiting operations

### DIFF
--- a/.changeset/stupid-cobras-clap.md
+++ b/.changeset/stupid-cobras-clap.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-auth': patch
+---
+
+Fix `willAuthError` not being called for operations that are waiting on the authentication state to update. This can actually lead to a common issue where operations that came in during the authentication initialization (on startup) will never have `willAuthError` called on them. This can cause an easy mistake where the initial authentication state is never checked to be valid.

--- a/exchanges/auth/src/authExchange.test.ts
+++ b/exchanges/auth/src/authExchange.test.ts
@@ -165,6 +165,8 @@ it('adds the same token to subsequent operations', async () => {
     toPromise
   );
 
+  await new Promise(resolve => setTimeout(resolve));
+
   next(queryOperation);
 
   next(


### PR DESCRIPTION
## Summary

When operations are waiting for `authPromise` to resolve, i.e. they're not queued but instead are waiting for the authentication update/refresh to resolve, `willAuthError` will actually _not_ be called, even if it's provided.

This can lead to an easy mistake, where the authentication state may have been rehydrated (on startup), but is never checked to be valid.

We now queue operations that are waiting for the promise like we do for failed operations, which simplifies the logic a little, and make sure to call `willAuthError` on them again.

## Set of changes

- Call `willAuthError` on queued retry operations
- Reuse queue for waiting operations
- Update how `mutate` bypasses the authentication logic
