### PR TITLE
fix(core/bindings): Fix conditional/optional variables type based on TypedDocumentNode generic

### DIFF
--- a/.changeset/slimy-shirts-bow.md
+++ b/.changeset/slimy-shirts-bow.md
@@ -1,0 +1,8 @@
+---
+'@urql/preact': patch
+'@urql/svelte': patch
+'urql': patch
+'@urql/vue': patch
+---
+
+Fix type utilities turning the `variables` properties optional when a type from `TypedDocumentNode` has no `Variables` or all optional `Variables`. Previously this would break for wrappers, e.g. in code generators, or when the type didn't quite match what we'd expect.

--- a/.changeset/tricky-ears-add.md
+++ b/.changeset/tricky-ears-add.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Expose consistent `GraphQLRequestParams` utility type from which `GraphQLRequest`s are created in all bindings.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -238,6 +238,43 @@ export interface GraphQLRequest<
   variables: Variables;
 }
 
+/** Parameters from which {@link GraphQLRequest | GraphQLRequests} are created from.
+ *
+ * @remarks
+ * A `GraphQLRequest` is a single executable request with a generated `key` to identify
+ * their results, whereas `GraphQLRequestParams` is a utility type used to generate
+ * inputs for `urql` to create requests from, i.e. it only contains a `query` and
+ * `variables`. The type conditionally makes the `variables` property completely
+ * optional.
+ *
+ * @privateRemarks
+ * The wrapping union type is needed for passthrough or wrapper utilities that wrap
+ * functions like `useQuery` with generics.
+ */
+export type GraphQLRequestParams<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+> =
+  | ({
+      query: string | DocumentNode | TypedDocumentNode<Data, Variables>;
+    } & (Variables extends void
+      ? {
+          variables?: Variables;
+        }
+      : Variables extends {
+          [P in keyof Variables]: Exclude<Variables[P], null | void>;
+        }
+      ? {
+          variables: Variables;
+        }
+      : {
+          variables?: Variables;
+        }))
+  | {
+      query: string | DocumentNode | TypedDocumentNode<Data, Variables>;
+      variables: Variables;
+    };
+
 /** Metadata used to annotate an `Operation` in development for the `urql-devtools`.
  *
  * @remarks

--- a/packages/preact-urql/src/hooks/useQuery.ts
+++ b/packages/preact-urql/src/hooks/useQuery.ts
@@ -1,4 +1,3 @@
-import { DocumentNode } from 'graphql';
 import { useEffect, useCallback, useMemo } from 'preact/hooks';
 
 import {
@@ -15,8 +14,8 @@ import {
 
 import {
   Client,
+  GraphQLRequestParams,
   AnyVariables,
-  TypedDocumentNode,
   CombinedError,
   OperationContext,
   RequestPolicy,
@@ -33,19 +32,10 @@ export type UseQueryArgs<
   Variables extends AnyVariables = AnyVariables,
   Data = any
 > = {
-  query: string | DocumentNode | TypedDocumentNode<Data, Variables>;
   requestPolicy?: RequestPolicy;
   context?: Partial<OperationContext>;
   pause?: boolean;
-} & (Variables extends void
-  ? {
-      variables?: Variables;
-    }
-  : Variables extends { [P in keyof Variables]: Variables[P] | null }
-  ? { variables?: Variables }
-  : {
-      variables: Variables;
-    });
+} & GraphQLRequestParams<Data, Variables>;
 
 export interface UseQueryState<
   Data = any,

--- a/packages/preact-urql/src/hooks/useSubscription.ts
+++ b/packages/preact-urql/src/hooks/useSubscription.ts
@@ -1,10 +1,9 @@
-import { DocumentNode } from 'graphql';
 import { useEffect, useCallback, useRef, useMemo } from 'preact/hooks';
 import { pipe, concat, fromValue, switchMap, map, scan } from 'wonka';
 
 import {
   AnyVariables,
-  TypedDocumentNode,
+  GraphQLRequestParams,
   CombinedError,
   OperationContext,
   Operation,
@@ -19,18 +18,9 @@ export type UseSubscriptionArgs<
   Variables extends AnyVariables = AnyVariables,
   Data = any
 > = {
-  query: DocumentNode | TypedDocumentNode<Data, Variables> | string;
   pause?: boolean;
   context?: Partial<OperationContext>;
-} & (Variables extends void
-  ? {
-      variables?: Variables;
-    }
-  : Variables extends { [P in keyof Variables]: Variables[P] | null }
-  ? { variables?: Variables }
-  : {
-      variables: Variables;
-    });
+} & GraphQLRequestParams<Data, Variables>;
 
 export type SubscriptionHandler<T, R> = (prev: R | undefined, data: T) => R;
 

--- a/packages/react-urql/src/hooks/useQuery.ts
+++ b/packages/react-urql/src/hooks/useQuery.ts
@@ -1,13 +1,12 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 
-import { DocumentNode } from 'graphql';
 import { Source, pipe, subscribe, onEnd, onPush, takeWhile } from 'wonka';
 import { useState, useEffect, useCallback, useMemo } from 'react';
 
 import {
+  GraphQLRequestParams,
   AnyVariables,
   Client,
-  TypedDocumentNode,
   CombinedError,
   OperationContext,
   RequestPolicy,
@@ -24,19 +23,10 @@ export type UseQueryArgs<
   Variables extends AnyVariables = AnyVariables,
   Data = any
 > = {
-  query: string | DocumentNode | TypedDocumentNode<Data, Variables>;
   requestPolicy?: RequestPolicy;
   context?: Partial<OperationContext>;
   pause?: boolean;
-} & (Variables extends void
-  ? {
-      variables?: Variables;
-    }
-  : Variables extends { [P in keyof Variables]: Variables[P] | null }
-  ? { variables?: Variables }
-  : {
-      variables: Variables;
-    });
+} & GraphQLRequestParams<Data, Variables>;
 
 export interface UseQueryState<
   Data = any,

--- a/packages/react-urql/src/hooks/useSubscription.ts
+++ b/packages/react-urql/src/hooks/useSubscription.ts
@@ -1,12 +1,11 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 
-import { DocumentNode } from 'graphql';
 import { pipe, subscribe, onEnd } from 'wonka';
 import { useEffect, useState, useCallback, useMemo, useRef } from 'react';
 
 import {
+  GraphQLRequestParams,
   AnyVariables,
-  TypedDocumentNode,
   CombinedError,
   OperationContext,
   Operation,
@@ -20,18 +19,9 @@ export type UseSubscriptionArgs<
   Variables extends AnyVariables = AnyVariables,
   Data = any
 > = {
-  query: DocumentNode | TypedDocumentNode<Data, Variables> | string;
   pause?: boolean;
   context?: Partial<OperationContext>;
-} & (Variables extends void
-  ? {
-      variables?: Variables;
-    }
-  : Variables extends { [P in keyof Variables]: Variables[P] | null }
-  ? { variables?: Variables }
-  : {
-      variables: Variables;
-    });
+} & GraphQLRequestParams<Data, Variables>;
 
 export type SubscriptionHandler<T, R> = (prev: R | undefined, data: T) => R;
 

--- a/packages/svelte-urql/src/mutationStore.ts
+++ b/packages/svelte-urql/src/mutationStore.ts
@@ -1,13 +1,13 @@
-import type { DocumentNode } from 'graphql';
-import {
-  AnyVariables,
-  Client,
-  OperationContext,
-  TypedDocumentNode,
-  createRequest,
-} from '@urql/core';
 import { pipe, map, scan, subscribe } from 'wonka';
 import { derived, writable } from 'svelte/store';
+
+import {
+  AnyVariables,
+  GraphQLRequestParams,
+  Client,
+  OperationContext,
+  createRequest,
+} from '@urql/core';
 
 import {
   OperationResultState,
@@ -22,17 +22,8 @@ export type MutationArgs<
   Variables extends AnyVariables = AnyVariables
 > = {
   client: Client;
-  query: string | DocumentNode | TypedDocumentNode<Data, Variables>;
   context?: Partial<OperationContext>;
-} & (Variables extends void
-  ? {
-      variables?: Variables;
-    }
-  : Variables extends { [P in keyof Variables]: Variables[P] | null }
-  ? { variables?: Variables }
-  : {
-      variables: Variables;
-    });
+} & GraphQLRequestParams<Data, Variables>;
 
 export function mutationStore<
   Data = any,

--- a/packages/svelte-urql/src/queryStore.ts
+++ b/packages/svelte-urql/src/queryStore.ts
@@ -1,12 +1,12 @@
-import type { DocumentNode } from 'graphql';
 import {
   Client,
+  GraphQLRequestParams,
   AnyVariables,
   OperationContext,
-  TypedDocumentNode,
   RequestPolicy,
   createRequest,
 } from '@urql/core';
+
 import {
   Source,
   pipe,
@@ -18,6 +18,7 @@ import {
   scan,
   never,
 } from 'wonka';
+
 import { derived, writable } from 'svelte/store';
 
 import {
@@ -34,19 +35,10 @@ export type QueryArgs<
   Variables extends AnyVariables = AnyVariables
 > = {
   client: Client;
-  query: string | DocumentNode | TypedDocumentNode<Data, Variables>;
   context?: Partial<OperationContext>;
   requestPolicy?: RequestPolicy;
   pause?: boolean;
-} & (Variables extends void
-  ? {
-      variables?: Variables;
-    }
-  : Variables extends { [P in keyof Variables]: Variables[P] | null }
-  ? { variables?: Variables }
-  : {
-      variables: Variables;
-    });
+} & GraphQLRequestParams<Data, Variables>;
 
 export function queryStore<
   Data = any,

--- a/packages/svelte-urql/src/subscriptionStore.ts
+++ b/packages/svelte-urql/src/subscriptionStore.ts
@@ -1,11 +1,11 @@
-import type { DocumentNode } from 'graphql';
 import {
   AnyVariables,
+  GraphQLRequestParams,
   Client,
   OperationContext,
-  TypedDocumentNode,
   createRequest,
 } from '@urql/core';
+
 import {
   Source,
   pipe,
@@ -17,6 +17,7 @@ import {
   scan,
   never,
 } from 'wonka';
+
 import { derived, writable } from 'svelte/store';
 
 import {
@@ -33,18 +34,9 @@ export type SubscriptionArgs<
   Variables extends AnyVariables = AnyVariables
 > = {
   client: Client;
-  query: string | DocumentNode | TypedDocumentNode<Data, Variables>;
   context?: Partial<OperationContext>;
   pause?: boolean;
-} & (Variables extends void
-  ? {
-      variables?: Variables;
-    }
-  : Variables extends { [P in keyof Variables]: Variables[P] | null }
-  ? { variables?: Variables }
-  : {
-      variables: Variables;
-    });
+} & GraphQLRequestParams<Data, Variables>;
 
 export function subscriptionStore<
   Data,

--- a/packages/vue-urql/src/useQuery.ts
+++ b/packages/vue-urql/src/useQuery.ts
@@ -1,7 +1,5 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 
-import { DocumentNode } from 'graphql';
-
 import { WatchStopHandle, Ref, ref, watchEffect, reactive, isRef } from 'vue';
 
 import { Subscription, Source, pipe, subscribe, onEnd } from 'wonka';
@@ -10,7 +8,7 @@ import {
   Client,
   AnyVariables,
   OperationResult,
-  TypedDocumentNode,
+  GraphQLRequestParams,
   CombinedError,
   OperationContext,
   RequestPolicy,
@@ -22,22 +20,20 @@ import {
 import { useClient } from './useClient';
 import { unwrapPossibleProxy } from './utils';
 
-type MaybeRef<T> = T | Ref<T>;
+type MaybeRefObj<T extends {}> = {
+  [K in keyof T]: T[K] | Ref<T[K]>;
+};
 
-export type UseQueryArgs<T = any, V extends AnyVariables = AnyVariables> = {
-  query: MaybeRef<TypedDocumentNode<T, V> | DocumentNode | string>;
-  requestPolicy?: MaybeRef<RequestPolicy>;
-  context?: MaybeRef<Partial<OperationContext>>;
-  pause?: MaybeRef<boolean>;
-} & (V extends void
-  ? {
-      variables?: MaybeRef<{ [K in keyof V]: MaybeRef<V[K]> }>;
-    }
-  : V extends { [P in keyof V]: V[P] | null }
-  ? { variables?: MaybeRef<{ [K in keyof V]: MaybeRef<V[K]> }> }
-  : {
-      variables: MaybeRef<{ [K in keyof V]: MaybeRef<V[K]> }>;
-    });
+export type UseQueryArgs<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+> = MaybeRefObj<
+  {
+    requestPolicy?: RequestPolicy;
+    context?: Partial<OperationContext>;
+    pause?: boolean;
+  } & GraphQLRequestParams<Data, Variables>
+>;
 
 export type QueryPartialState<
   T = any,

--- a/packages/vue-urql/src/useSubscription.ts
+++ b/packages/vue-urql/src/useSubscription.ts
@@ -1,15 +1,14 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 
-import { DocumentNode } from 'graphql';
 import { Source, pipe, subscribe, onEnd } from 'wonka';
 
 import { WatchStopHandle, Ref, ref, watchEffect, reactive, isRef } from 'vue';
 
 import {
   Client,
+  GraphQLRequestParams,
   AnyVariables,
   OperationResult,
-  TypedDocumentNode,
   CombinedError,
   OperationContext,
   Operation,
@@ -21,23 +20,17 @@ import { useClient } from './useClient';
 import { unwrapPossibleProxy } from './utils';
 
 type MaybeRef<T> = T | Ref<T>;
+type MaybeRefObj<T extends {}> = { [K in keyof T]: MaybeRef<T[K]> };
 
 export type UseSubscriptionArgs<
-  T = any,
-  V extends AnyVariables = AnyVariables
-> = {
-  query: MaybeRef<TypedDocumentNode<T, V> | DocumentNode | string>;
-  pause?: MaybeRef<boolean>;
-  context?: MaybeRef<Partial<OperationContext>>;
-} & (V extends void
-  ? {
-      variables?: MaybeRef<{ [K in keyof V]: MaybeRef<V[K]> }>;
-    }
-  : V extends { [P in keyof V]: V[P] | null }
-  ? { variables?: MaybeRef<{ [K in keyof V]: MaybeRef<V[K]> }> }
-  : {
-      variables: MaybeRef<{ [K in keyof V]: MaybeRef<V[K]> }>;
-    });
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+> = MaybeRefObj<
+  {
+    pause?: boolean;
+    context?: Partial<OperationContext>;
+  } & GraphQLRequestParams<Data, Variables>
+>;
 
 export type SubscriptionHandler<T, R> = (prev: R | undefined, data: T) => R;
 export type SubscriptionHandlerArg<T, R> = MaybeRef<SubscriptionHandler<T, R>>;


### PR DESCRIPTION
Resolves #2668

## Summary

Previously, we had a couple of cases that wouldn't allow us to correctly identify when the `variables` input should be optional, e.g. allowing for:

```ts
import { useQuery, TypedDocumentNode } from 'urql';
const x: TypedDocumentNode<{ data: null }, { test: string | null }> = {} as any;
useQuery({ query: x });
```

Additionally, it wasn't always easily possible to proxy generic inputs to our hooks and bindings, e.g. allowing for:

```ts
import { useQuery, TypedDocumentNode, AnyVariables } from 'urql';

export function wrapper<Data, Variables extends AnyVariables = AnyVariables>(
  query: TypedDocumentNode<Data, Variables>,
  variables: Variables,
) {
  return useQuery({ query, variables });
}
```

This is now resolved and to prevent future mistakes a `GraphQLRequestParams` utility type has been exposed by `@urql/core` which will be maintained/exposed as a public type, but is also reused in all of our bindings.

**NOTE on patch:** This is a patch and not a major/breaking change since we can never break types by making a property optional rather than required. Since we're a) widening the type with the union, and b) fixing cases where `variables` should be optional, this shouldn't break any TS types.

## Set of changes

- Add `GraphQLRequestParams` utility fixing optional `variables`
- Update bindings to use `GraphQLRequestParams` where `query, variables` inputs are accepted
