### PR TITLE
fix(graphcache): fix restoring variables on mutation operations

### DIFF
--- a/.changeset/fifty-jeans-invite.md
+++ b/.changeset/fifty-jeans-invite.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Restore variables correctly on mutations

--- a/exchanges/graphcache/src/cacheExchange.test.ts
+++ b/exchanges/graphcache/src/cacheExchange.test.ts
@@ -326,7 +326,7 @@ describe('data dependencies', () => {
     const opMutation = client.createRequestOperation('mutation', {
       key: 3,
       query: mutation,
-      variables: { userId: '1', amount: 1000 },
+      variables: { userId: '1', amount: 1000, testExtra: true },
     });
 
     const response = vi.fn(
@@ -348,7 +348,8 @@ describe('data dependencies', () => {
 
     const updates = {
       Mutation: {
-        updateBalance: vi.fn((result, _args, cache) => {
+        updateBalance: vi.fn((result, _args, cache, info) => {
+          console.log(_args, info.variables);
           const {
             updateBalance: { userId, balance },
           } = result;

--- a/exchanges/graphcache/src/cacheExchange.test.ts
+++ b/exchanges/graphcache/src/cacheExchange.test.ts
@@ -326,7 +326,7 @@ describe('data dependencies', () => {
     const opMutation = client.createRequestOperation('mutation', {
       key: 3,
       query: mutation,
-      variables: { userId: '1', amount: 1000, testExtra: true },
+      variables: { userId: '1', amount: 1000 },
     });
 
     const response = vi.fn(
@@ -348,8 +348,7 @@ describe('data dependencies', () => {
 
     const updates = {
       Mutation: {
-        updateBalance: vi.fn((result, _args, cache, info) => {
-          console.log(_args, info.variables);
+        updateBalance: vi.fn((result, _args, cache) => {
           const {
             updateBalance: { userId, balance },
           } = result;

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -207,7 +207,8 @@ export const cacheExchange = <C extends Partial<CacheExchangeOpts>>(
         )
       : result.operation;
 
-    operation.variables = result.operation.context?.originalVariables || operation.variables
+    operation.variables =
+      result.operation.context?.originalVariables || operation.variables;
     if (operation.kind === 'mutation') {
       // Collect previous dependencies that have been written for optimistic updates
       const dependencies = optimisticKeysToDependencies.get(operation.key);

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -207,9 +207,9 @@ export const cacheExchange = <C extends Partial<CacheExchangeOpts>>(
         )
       : result.operation;
 
-    operation.variables =
-      result.operation.context?.originalVariables || operation.variables;
     if (operation.kind === 'mutation') {
+      operation.variables =
+        result.operation.context?.originalVariables || operation.variables;
       // Collect previous dependencies that have been written for optimistic updates
       const dependencies = optimisticKeysToDependencies.get(operation.key);
       collectPendingOperations(pendingOperations, dependencies);

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -153,7 +153,7 @@ export const cacheExchange = <C extends Partial<CacheExchangeOpts>>(
             )
           : operation.variables,
       },
-      operation.context
+      { ...operation.context, originalVariables: operation.variables }
     );
   };
 
@@ -207,6 +207,7 @@ export const cacheExchange = <C extends Partial<CacheExchangeOpts>>(
         )
       : result.operation;
 
+    operation.variables = result.operation.context?.originalVariables || operation.variables
     if (operation.kind === 'mutation') {
       // Collect previous dependencies that have been written for optimistic updates
       const dependencies = optimisticKeysToDependencies.get(operation.key);

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -208,8 +208,11 @@ export const cacheExchange = <C extends Partial<CacheExchangeOpts>>(
       : result.operation;
 
     if (operation.kind === 'mutation') {
-      operation.variables =
-        result.operation.context?.originalVariables || operation.variables;
+      if (result.operation.context.originalVariables) {
+        operation.variables = result.operation.context.originalVariables;
+        delete result.operation.context.originalVariables;
+      }
+
       // Collect previous dependencies that have been written for optimistic updates
       const dependencies = optimisticKeysToDependencies.get(operation.key);
       collectPendingOperations(pendingOperations, dependencies);


### PR DESCRIPTION
## Summary

Before we send out the mutation we filter the variables so extraneous variables don't cause an issue on the server. However this makes it so that we don't restore them afterwards as they are not part of the `operations` Map. This gives us a way to restore variables on mutations.

Works now: https://codesandbox.io/s/empty-water-6tm6yy?file=/src/index.js
