### PR TITLE
fix(core): Fix legacy GCG generated Variables types

### DIFF
--- a/.changeset/dry-islands-double.md
+++ b/.changeset/dry-islands-double.md
@@ -1,0 +1,12 @@
+---
+'@urql/core': patch
+---
+
+Fix generated empty `Variables` type as passed to generics, that outputs a type of `{ [var: string]: never; }`.
+A legacy/unsupported version of `typescript-urql`, which wraps `urql`'s React hooks, generates
+empty variables types as the following code snippet, which is not detected:
+
+```ts
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+type Variables = Exact<{ [key: string]: never }>;
+```

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -264,9 +264,15 @@ export type GraphQLRequestParams<
       : Variables extends {
           [P in keyof Variables]: Exclude<Variables[P], null | void>;
         }
-      ? {
-          variables: Variables;
+      ? Variables extends {
+          [P in keyof Variables]: never;
         }
+        ? {
+            variables?: Variables;
+          }
+        : {
+            variables: Variables;
+          }
       : {
           variables?: Variables;
         }))


### PR DESCRIPTION
Resolves #3026

## Summary

Fix generated empty `Variables` type as passed to generics, that outputs a type of `{ [var: string]: never; }`.
A legacy/unsupported version of `typescript-urql`, which wraps `urql`'s React hooks, generates
empty variables types as the following code snippet, which is not detected:

```ts
type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
type Variables = Exact<{ [key: string]: never }>;
```

**NOTE:** We cannot guarantee that this actually fixes `@graphql-codegen/typescript-urql`, which will going forward be unsupported. Generally, we choose not to create test harnesses for outside type generators like these, until we'd have our own type/code generator.

We cannot guarantee that types of hook/wrapper generators don't break, and instead recommend and support type/code generators that output `TypedDocumentNode`s, such as:
- `@graphql-codegen/typed-document-node`
- `@graphql-codegen/client-preset`

## Set of changes

- Add `{ [prop: string]: never }` check to variables types
