### PR TITLE
feat(core): Reimplement fetch source as async generator

### DIFF
--- a/.changeset/real-donkeys-act.md
+++ b/.changeset/real-donkeys-act.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Replace fetch source implementation with async generator implementation, based on Wonka's `fromAsyncIterable`.

--- a/.changeset/real-donkeys-act.md
+++ b/.changeset/real-donkeys-act.md
@@ -3,3 +3,5 @@
 ---
 
 Replace fetch source implementation with async generator implementation, based on Wonka's `fromAsyncIterable`.
+This also further hardens our support for the "Incremental Delivery" specification and
+refactors its implementation and covers more edge cases.

--- a/exchanges/execute/src/execute.test.ts
+++ b/exchanges/execute/src/execute.test.ts
@@ -196,6 +196,7 @@ describe('on operation', () => {
 
     fetchMock.mockResolvedValue({
       status: 200,
+      headers: { get: () => 'application/json' },
       text: vi
         .fn()
         .mockResolvedValue(JSON.stringify({ data: mockHttpResponseData })),

--- a/exchanges/graphcache/src/offlineExchange.test.ts
+++ b/exchanges/graphcache/src/offlineExchange.test.ts
@@ -62,7 +62,11 @@ const storage = {
 
 describe('storage', () => {
   it('should read the metadata and dispatch operations on initialization', () => {
-    const client = createClient({ url: 'http://0.0.0.0' });
+    const client = createClient({
+      url: 'http://0.0.0.0',
+      exchanges: [],
+    });
+
     const reexecuteOperation = vi
       .spyOn(client, 'reexecuteOperation')
       .mockImplementation(() => undefined);
@@ -100,7 +104,11 @@ describe('offline', () => {
   it('should intercept errored mutations', () => {
     const onlineSpy = vi.spyOn(navigator, 'onLine', 'get');
 
-    const client = createClient({ url: 'http://0.0.0.0' });
+    const client = createClient({
+      url: 'http://0.0.0.0',
+      exchanges: [],
+    });
+
     const queryOp = client.createRequestOperation('query', {
       key: 1,
       query: queryOne,

--- a/exchanges/multipart-fetch/src/multipartFetchExchange.test.ts
+++ b/exchanges/multipart-fetch/src/multipartFetchExchange.test.ts
@@ -59,6 +59,7 @@ describe('on success', () => {
   beforeEach(() => {
     fetch.mockResolvedValue({
       status: 200,
+      headers: { get: () => 'application/json' },
       text: vi.fn().mockResolvedValue(response),
     });
   });
@@ -128,6 +129,7 @@ describe('on error', () => {
   beforeEach(() => {
     fetch.mockResolvedValue({
       status: 400,
+      headers: { get: () => 'application/json' },
       text: vi.fn().mockResolvedValue('{}'),
     });
   });
@@ -163,6 +165,7 @@ describe('on error', () => {
   it('ignores the error when a result is available', async () => {
     fetch.mockResolvedValue({
       status: 400,
+      headers: { get: () => 'application/json' },
       text: vi.fn().mockResolvedValue(response),
     });
 

--- a/exchanges/persisted-fetch/src/persistedFetchExchange.test.ts
+++ b/exchanges/persisted-fetch/src/persistedFetchExchange.test.ts
@@ -36,6 +36,8 @@ it('accepts successful persisted query responses', async () => {
   });
 
   fetch.mockResolvedValueOnce({
+    status: 200,
+    headers: { get: () => 'application/json' },
     text: () => Promise.resolve(expected),
   });
 
@@ -63,9 +65,13 @@ it('supports cache-miss persisted query errors', async () => {
 
   fetch
     .mockResolvedValueOnce({
+      status: 200,
+      headers: { get: () => 'application/json' },
       text: () => Promise.resolve(expectedMiss),
     })
     .mockResolvedValueOnce({
+      status: 200,
+      headers: { get: () => 'application/json' },
       text: () => Promise.resolve(expectedRetry),
     });
 
@@ -94,9 +100,13 @@ it('supports GET exclusively for persisted queries', async () => {
 
   fetch
     .mockResolvedValueOnce({
+      status: 200,
+      headers: { get: () => 'application/json' },
       text: () => Promise.resolve(expectedMiss),
     })
     .mockResolvedValueOnce({
+      status: 200,
+      headers: { get: () => 'application/json' },
       text: () => Promise.resolve(expectedRetry),
     });
 
@@ -127,12 +137,18 @@ it('supports unsupported persisted query errors', async () => {
 
   fetch
     .mockResolvedValueOnce({
+      status: 200,
+      headers: { get: () => 'application/json' },
       text: () => Promise.resolve(expectedMiss),
     })
     .mockResolvedValueOnce({
+      status: 200,
+      headers: { get: () => 'application/json' },
       text: () => Promise.resolve(expectedRetry),
     })
     .mockResolvedValueOnce({
+      status: 200,
+      headers: { get: () => 'application/json' },
       text: () => Promise.resolve(expectedRetry),
     });
 

--- a/packages/core/src/exchanges/fetch.test.ts
+++ b/packages/core/src/exchanges/fetch.test.ts
@@ -62,6 +62,7 @@ describe('on success', () => {
   beforeEach(() => {
     fetch.mockResolvedValue({
       status: 200,
+      headers: { get: () => 'application/json' },
       text: vi.fn().mockResolvedValue(response),
     });
   });
@@ -91,6 +92,7 @@ describe('on error', () => {
   beforeEach(() => {
     fetch.mockResolvedValue({
       status: 400,
+      headers: { get: () => 'application/json' },
       text: vi.fn().mockResolvedValue(JSON.stringify({})),
     });
   });
@@ -126,6 +128,7 @@ describe('on error', () => {
   it('ignores the error when a result is available', async () => {
     fetch.mockResolvedValue({
       status: 400,
+      headers: { get: () => 'application/json' },
       text: vi.fn().mockResolvedValue(response),
     });
 

--- a/packages/core/src/exchanges/fetch.test.ts
+++ b/packages/core/src/exchanges/fetch.test.ts
@@ -143,8 +143,9 @@ describe('on teardown', () => {
   const fail = () => {
     expect(true).toEqual(false);
   };
+
   it('does not start the outgoing request on immediate teardowns', () => {
-    fetch.mockRejectedValueOnce(abortError);
+    fetch.mockResolvedValue(new Response('text', { status: 200 }));
 
     const { unsubscribe } = pipe(
       fromValue(queryOperation),
@@ -154,11 +155,11 @@ describe('on teardown', () => {
 
     unsubscribe();
     expect(fetch).toHaveBeenCalledTimes(0);
-    expect(abort).toHaveBeenCalledTimes(1);
+    expect(abort).toHaveBeenCalledTimes(0);
   });
 
   it('aborts the outgoing request', async () => {
-    fetch.mockRejectedValueOnce(abortError);
+    fetch.mockResolvedValue(new Response('text', { status: 200 }));
 
     const { unsubscribe } = pipe(
       fromValue(queryOperation),
@@ -169,11 +170,16 @@ describe('on teardown', () => {
     await Promise.resolve();
 
     unsubscribe();
+
+    // NOTE: We can only observe the async iterator's final run after a macro tick
+    await new Promise(resolve => setTimeout(resolve));
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(abort).toHaveBeenCalledTimes(1);
   });
 
   it('does not call the query', () => {
+    fetch.mockResolvedValue(new Response('text', { status: 200 }));
+
     pipe(
       fromValue(
         makeOperation('teardown', queryOperation, queryOperation.context)

--- a/packages/core/src/exchanges/fetch.test.ts
+++ b/packages/core/src/exchanges/fetch.test.ts
@@ -174,7 +174,7 @@ describe('on teardown', () => {
     // NOTE: We can only observe the async iterator's final run after a macro tick
     await new Promise(resolve => setTimeout(resolve));
     expect(fetch).toHaveBeenCalledTimes(1);
-    expect(abort).toHaveBeenCalledTimes(1);
+    expect(abort).toHaveBeenCalled();
   });
 
   it('does not call the query', () => {

--- a/packages/core/src/internal/__snapshots__/fetchSource.test.ts.snap
+++ b/packages/core/src/internal/__snapshots__/fetchSource.test.ts.snap
@@ -606,6 +606,9 @@ exports[`on success > uses the mock fetch if given 1`] = `
           {
             "type": "return",
             "value": {
+              "headers": {
+                "get": [Function],
+              },
               "status": 200,
               "text": [MockFunction spy] {
                 "calls": [

--- a/packages/core/src/internal/fetchSource.test.ts
+++ b/packages/core/src/internal/fetchSource.test.ts
@@ -48,6 +48,7 @@ describe('on success', () => {
   beforeEach(() => {
     fetch.mockResolvedValue({
       status: 200,
+      headers: { get: () => 'application/json' },
       text: vi.fn().mockResolvedValue(response),
     });
   });
@@ -70,6 +71,7 @@ describe('on success', () => {
     const fetchOptions = {};
     const fetcher = vi.fn().mockResolvedValue({
       status: 200,
+      headers: { get: () => 'application/json' },
       text: vi.fn().mockResolvedValue(response),
     });
 
@@ -99,6 +101,7 @@ describe('on error', () => {
     fetch.mockResolvedValue({
       status: 400,
       statusText: 'Forbidden',
+      headers: { get: () => 'application/json' },
       text: vi.fn().mockResolvedValue('{}'),
     });
   });

--- a/packages/core/src/internal/fetchSource.ts
+++ b/packages/core/src/internal/fetchSource.ts
@@ -47,9 +47,12 @@ async function* parseMultipartChunks(
           buffer.indexOf('\r\n\r\n') + 4,
           boundaryIndex
         );
+
         try {
           yield (payload = JSON.parse(chunk));
-        } catch (_error) {}
+        } catch (error) {
+          if (!payload) throw error;
+        }
 
         buffer = buffer.slice(boundaryIndex + boundary.length);
         if (buffer.startsWith('--') || (payload && !payload.hasNext))

--- a/packages/core/src/internal/fetchSource.ts
+++ b/packages/core/src/internal/fetchSource.ts
@@ -1,4 +1,4 @@
-import { Source, make } from 'wonka';
+import { Source, fromAsyncIterable } from 'wonka';
 import { Operation, OperationResult } from '../types';
 import { makeResult, makeErrorResult, mergeResultPatch } from '../utils';
 
@@ -6,7 +6,7 @@ const decoder = typeof TextDecoder !== 'undefined' ? new TextDecoder() : null;
 const jsonHeaderRe = /content-type:[^\r\n]*application\/json/i;
 const boundaryHeaderRe = /boundary="?([^=";]+)"?/i;
 
-type ChunkData = { done: false; value: Buffer | Uint8Array } | { done: true };
+type ChunkData = Buffer | Uint8Array;
 
 // NOTE: We're avoiding referencing the `Buffer` global here to prevent
 // auto-polyfilling in Webpack
@@ -14,6 +14,129 @@ const toString = (input: Buffer | ArrayBuffer): string =>
   input.constructor.name === 'Buffer'
     ? (input as Buffer).toString()
     : decoder!.decode(input as ArrayBuffer);
+
+async function* fetchOperation(
+  operation: Operation,
+  url: string,
+  fetchOptions: RequestInit
+) {
+  let abortController: AbortController | void;
+  let response: Response;
+  let hasResults = false;
+  let statusNotOk = false;
+
+  try {
+    if (typeof AbortController !== 'undefined') {
+      fetchOptions.signal = (abortController = new AbortController()).signal;
+    }
+
+    // Delay for a tick to give the Client a chance to cancel the request
+    // if a teardown comes in immediately
+    await Promise.resolve();
+
+    response = await (operation.context.fetch || fetch)(url, fetchOptions);
+    statusNotOk =
+      response.status < 200 ||
+      response.status >= (fetchOptions.redirect === 'manual' ? 400 : 300);
+
+    const contentType =
+      (response.headers && response.headers.get('Content-Type')) || '';
+    if (/text\//i.test(contentType)) {
+      const text = await response.text();
+      return yield makeErrorResult(operation, new Error(text), response);
+    } else if (!/multipart\/mixed/i.test(contentType)) {
+      const text = await response.text();
+      return yield makeResult(operation, JSON.parse(text), response);
+    }
+
+    let boundary = '---';
+    const boundaryHeader = contentType.match(boundaryHeaderRe);
+    if (boundaryHeader) boundary = '--' + boundaryHeader[1];
+
+    let iterator: AsyncIterableIterator<ChunkData>;
+    if (response[Symbol.asyncIterator]) {
+      iterator = response[Symbol.asyncIterator]();
+    } else {
+      const reader = response.body!.getReader();
+      iterator = {
+        next() {
+          return reader.read() as Promise<IteratorResult<ChunkData>>;
+        },
+        [Symbol.asyncIterator]() {
+          return iterator;
+        },
+      };
+    }
+
+    let buffer = '';
+    let isPreamble = true;
+    let nextResult: OperationResult | null = null;
+    let prevResult: OperationResult | null = null;
+    for await (const data of iterator) {
+      hasResults = true;
+
+      const chunk = toString(data);
+      let boundaryIndex = chunk.indexOf(boundary);
+      if (boundaryIndex > -1) {
+        boundaryIndex += buffer.length;
+      } else {
+        boundaryIndex = buffer.indexOf(boundary);
+      }
+
+      buffer += chunk;
+      while (boundaryIndex > -1) {
+        const current = buffer.slice(0, boundaryIndex);
+        const next = buffer.slice(boundaryIndex + boundary.length);
+
+        if (isPreamble) {
+          isPreamble = false;
+        } else {
+          const headersEnd = current.indexOf('\r\n\r\n') + 4;
+          const headers = current.slice(0, headersEnd);
+          const body = current.slice(headersEnd, current.lastIndexOf('\r\n'));
+
+          let payload: any;
+          if (jsonHeaderRe.test(headers)) {
+            try {
+              payload = JSON.parse(body);
+              nextResult = prevResult = prevResult
+                ? mergeResultPatch(prevResult, payload, response)
+                : makeResult(operation, payload, response);
+            } catch (_error) {}
+          }
+
+          if (next.slice(0, 2) === '--' || (payload && !payload.hasNext)) {
+            if (!prevResult) yield makeResult(operation, {}, response);
+            break;
+          }
+        }
+
+        buffer = next;
+        boundaryIndex = buffer.indexOf(boundary);
+      }
+
+      if (nextResult) {
+        yield nextResult;
+        nextResult = null;
+      }
+    }
+  } catch (error: any) {
+    if (hasResults) {
+      throw error;
+    }
+
+    yield makeErrorResult(
+      operation,
+      (statusNotOk &&
+        response!.statusText &&
+        new Error(response!.statusText)) ||
+        error,
+      response!
+    );
+  } finally {
+    abortController?.abort();
+  }
+}
 
 /** Makes a GraphQL HTTP request to a given API by wrapping around the Fetch API.
  *
@@ -42,168 +165,10 @@ const toString = (input: Buffer | ArrayBuffer): string =>
  *
  * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API} for the Fetch API spec.
  */
-export const makeFetchSource = (
+export function makeFetchSource(
   operation: Operation,
   url: string,
   fetchOptions: RequestInit
-): Source<OperationResult> => {
-  const maxStatus = fetchOptions.redirect === 'manual' ? 400 : 300;
-  const fetcher = operation.context.fetch;
-
-  return make<OperationResult>(({ next, complete }) => {
-    const abortController =
-      typeof AbortController !== 'undefined' ? new AbortController() : null;
-    if (abortController) {
-      fetchOptions.signal = abortController.signal;
-    }
-
-    let hasResults = false;
-    // DERIVATIVE: Copyright (c) 2021 Marais Rossouw <hi@marais.io>
-    // See: https://github.com/maraisr/meros/blob/219fe95/src/browser.ts
-    const executeIncrementalFetch = (
-      onResult: (result: OperationResult) => void,
-      operation: Operation,
-      response: Response
-    ): Promise<void> => {
-      // NOTE: Guarding against fetch polyfills here
-      const contentType =
-        (response.headers && response.headers.get('Content-Type')) || '';
-      if (/text\//i.test(contentType)) {
-        return response.text().then(text => {
-          onResult(makeErrorResult(operation, new Error(text), response));
-        });
-      } else if (!/multipart\/mixed/i.test(contentType)) {
-        return response.text().then(payload => {
-          onResult(makeResult(operation, JSON.parse(payload), response));
-        });
-      }
-
-      let boundary = '---';
-      const boundaryHeader = contentType.match(boundaryHeaderRe);
-      if (boundaryHeader) boundary = '--' + boundaryHeader[1];
-
-      let read: () => Promise<ChunkData>;
-      let cancel = () => {
-        /*noop*/
-      };
-      if (response[Symbol.asyncIterator]) {
-        const iterator = response[Symbol.asyncIterator]();
-        read = iterator.next.bind(iterator);
-      } else if ('body' in response && response.body) {
-        const reader = response.body.getReader();
-        cancel = () => reader.cancel();
-        read = () => reader.read();
-      } else {
-        throw new TypeError('Streaming requests unsupported');
-      }
-
-      let buffer = '';
-      let isPreamble = true;
-      let nextResult: OperationResult | null = null;
-      let prevResult: OperationResult | null = null;
-
-      function next(data: ChunkData): Promise<void> | void {
-        if (!data.done) {
-          const chunk = toString(data.value);
-          let boundaryIndex = chunk.indexOf(boundary);
-          if (boundaryIndex > -1) {
-            boundaryIndex += buffer.length;
-          } else {
-            boundaryIndex = buffer.indexOf(boundary);
-          }
-
-          buffer += chunk;
-          while (boundaryIndex > -1) {
-            const current = buffer.slice(0, boundaryIndex);
-            const next = buffer.slice(boundaryIndex + boundary.length);
-
-            if (isPreamble) {
-              isPreamble = false;
-            } else {
-              const headersEnd = current.indexOf('\r\n\r\n') + 4;
-              const headers = current.slice(0, headersEnd);
-              const body = current.slice(
-                headersEnd,
-                current.lastIndexOf('\r\n')
-              );
-
-              let payload: any;
-              if (jsonHeaderRe.test(headers)) {
-                try {
-                  payload = JSON.parse(body);
-                  nextResult = prevResult = prevResult
-                    ? mergeResultPatch(prevResult, payload, response)
-                    : makeResult(operation, payload, response);
-                } catch (_error) {}
-              }
-
-              if (next.slice(0, 2) === '--' || (payload && !payload.hasNext)) {
-                if (!prevResult)
-                  return onResult(makeResult(operation, {}, response));
-                break;
-              }
-            }
-
-            buffer = next;
-            boundaryIndex = buffer.indexOf(boundary);
-          }
-        } else {
-          hasResults = true;
-        }
-
-        if (nextResult) {
-          onResult(nextResult);
-          nextResult = null;
-        }
-
-        if (!data.done && (!prevResult || prevResult.hasNext)) {
-          return read().then(next);
-        }
-      }
-
-      return read().then(next).finally(cancel);
-    };
-
-    let ended = false;
-    let statusNotOk = false;
-    let response: Response;
-
-    Promise.resolve()
-      .then(() => {
-        if (ended) return;
-        return (fetcher || fetch)(url, fetchOptions);
-      })
-      .then((_response: Response | void) => {
-        if (!_response) return;
-        response = _response;
-        statusNotOk = response.status < 200 || response.status >= maxStatus;
-        return executeIncrementalFetch(next, operation, response);
-      })
-      .then(complete)
-      .catch((error: Error) => {
-        if (hasResults) {
-          throw error;
-        }
-
-        const result = makeErrorResult(
-          operation,
-          statusNotOk
-            ? response.statusText
-              ? new Error(response.statusText)
-              : error
-            : error,
-          response
-        );
-
-        next(result);
-        complete();
-      });
-
-    return () => {
-      ended = true;
-      if (abortController) {
-        abortController.abort();
-      }
-    };
-  });
-};
+): Source<OperationResult> {
+  return fromAsyncIterable(fetchOperation(operation, url, fetchOptions));
+}

--- a/packages/core/src/internal/fetchSource.ts
+++ b/packages/core/src/internal/fetchSource.ts
@@ -62,10 +62,8 @@ async function* fetchOperation(
       return yield makeResult(operation, JSON.parse(text), response);
     }
 
-    let boundary = '---';
     const boundaryHeader = contentType.match(boundaryHeaderRe);
-    if (boundaryHeader) boundary = '--' + boundaryHeader[1];
-
+    const boundary = '--' + (boundaryHeader ? boundaryHeader[1] : '-');
     const iterator = streamBody(response);
 
     let buffer = '';

--- a/packages/core/src/internal/fetchSource.ts
+++ b/packages/core/src/internal/fetchSource.ts
@@ -29,7 +29,7 @@ async function* streamBody(response: Response): AsyncIterableIterator<string> {
   }
 }
 
-async function* parseMultipartChunks(
+async function* parseMultipartMixed(
   contentType: string,
   response: Response
 ): AsyncIterableIterator<ExecutionResult> {
@@ -95,7 +95,7 @@ async function* fetchOperation(
       return yield makeResult(operation, JSON.parse(text), response);
     }
 
-    const iterator = parseMultipartChunks(contentType, response);
+    const iterator = parseMultipartMixed(contentType, response);
     for await (const payload of iterator) {
       yield (result = result
         ? mergeResultPatch(result, payload, response)

--- a/packages/core/src/internal/fetchSource.ts
+++ b/packages/core/src/internal/fetchSource.ts
@@ -21,7 +21,11 @@ async function* streamBody(response: Response): AsyncIterableIterator<string> {
   } else {
     const reader = response.body!.getReader();
     let result: ReadableStreamReadResult<ChunkData>;
-    while (!(result = await reader.read()).done) yield toString(result.value);
+    try {
+      while (!(result = await reader.read()).done) yield toString(result.value);
+    } finally {
+      reader.cancel();
+    }
   }
 }
 

--- a/packages/core/src/internal/fetchSource.ts
+++ b/packages/core/src/internal/fetchSource.ts
@@ -69,7 +69,7 @@ async function* fetchOperation(
     let buffer = '';
     let isPreamble = true;
     let result: OperationResult | null = null;
-    for await (const data of iterator) {
+    chunks: for await (const data of iterator) {
       hasResults = true;
       buffer += toString(data);
 
@@ -89,15 +89,14 @@ async function* fetchOperation(
           let payload: any;
           try {
             payload = JSON.parse(body);
-            result = result
+            yield (result = result
               ? mergeResultPatch(result, payload, response)
-              : makeResult(operation, payload, response);
-            yield result;
+              : makeResult(operation, payload, response));
           } catch (_error) {}
 
           if (next.slice(0, 2) === '--' || (payload && !payload.hasNext)) {
             if (!result) yield makeResult(operation, {}, response);
-            break;
+            break chunks;
           }
         }
 

--- a/packages/core/src/internal/fetchSource.ts
+++ b/packages/core/src/internal/fetchSource.ts
@@ -68,8 +68,7 @@ async function* fetchOperation(
 
     let buffer = '';
     let isPreamble = true;
-    let nextResult: OperationResult | null = null;
-    let prevResult: OperationResult | null = null;
+    let result: OperationResult | null = null;
     for await (const data of iterator) {
       hasResults = true;
       buffer += toString(data);
@@ -90,23 +89,19 @@ async function* fetchOperation(
           let payload: any;
           try {
             payload = JSON.parse(body);
-            nextResult = prevResult = prevResult
-              ? mergeResultPatch(prevResult, payload, response)
+            result = result
+              ? mergeResultPatch(result, payload, response)
               : makeResult(operation, payload, response);
+            yield result;
           } catch (_error) {}
 
           if (next.slice(0, 2) === '--' || (payload && !payload.hasNext)) {
-            if (!prevResult) yield makeResult(operation, {}, response);
+            if (!result) yield makeResult(operation, {}, response);
             break;
           }
         }
 
         buffer = next;
-      }
-
-      if (nextResult) {
-        yield nextResult;
-        nextResult = null;
       }
     }
   } catch (error: any) {

--- a/packages/core/src/internal/fetchSource.ts
+++ b/packages/core/src/internal/fetchSource.ts
@@ -32,6 +32,7 @@ async function* parseMultipartChunks(response: Response, contentType: string) {
   let buffer = '';
   let isPreamble = true;
   let boundaryIndex: number;
+  let payload: any;
 
   chunks: for await (const chunk of streamBody(response)) {
     buffer += chunk;
@@ -43,7 +44,6 @@ async function* parseMultipartChunks(response: Response, contentType: string) {
           buffer.indexOf('\r\n\r\n') + 4,
           boundaryIndex
         );
-        let payload: any;
         try {
           yield (payload = JSON.parse(chunk));
         } catch (_error) {}
@@ -54,6 +54,8 @@ async function* parseMultipartChunks(response: Response, contentType: string) {
       }
     }
   }
+
+  if (payload && payload.hasNext) yield { hasNext: false };
 }
 
 async function* fetchOperation(

--- a/packages/core/src/internal/fetchSource.ts
+++ b/packages/core/src/internal/fetchSource.ts
@@ -46,8 +46,7 @@ async function* fetchOperation(
     // if a teardown comes in immediately
     await Promise.resolve();
     response = await (operation.context.fetch || fetch)(url, fetchOptions);
-    const contentType =
-      (response.headers && response.headers.get('Content-Type')) || '';
+    const contentType = response.headers.get('Content-Type') || '';
     if (/text\//i.test(contentType)) {
       const text = await response.text();
       return yield makeErrorResult(operation, new Error(text), response);
@@ -87,8 +86,7 @@ async function* fetchOperation(
           } catch (_error) {}
 
           if (next.startsWith('--') || (payload && !payload.hasNext)) {
-            if (!result)
-              yield (result = makeResult(operation, {}, response));
+            if (!result) yield (result = makeResult(operation, {}, response));
             break chunks;
           }
         }
@@ -103,7 +101,8 @@ async function* fetchOperation(
 
     yield makeErrorResult(
       operation,
-      (response!.status < 200 || response!.status >= 300) && response!.statusText
+      (response!.status < 200 || response!.status >= 300) &&
+        response!.statusText
         ? new Error(response!.statusText)
         : error,
       response!

--- a/packages/core/src/internal/fetchSource.ts
+++ b/packages/core/src/internal/fetchSource.ts
@@ -72,17 +72,10 @@ async function* fetchOperation(
     let prevResult: OperationResult | null = null;
     for await (const data of iterator) {
       hasResults = true;
+      buffer += toString(data);
 
-      const chunk = toString(data);
-      let boundaryIndex = chunk.indexOf(boundary);
-      if (boundaryIndex > -1) {
-        boundaryIndex += buffer.length;
-      } else {
-        boundaryIndex = buffer.indexOf(boundary);
-      }
-
-      buffer += chunk;
-      while (boundaryIndex > -1) {
+      let boundaryIndex: number;
+      while ((boundaryIndex = buffer.indexOf(boundary)) > -1) {
         const current = buffer.slice(0, boundaryIndex);
         const next = buffer.slice(boundaryIndex + boundary.length);
 
@@ -109,7 +102,6 @@ async function* fetchOperation(
         }
 
         buffer = next;
-        boundaryIndex = buffer.indexOf(boundary);
       }
 
       if (nextResult) {

--- a/packages/core/src/internal/fetchSource.ts
+++ b/packages/core/src/internal/fetchSource.ts
@@ -134,7 +134,7 @@ async function* fetchOperation(
       response!
     );
   } finally {
-    abortController?.abort();
+    if (abortController) abortController.abort();
   }
 }
 

--- a/packages/core/src/internal/fetchSource.ts
+++ b/packages/core/src/internal/fetchSource.ts
@@ -88,7 +88,7 @@ async function* fetchOperation(
               : makeResult(operation, payload, response));
           } catch (_error) {}
 
-          if (next.slice(0, 2) === '--' || (payload && !payload.hasNext)) {
+          if (next.startsWith('--') || (payload && !payload.hasNext)) {
             if (!result) yield makeResult(operation, {}, response);
             break chunks;
           }

--- a/packages/core/src/internal/fetchSource.ts
+++ b/packages/core/src/internal/fetchSource.ts
@@ -57,11 +57,11 @@ async function* parseMultipartMixed(
         } catch (error) {
           if (!payload) throw error;
         }
-
-        buffer = buffer.slice(boundaryIndex + boundary.length);
-        if (buffer.startsWith('--') || (payload && !payload.hasNext))
-          break chunks;
       }
+
+      buffer = buffer.slice(boundaryIndex + boundary.length);
+      if (buffer.startsWith('--') || (payload && !payload.hasNext))
+        break chunks;
     }
   }
 

--- a/packages/svelte-urql/src/mutationStore.test.ts
+++ b/packages/svelte-urql/src/mutationStore.test.ts
@@ -6,9 +6,14 @@ import { vi, expect, it, describe } from 'vitest';
 import { mutationStore } from './mutationStore';
 
 describe('mutationStore', () => {
-  const client = createClient({ url: 'https://example.com' });
+  const client = createClient({
+    url: 'noop',
+    exchanges: [],
+  });
+
   const variables = {};
   const context = {};
+
   const query =
     'mutation ($input: Example!) { doExample(input: $input) { id } }';
   const store = mutationStore({
@@ -26,14 +31,13 @@ describe('mutationStore', () => {
 
   it('fills the store with correct values', () => {
     expect(get(store).operation.kind).toBe('mutation');
-    expect(get(store).operation.context.url).toBe('https://example.com');
+    expect(get(store).operation.context.url).toBe('noop');
     expect(get(store).operation.variables).toBe(variables);
 
     expect(print(get(store).operation.query)).toMatchInlineSnapshot(`
       "mutation ($input: Example!) {
         doExample(input: $input) {
           id
-          __typename
         }
       }"
     `);

--- a/packages/svelte-urql/src/mutationStore.test.ts
+++ b/packages/svelte-urql/src/mutationStore.test.ts
@@ -33,6 +33,7 @@ describe('mutationStore', () => {
       "mutation ($input: Example!) {
         doExample(input: $input) {
           id
+          __typename
         }
       }"
     `);

--- a/packages/svelte-urql/src/queryStore.test.ts
+++ b/packages/svelte-urql/src/queryStore.test.ts
@@ -5,7 +5,11 @@ import { get } from 'svelte/store';
 import { queryStore } from './queryStore';
 
 describe('queryStore', () => {
-  const client = createClient({ url: 'https://example.com' });
+  const client = createClient({
+    url: 'https://example.com',
+    exchanges: [],
+  });
+
   const variables = {};
   const context = {};
   const query = '{ test }';

--- a/packages/svelte-urql/src/subscriptionStore.test.ts
+++ b/packages/svelte-urql/src/subscriptionStore.test.ts
@@ -5,7 +5,11 @@ import { vi, expect, it, describe } from 'vitest';
 import { subscriptionStore } from './subscriptionStore';
 
 describe('subscriptionStore', () => {
-  const client = createClient({ url: 'https://example.com' });
+  const client = createClient({
+    url: 'https://example.com',
+    exchanges: [],
+  });
+
   const variables = {};
   const context = {};
   const query = `subscription ($input: ExampleInput) { exampleSubscribe(input: $input) { data } }`;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -595,10 +595,10 @@ packages:
       '@babel/generator': 7.20.4
       '@babel/helper-module-transforms': 7.20.2
       '@babel/helpers': 7.20.1
-      '@babel/parser': 7.20.3
+      '@babel/parser': 7.20.15
       '@babel/template': 7.18.10
       '@babel/traverse': 7.20.1
-      '@babel/types': 7.20.2
+      '@babel/types': 7.20.7
       convert-source-map: 1.7.0
       debug: 4.3.4
       gensync: 1.0.0-beta.2
@@ -650,7 +650,7 @@ packages:
     resolution: {integrity: sha512-CZOv9tGphhDRlVjVkAgm8Nhklm9RzSmWpX2my+t7Ua/KT616pEzXsQCjinzvkRvHWJ9itO4f296efroX23XCMA==}
     dependencies:
       '@babel/helper-explode-assignable-expression': 7.13.0
-      '@babel/types': 7.20.2
+      '@babel/types': 7.20.7
 
   /@babel/helper-compilation-targets/7.20.0_@babel+core@7.20.2:
     resolution: {integrity: sha512-0jp//vDGp9e8hZzBc6N/KwA5ZK3Wsm/pfm4CrY7vzegkVxc65SgSn6wYOnwHe9Js9HRQ1YTCKLGPzDtaS3RoLQ==}
@@ -729,25 +729,25 @@ packages:
   /@babel/helper-explode-assignable-expression/7.13.0:
     resolution: {integrity: sha512-qS0peLTDP8kOisG1blKbaoBg/o9OSa1qoumMjTK5pM+KDTtpxpsiubnCGP34vK8BXGcb2M9eigwgvoJryrzwWA==}
     dependencies:
-      '@babel/types': 7.20.2
+      '@babel/types': 7.20.7
 
   /@babel/helper-function-name/7.19.0:
     resolution: {integrity: sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.18.10
-      '@babel/types': 7.20.2
+      '@babel/types': 7.20.7
 
   /@babel/helper-hoist-variables/7.18.6:
     resolution: {integrity: sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.2
+      '@babel/types': 7.20.7
 
   /@babel/helper-member-expression-to-functions/7.13.12:
     resolution: {integrity: sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==}
     dependencies:
-      '@babel/types': 7.20.2
+      '@babel/types': 7.20.7
 
   /@babel/helper-module-imports/7.18.6:
     resolution: {integrity: sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==}
@@ -773,7 +773,7 @@ packages:
   /@babel/helper-optimise-call-expression/7.12.13:
     resolution: {integrity: sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==}
     dependencies:
-      '@babel/types': 7.20.2
+      '@babel/types': 7.20.7
 
   /@babel/helper-plugin-utils/7.10.4:
     resolution: {integrity: sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==}
@@ -787,7 +787,7 @@ packages:
     dependencies:
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-wrap-function': 7.13.0
-      '@babel/types': 7.20.2
+      '@babel/types': 7.20.7
     transitivePeerDependencies:
       - supports-color
 
@@ -797,7 +797,7 @@ packages:
       '@babel/helper-member-expression-to-functions': 7.13.12
       '@babel/helper-optimise-call-expression': 7.12.13
       '@babel/traverse': 7.20.1
-      '@babel/types': 7.20.2
+      '@babel/types': 7.20.7
     transitivePeerDependencies:
       - supports-color
 
@@ -805,18 +805,18 @@ packages:
     resolution: {integrity: sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.2
+      '@babel/types': 7.20.7
 
   /@babel/helper-skip-transparent-expression-wrappers/7.12.1:
     resolution: {integrity: sha512-Mf5AUuhG1/OCChOJ/HcADmvcHM42WJockombn8ATJG3OnyiSxBK/Mm5x78BQWvmtXZKHgbjdGL2kin/HOLlZGA==}
     dependencies:
-      '@babel/types': 7.20.2
+      '@babel/types': 7.20.7
 
   /@babel/helper-split-export-declaration/7.18.6:
     resolution: {integrity: sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.2
+      '@babel/types': 7.20.7
 
   /@babel/helper-string-parser/7.19.4:
     resolution: {integrity: sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==}
@@ -836,7 +836,7 @@ packages:
       '@babel/helper-function-name': 7.19.0
       '@babel/template': 7.18.10
       '@babel/traverse': 7.20.1
-      '@babel/types': 7.20.2
+      '@babel/types': 7.20.7
     transitivePeerDependencies:
       - supports-color
 
@@ -864,7 +864,6 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.20.7
-    dev: true
 
   /@babel/parser/7.20.3:
     resolution: {integrity: sha512-OP/s5a94frIPXwjzEcv5S/tpQfc6XhxYUnmWpgdqMWGgYCuErA3SzozaRAMQgSZWKeTJxht9aWAkUY+0UzvOFg==}
@@ -1648,7 +1647,7 @@ packages:
       '@babel/plugin-transform-unicode-escapes': 7.12.13_@babel+core@7.20.2
       '@babel/plugin-transform-unicode-regex': 7.12.13_@babel+core@7.20.2
       '@babel/preset-modules': 0.1.4_@babel+core@7.20.2
-      '@babel/types': 7.20.2
+      '@babel/types': 7.20.7
       babel-plugin-polyfill-corejs2: 0.2.0_@babel+core@7.20.2
       babel-plugin-polyfill-corejs3: 0.2.0_@babel+core@7.20.2
       babel-plugin-polyfill-regenerator: 0.2.0_@babel+core@7.20.2
@@ -1677,7 +1676,7 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-proposal-unicode-property-regex': 7.12.13_@babel+core@7.20.2
       '@babel/plugin-transform-dotall-regex': 7.12.13_@babel+core@7.20.2
-      '@babel/types': 7.20.2
+      '@babel/types': 7.20.7
       esutils: 2.0.3
 
   /@babel/preset-react/7.13.13_@babel+core@7.20.2:
@@ -1797,7 +1796,6 @@ packages:
       '@babel/helper-string-parser': 7.19.4
       '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
-    dev: true
 
   /@babel/types/7.8.3:
     resolution: {integrity: sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==}


### PR DESCRIPTION
## Summary

This builds on `fix/node-memory-leak-fetch-source` to finally reimplement the fetch source implementation as an async generator, wrapped in a `fromAsyncIterable` conversion from `wonka`.

This also simplifies some of the existing logic, as per how `meros` works, and how Incremental Delivery is defined. For instance, we now assume that each chunk is a JSON blob instead of checking headers, which we aren't using or merging anyway.

`6.06kB -> 5.89 kB` min+gzip

## Set of changes

- Reimplement `makeFetchSource` with async generator
- Remove headers regex check
