### PR TITLE
chore(request-policy): add TSDoc for the requestPolicyExchange

### DIFF
--- a/exchanges/request-policy/src/requestPolicyExchange.ts
+++ b/exchanges/request-policy/src/requestPolicyExchange.ts
@@ -9,7 +9,14 @@ import { pipe, tap, map } from 'wonka';
 const defaultTTL = 5 * 60 * 1000;
 
 export interface Options {
-  /** A function allowing you to return a boolean on whether or not to upgrade the
+  /** Predicate allowing you to selectively not upgrade `Operation`s.
+  
+  @remarks
+  When `shouldUpgrade` is set, it may be used to selectively return a boolean
+  per `Operation`. This allows certain `Operation`s to not be upgraded to a
+  `cache-and-network` policy, when `false` is returned.
+  
+  By default, all `Operation`s are subject to be upgraded.
    * operation to "cache-and-network". */
   shouldUpgrade?: (op: Operation) => boolean;
   /** The time-to-live (TTL) for which a request policy won't be upgraded.

--- a/exchanges/request-policy/src/requestPolicyExchange.ts
+++ b/exchanges/request-policy/src/requestPolicyExchange.ts
@@ -50,7 +50,7 @@ export interface Options {
  * requestPolicyExchange({
  *  // Upgrade when we haven't seen this operation for 1 second
  *  ttl: 1000,
- *  // or when it's a todos query, we always upgrade those
+ *  // and only upgrade operations that query the `todos` field.
  *  shouldUpgrade: op => op.kind === 'query' && op.query.definitions[0].name?.value === 'todos'
  * });
  * ```

--- a/exchanges/request-policy/src/requestPolicyExchange.ts
+++ b/exchanges/request-policy/src/requestPolicyExchange.ts
@@ -8,6 +8,7 @@ import { pipe, tap, map } from 'wonka';
 
 const defaultTTL = 5 * 60 * 1000;
 
+/** Input parameters for the {@link requestPolicyExchange}. */
 export interface Options {
   /** Predicate allowing you to selectively not upgrade `Operation`s.
   

--- a/exchanges/request-policy/src/requestPolicyExchange.ts
+++ b/exchanges/request-policy/src/requestPolicyExchange.ts
@@ -12,7 +12,15 @@ export interface Options {
   /** A function allowing you to return a boolean on whether or not to upgrade the
    * operation to "cache-and-network". */
   shouldUpgrade?: (op: Operation) => boolean;
-  /** The TTL in ms for which we should not upgrade an operation for. */
+  /** The time-to-live (TTL) for which a request policy won't be upgraded.
+  
+  @remarks
+  The `ttl` defines the time frame in which the `Operation` won't be updated
+  with a `cache-and-network` request policy. If an `Operation` is sent again
+  and the `ttl` time period has expired, the policy is upgraded.
+  
+  @defaultValue `300_000` - 5min
+  */
   ttl?: number;
 }
 

--- a/exchanges/request-policy/src/requestPolicyExchange.ts
+++ b/exchanges/request-policy/src/requestPolicyExchange.ts
@@ -32,7 +32,7 @@ export interface Options {
   ttl?: number;
 }
 
-/** Creates an `Exchange` that can upgrade the request-policy to "cache-and-network" of an urql query operation.
+/** Exchange factory that upgrades request policies to `cache-and-network` for queries outside of a defined `ttl`.
  *
  * @param options - An {@link Options} configuration object.
  * @returns the created request-policy {@link Exchange}.

--- a/exchanges/request-policy/src/requestPolicyExchange.ts
+++ b/exchanges/request-policy/src/requestPolicyExchange.ts
@@ -39,7 +39,7 @@ export interface Options {
  *
  * @remarks
  * The `requestPolicyExchange` upgrades query operations based on {@link Options.ttl}.
- * The `ttl` defines a timeframe outside of which a query's request policy is set to 
+ * The `ttl` defines a timeframe outside of which a query's request policy is set to
  * `cache-and-network` to refetch it in the background.
  *
  * You may define a {@link Options.shouldUpgrade} function to selectively ignore some

--- a/exchanges/request-policy/src/requestPolicyExchange.ts
+++ b/exchanges/request-policy/src/requestPolicyExchange.ts
@@ -38,8 +38,12 @@ export interface Options {
  * @returns the created request-policy {@link Exchange}.
  *
  * @remarks
- * The `requestPolicyExchange` observes all operations going through and allows you
- * to upgrade based on a "ttl" or "shouldUpgrade" function.
+ * The `requestPolicyExchange` upgrades query operations based on {@link Options.ttl}.
+ * The `ttl` defines a timeframe outside of which a query's request policy is set to 
+ * `cache-and-network` to refetch it in the background.
+ *
+ * You may define a {@link Options.shouldUpgrade} function to selectively ignore some
+ * operations by returning `false` there.
  *
  * @example
  * ```ts

--- a/exchanges/request-policy/src/requestPolicyExchange.ts
+++ b/exchanges/request-policy/src/requestPolicyExchange.ts
@@ -9,10 +9,32 @@ import { pipe, tap, map } from 'wonka';
 const defaultTTL = 5 * 60 * 1000;
 
 export interface Options {
+  /** A function allowing you to return a boolean on whether or not to upgrade the
+   * operation to "cache-and-network". */
   shouldUpgrade?: (op: Operation) => boolean;
+  /** The TTL in ms for which we should not upgrade an operation for. */
   ttl?: number;
 }
 
+/** Creates an `Exchange` that can upgrade the request-policy to "cache-and-network" of an urql query operation.
+ *
+ * @param options - An {@link Options} configuration object.
+ * @returns the created request-policy {@link Exchange}.
+ *
+ * @remarks
+ * The `requestPolicyExchange` observes all operations going through and allows you
+ * to upgrade based on a "ttl" or "shouldUpgrade" function.
+ *
+ * @example
+ * ```ts
+ * requestPolicyExchange({
+ *  // Upgrade when we haven't seen this operation for 1 second
+ *  ttl: 1000,
+ *  // or when it's a todos query, we always upgrade those
+ *  shouldUpgrade: op => op.kind === 'query' && op.query.definitions[0].name?.value === 'todos'
+ * });
+ * ```
+ */
 export const requestPolicyExchange = (options: Options): Exchange => ({
   forward,
 }) => {


### PR DESCRIPTION
## Summary

This adds inline TSDoc annotations for the request-policy exchange, this should make adopting it a bit easier. I am considering adding a changeset here as the frequency of changes to this exchange are pretty low.