### PR TITLE
chore(core): Reformat some code to reduce @urql/core size

### DIFF
--- a/exchanges/graphcache/default-storage/package.json
+++ b/exchanges/graphcache/default-storage/package.json
@@ -16,7 +16,7 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@urql/core": ">=3.1.1",
+    "@urql/core": ">=3.2.2",
     "wonka": "^6.0.0"
   }
 }

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -21,7 +21,7 @@ import {
 } from 'wonka';
 
 import { query, write, writeOptimistic } from './operations';
-import { addCacheOutcome, toRequestPolicy } from './helpers/operation';
+import { addMetadata, toRequestPolicy } from './helpers/operation';
 import { filterVariables, getMainOperation } from './ast';
 import { Store, noopDataState, hydrateData, reserveLayer } from './store';
 import { Data, Dependencies, CacheExchangeOpts } from './types';
@@ -295,7 +295,7 @@ export const cacheExchange = <C extends Partial<CacheExchangeOpts>>(
           message: 'The result could not be retrieved from the cache',
           operation: res.operation,
         });
-        return addCacheOutcome(res.operation, 'miss');
+        return addMetadata(res.operation, { cacheOutcome: 'miss' });
       })
     );
 
@@ -327,7 +327,9 @@ export const cacheExchange = <C extends Partial<CacheExchangeOpts>>(
               !reexecutingOperations.has(res.operation.key));
 
           const result: OperationResult = {
-            operation: addCacheOutcome(res.operation, res.outcome),
+            operation: addMetadata(res.operation, {
+              cacheOutcome: res.outcome,
+            }),
             data: res.data,
             error: res.error,
             extensions: res.extensions,

--- a/exchanges/graphcache/src/helpers/operation.ts
+++ b/exchanges/graphcache/src/helpers/operation.ts
@@ -1,20 +1,20 @@
 import {
   Operation,
   RequestPolicy,
-  CacheOutcome,
+  OperationDebugMeta,
   makeOperation,
 } from '@urql/core';
 
 // Returns the given operation result with added cacheOutcome meta field
-export const addCacheOutcome = (
+export const addMetadata = (
   operation: Operation,
-  outcome: CacheOutcome
+  meta: OperationDebugMeta
 ): Operation =>
   makeOperation(operation.kind, operation, {
     ...operation.context,
     meta: {
       ...operation.context.meta,
-      cacheOutcome: outcome,
+      ...meta,
     },
   });
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -433,6 +433,7 @@ export interface OperationContext {
    * `OperationResult`s and is filled in by exchanges across the codebase in development.
    *
    * This data is not for production use and hence shouldn't be used or relied upon directly.
+   * In production, this may not be set by default exchanges.
    */
   meta?: OperationDebugMeta;
   /** Instructs fetch exchanges to use a GET request.

--- a/packages/core/src/utils/hash.ts
+++ b/packages/core/src/utils/hash.ts
@@ -17,6 +17,8 @@ export type HashValue = number & {
   readonly _opaque: unique symbol;
 };
 
+const BASE = 5381 as HashValue;
+
 /** Computes a djb2 hash of the given string.
  *
  * @param x - the string to be hashed
@@ -29,8 +31,8 @@ export type HashValue = number & {
  *
  * @see {@link http://www.cse.yorku.ca/~oz/hash.html#djb2} for a further description of djb2.
  */
-export const phash = (x: string, seed?: HashValue): HashValue => {
-  let h = typeof seed === 'number' ? seed | 0 : 5381;
+export const phash = (x: string, seed: HashValue = BASE): HashValue => {
+  let h = seed | 0;
   for (let i = 0, l = x.length | 0; i < l; i++)
     h = (h << 5) + h + x.charCodeAt(i);
   return h as HashValue;

--- a/packages/core/src/utils/hash.ts
+++ b/packages/core/src/utils/hash.ts
@@ -17,8 +17,6 @@ export type HashValue = number & {
   readonly _opaque: unique symbol;
 };
 
-const BASE = 5381 as HashValue;
-
 /** Computes a djb2 hash of the given string.
  *
  * @param x - the string to be hashed
@@ -31,8 +29,8 @@ const BASE = 5381 as HashValue;
  *
  * @see {@link http://www.cse.yorku.ca/~oz/hash.html#djb2} for a further description of djb2.
  */
-export const phash = (x: string, seed: HashValue = BASE): HashValue => {
-  let h = seed | 0;
+export const phash = (x: string, seed?: HashValue): HashValue => {
+  let h = (seed || 5381) | 0;
   for (let i = 0, l = x.length | 0; i < l; i++)
     h = (h << 5) + h + x.charCodeAt(i);
   return h as HashValue;

--- a/packages/core/src/utils/result.ts
+++ b/packages/core/src/utils/result.ts
@@ -79,12 +79,7 @@ export const mergeResultPatch = (
 
   // NOTE: We handle the old version of the incremental delivery payloads as well
   if ('path' in nextResult) {
-    incremental = [
-      {
-        data: nextResult.data,
-        path: nextResult.path,
-      } as IncrementalPayload,
-    ];
+    incremental = [nextResult as IncrementalPayload];
   }
 
   if (incremental) {

--- a/packages/core/src/utils/result.ts
+++ b/packages/core/src/utils/result.ts
@@ -42,8 +42,7 @@ export const makeResult = (
           response,
         })
       : undefined,
-    extensions:
-      (typeof result.extensions === 'object' && result.extensions) || undefined,
+    extensions: result.extensions ? { ...result.extensions } : undefined,
     hasNext: result.hasNext == null ? defaultHasNext : result.hasNext,
   };
 };

--- a/packages/core/src/utils/result.ts
+++ b/packages/core/src/utils/result.ts
@@ -28,10 +28,7 @@ export const makeResult = (
   result: ExecutionResult,
   response?: any
 ): OperationResult => {
-  if (
-    (!('data' in result) && !('errors' in result)) ||
-    'incremental' in result
-  ) {
+  if (!('data' in result) && !('errors' in result)) {
     throw new Error('No Content');
   }
 

--- a/packages/core/src/utils/stringifyVariables.ts
+++ b/packages/core/src/utils/stringifyVariables.ts
@@ -22,7 +22,7 @@ const stringify = (x: any): string => {
   if (!keys.length && x.constructor && x.constructor !== Object) {
     const key = cache.get(x) || Math.random().toString(36).slice(2);
     cache.set(x, key);
-    return `{"__key":"${key}"}`;
+    return stringify({ __key: key });
   }
 
   seen.add(x);

--- a/packages/core/src/utils/stringifyVariables.ts
+++ b/packages/core/src/utils/stringifyVariables.ts
@@ -10,12 +10,10 @@ const stringify = (x: any): string => {
     return stringify(x.toJSON());
   } else if (Array.isArray(x)) {
     let out = '[';
-    for (let value of x) {
-      if (out !== '[') out += ',';
-      value = stringify(value);
-      out += value.length > 0 ? value : 'null';
+    for (const value of x) {
+      if (out.length > 1) out += ',';
+      out += stringify(value) || 'null';
     }
-
     out += ']';
     return out;
   }


### PR DESCRIPTION
Follow-up to #3035

## Summary

This further attempts to reduce the size and clean up some implementations in `@urql/core`.

`6.2kB -> 6.06kB` gzip+min

## Set of changes

- Reformat `phash`
- Reformat `hashDocument` and `createRequest`
- Remove `OperationContext.meta` in production by compiling away `addMetadata` calls
- Reformat and remove redundant `'incremental'` check in `makeResult`
- Reformat legacy fallback in `mergeResultPatch`
- Reformat `withPromise` and rewrite with `wonka` update (**NOTE:** This should work due to wonka's `toPromise` fix)
- Reformat `gql` implementation
- Reformat `stringify` in `stringifyVariables`
