### PR TITLE
feat(populate): add way to limit depth and skip certain types from that depth-count

### DIFF
--- a/.changeset/stupid-cherries-join.md
+++ b/.changeset/stupid-cherries-join.md
@@ -1,0 +1,7 @@
+---
+'@urql/exchange-populate': minor
+---
+
+Introduce `maxDepth` and `skipType` into the `populateExchange`, these options allow you to specify
+the maximum depth a mutation should be populated as well as which types should not be counted towards
+this depth.

--- a/exchanges/persisted-fetch/src/__snapshots__/persistedFetchExchange.test.ts.snap
+++ b/exchanges/persisted-fetch/src/__snapshots__/persistedFetchExchange.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`accepts successful persisted query responses 1`] = `"{\\"operationName\\":\\"getUser\\",\\"variables\\":{\\"name\\":\\"Clara\\"},\\"extensions\\":{\\"persistedQuery\\":{\\"version\\":1,\\"sha256Hash\\":\\"b4228e10e04c59def248546d305b710309c1b297423b38eb64f989a89a398cd8\\"}}}"`;
 

--- a/packages/react-urql/src/hooks/__snapshots__/useMutation.test.tsx.snap
+++ b/packages/react-urql/src/hooks/__snapshots__/useMutation.test.tsx.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`on initial useEffect > initialises default state 1`] = `
 {

--- a/packages/react-urql/src/hooks/__snapshots__/useQuery.test.tsx.snap
+++ b/packages/react-urql/src/hooks/__snapshots__/useQuery.test.tsx.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`on initial useEffect > initialises default state 1`] = `
 {

--- a/packages/react-urql/src/hooks/__snapshots__/useSubscription.test.tsx.snap
+++ b/packages/react-urql/src/hooks/__snapshots__/useSubscription.test.tsx.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`on initial useEffect > initialises default state 1`] = `
 {


### PR DESCRIPTION
## Summary

This introduces a `maxDepth` and `skipType` (naming suggestion welcome) option to the `populateExchange`, this is mainly meant to avoid having long running applications have infinitely deep selection-sets due to seeing a lot of queries and a root-type being mutated.
