### PR TITLE
feat(core): Replace formatDocument's graphql.visit usage

### DIFF
--- a/.changeset/tame-pumas-promise.md
+++ b/.changeset/tame-pumas-promise.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Remove dependence on `import { visit } from 'graphql';` with smaller but functionally equivalent alternative.


### PR DESCRIPTION
## Summary

This replaces `graphql.visit` with a small alternative that is functionally equivalent. Many GraphQL apps actually never touch the GraphQL document or use `visit`, so this can be treeshaken away if `urql` doesn't rely on it.

This does increase our bundlesize by `40B` gzipped, but may be worth it overall.

## Set of changes

- Replace `graphql.visit` with custom alternative
