### PR TITLE
chore(core): Clean up some code to reduce @urql/core size

### DIFF
--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -265,35 +265,30 @@ export const cacheExchange = <C extends Partial<CacheExchangeOpts>>(
     // Filter by operations that are cacheable and attempt to query them from the cache
     const cacheOps$ = pipe(
       sharedOps$,
-      filter(op => {
-        return (
-          op.kind === 'query' && op.context.requestPolicy !== 'network-only'
-        );
-      }),
+      filter(
+        op => op.kind === 'query' && op.context.requestPolicy !== 'network-only'
+      ),
       map(operationResultFromCache),
       share
     );
 
     const nonCacheOps$ = pipe(
       sharedOps$,
-      filter(op => {
-        return (
-          op.kind !== 'query' || op.context.requestPolicy === 'network-only'
-        );
-      })
+      filter(
+        op => op.kind !== 'query' || op.context.requestPolicy === 'network-only'
+      )
     );
 
     // Rebound operations that are incomplete, i.e. couldn't be queried just from the cache
     const cacheMissOps$ = pipe(
       cacheOps$,
-      filter(res => {
-        return (
+      filter(
+        res =>
           res.outcome === 'miss' &&
           res.operation.context.requestPolicy !== 'cache-only' &&
           !isBlockedByOptimisticUpdate(res.dependencies) &&
           !reexecutingOperations.has(res.operation.key)
-        );
-      }),
+      ),
       map(res => {
         dispatchDebug({
           type: 'cacheMiss',

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -585,14 +585,13 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
   const makeResultSource = (operation: Operation) => {
     let result$ = pipe(
       results$,
-      filter((res: OperationResult) => {
-        return (
+      filter(
+        (res: OperationResult) =>
           res.operation.kind === operation.kind &&
           res.operation.key === operation.key &&
           (!res.operation.context._instance ||
             res.operation.context._instance === operation.context._instance)
-        );
-      })
+      )
     );
 
     // Mask typename properties if the option for it is turned on

--- a/packages/core/src/exchanges/cache.ts
+++ b/packages/core/src/exchanges/cache.ts
@@ -48,18 +48,11 @@ export const cacheExchange: Exchange = ({ forward, client, dispatchDebug }) => {
     return formattedOperation;
   };
 
-  const isOperationCached = (operation: Operation) => {
-    const {
-      key,
-      kind,
-      context: { requestPolicy },
-    } = operation;
-    return (
-      kind === 'query' &&
-      requestPolicy !== 'network-only' &&
-      (requestPolicy === 'cache-only' || resultCache.has(key))
-    );
-  };
+  const isOperationCached = (operation: Operation) =>
+    operation.kind === 'query' &&
+    operation.context.requestPolicy !== 'network-only' &&
+    (operation.context.requestPolicy === 'cache-only' ||
+      resultCache.has(operation.key));
 
   return ops$ => {
     const sharedOps$ = share(ops$);

--- a/packages/core/src/exchanges/fallback.ts
+++ b/packages/core/src/exchanges/fallback.ts
@@ -1,5 +1,5 @@
 import { filter, pipe, tap } from 'wonka';
-import { Operation, ExchangeIO, ExchangeInput } from '../types';
+import { ExchangeIO, ExchangeInput } from '../types';
 
 /** Used by the `Client` as the last exchange to warn about unhandled operations.
  *
@@ -14,24 +14,28 @@ export const fallbackExchange: ({
   dispatchDebug,
 }: Pick<ExchangeInput, 'dispatchDebug'>) => ExchangeIO = ({
   dispatchDebug,
-}) => ops$ =>
-  pipe(
-    ops$,
-    tap<Operation>(operation => {
-      if (
-        operation.kind !== 'teardown' &&
-        process.env.NODE_ENV !== 'production'
-      ) {
-        const message = `No exchange has handled operations of kind "${operation.kind}". Check whether you've added an exchange responsible for these operations.`;
+}) => ops$ => {
+  if (process.env.NODE_ENV !== 'production') {
+    ops$ = pipe(
+      ops$,
+      tap(operation => {
+        if (
+          operation.kind !== 'teardown' &&
+          process.env.NODE_ENV !== 'production'
+        ) {
+          const message = `No exchange has handled operations of kind "${operation.kind}". Check whether you've added an exchange responsible for these operations.`;
 
-        dispatchDebug({
-          type: 'fallbackCatch',
-          message,
-          operation,
-        });
-        console.warn(message);
-      }
-    }),
-    // All operations that skipped through the entire exchange chain should be filtered from the output
-    filter<any>(() => false)
-  );
+          dispatchDebug({
+            type: 'fallbackCatch',
+            message,
+            operation,
+          });
+          console.warn(message);
+        }
+      })
+    );
+  }
+
+  // All operations that skipped through the entire exchange chain should be filtered from the output
+  return filter((_x): _x is never => false)(ops$);
+};

--- a/packages/core/src/exchanges/fetch.ts
+++ b/packages/core/src/exchanges/fetch.ts
@@ -35,7 +35,6 @@ export const fetchExchange: Exchange = ({ forward, dispatchDebug }) => {
         return operation.kind === 'query' || operation.kind === 'mutation';
       }),
       mergeMap(operation => {
-        const { key } = operation;
         const body = makeFetchBody(operation);
         const url = makeFetchURL(operation, body);
         const fetchOptions = makeFetchOptions(operation, body);
@@ -55,7 +54,7 @@ export const fetchExchange: Exchange = ({ forward, dispatchDebug }) => {
           takeUntil(
             pipe(
               sharedOps$,
-              filter(op => op.kind === 'teardown' && op.key === key)
+              filter(op => op.kind === 'teardown' && op.key === operation.key)
             )
           )
         );

--- a/packages/core/src/internal/fetchOptions.ts
+++ b/packages/core/src/internal/fetchOptions.ts
@@ -50,13 +50,15 @@ export const makeFetchURL = (
   if (!useGETMethod || !body) return operation.context.url;
 
   const url = new URL(operation.context.url);
-  const search = url.searchParams;
-  if (body.operationName) search.set('operationName', body.operationName);
-  if (body.query) search.set('query', body.query);
-  if (body.variables)
-    search.set('variables', stringifyVariables(body.variables));
-  if (body.extensions)
-    search.set('extensions', stringifyVariables(body.extensions));
+  for (const key in body) {
+    const value = body[key];
+    if (value) {
+      url.searchParams.set(
+        key,
+        typeof value === 'object' ? stringifyVariables(value) : value
+      );
+    }
+  }
 
   const finalUrl = url.toString();
   if (finalUrl.length > 2047 && useGETMethod !== 'force') {


### PR DESCRIPTION
## Summary

No changeset, since no functionality changed.
Nothing much but cleaned up some things that are low hanging fruits to reduce the size of `@urql/core`.

## Set of changes

- Remove unnecessary destructuring/variables in Wonka operations
- Remove unneeded functions in `dedupExchange`
- Simplify `fallbackExchangeIO` by reducing minified code
- Simplify `searchParams` construction in `@urql/core/internal`
