### PR TITLE
fix(core): move `multipart/mixed` to end of accept headers

### DIFF
--- a/.changeset/early-crabs-draw.md
+++ b/.changeset/early-crabs-draw.md
@@ -2,5 +2,4 @@
 '@urql/core': patch
 ---
 
-move `multipart/mixed` to the last `Accept` header to avoid breaking
-`react-native-fetch`
+Move `multipart/mixed` to end of `Accept` header to avoid cauing Yoga to unnecessarily use it.

--- a/.changeset/early-crabs-draw.md
+++ b/.changeset/early-crabs-draw.md
@@ -2,4 +2,5 @@
 '@urql/core': patch
 ---
 
-only add `multipart/mixed` when we see one of the streaming directives
+move `multipart/mixed` to the last `Accept` header to avoid breaking
+`react-native-fetch`

--- a/.changeset/early-crabs-draw.md
+++ b/.changeset/early-crabs-draw.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+only add `multipart/mixed` when we see one of the streaming directives

--- a/packages/core/src/internal/fetchOptions.ts
+++ b/packages/core/src/internal/fetchOptions.ts
@@ -89,15 +89,9 @@ export const makeFetchOptions = (
   const useGETMethod =
     operation.kind === 'query' && !!operation.context.preferGetMethod;
 
-  // Alternatively we could use visit() to see if we find any of the two
-  // directives
-  const hasStreamingDirective =
-    body?.query?.includes('@defer') || body?.query?.includes('@stream');
-
   const headers: HeadersInit = {
-    accept: `${
-      hasStreamingDirective ? 'multipart/mixed, ' : ''
-    }application/graphql-response+json, application/graphql+json, application/json`,
+    accept:
+      'application/graphql-response+json, application/graphql+json, application/json, multipart/mixed',
   };
   if (!useGETMethod) headers['content-type'] = 'application/json';
   const extraOptions =

--- a/packages/core/src/internal/fetchOptions.ts
+++ b/packages/core/src/internal/fetchOptions.ts
@@ -89,6 +89,8 @@ export const makeFetchOptions = (
   const useGETMethod =
     operation.kind === 'query' && !!operation.context.preferGetMethod;
 
+  // Alternatively we could use visit() to see if we find any of the two
+  // directives
   const hasStreamingDirective =
     body?.query?.includes('@defer') || body?.query?.includes('@stream');
 

--- a/packages/core/src/internal/fetchOptions.ts
+++ b/packages/core/src/internal/fetchOptions.ts
@@ -88,9 +88,14 @@ export const makeFetchOptions = (
 ): RequestInit => {
   const useGETMethod =
     operation.kind === 'query' && !!operation.context.preferGetMethod;
+
+  const hasStreamingDirective =
+    body?.query?.includes('@defer') || body?.query?.includes('@stream');
+
   const headers: HeadersInit = {
-    accept:
-      'multipart/mixed, application/graphql-response+json, application/graphql+json, application/json',
+    accept: `${
+      hasStreamingDirective ? 'multipart/mixed, ' : ''
+    }application/graphql-response+json, application/graphql+json, application/json`,
   };
   if (!useGETMethod) headers['content-type'] = 'application/json';
   const extraOptions =


### PR DESCRIPTION
## Summary

Follow up to https://github.com/urql-graphql/urql/pull/3007

In React-Native-Fetch streaming isn't supported meaning that the inclusion of `multipart/mixed` can lead to errors. We move it to the end of the Accept headers to avoid running into this bug. This was reported on Discord.

Relates to https://github.com/facebook/react-native/issues/27741