### PR TITLE
feat(core): Implement GraphQL SSE Response Support

### DIFF
--- a/.changeset/proud-buses-change.md
+++ b/.changeset/proud-buses-change.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': minor
+---
+
+Implement `text/event-stream` response support. This generally adheres to the GraphQL SSE protocol and GraphQL Yoga push responses, and is an alternative to `multipart/mixed`.

--- a/packages/core/src/internal/fetchOptions.ts
+++ b/packages/core/src/internal/fetchOptions.ts
@@ -91,8 +91,9 @@ export const makeFetchOptions = (
 
   const headers: HeadersInit = {
     accept:
-      'application/graphql-response+json, application/graphql+json, application/json, multipart/mixed',
+      'application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed',
   };
+
   if (!useGETMethod) headers['content-type'] = 'application/json';
   const extraOptions =
     (typeof operation.context.fetchOptions === 'function'


### PR DESCRIPTION
## Summary

This implements support for `text/event-stream` responses, as per GraphQL SSE.

We've used GraphQL Yoga's "push" mechanism as a general template for what this must look like: https://github.com/dotansimha/graphql-yoga/blob/d2060c1/packages/graphql-yoga/src/plugins/resultProcessor/push.ts
And this generally adheres to the GraphQL SSE protocol: https://github.com/enisdenjo/graphql-sse/blob/master/PROTOCOL.md

The current implementation found it unnecessary to respect `event:` type fields, instead it will just loosely look at `data:` fields and attempt to parse them.

We generally regard this as an alternative to `multipart/mixed` responses, and the protocol is loosely supported alongside it, while basically being an alternative to `text/event-stream`.
Currently, it's unclear to us when which one would be preferred, and we believe that's up to implementors and APIs to decide.

We also know that subscription operations _could_ now be implemented with either response formats, however, we haven't decided yet how the default `fetchExchange` could switch over to handle `subscription` operations. This could be an option on the `Client`, but, we think that overall we already have a lot of `fetch`-related options on the `Client`, some of which may have to go. Discussion needed :v:

`5.9kB -> 5.98 kB` min+gzip

## Set of changes

- Add selector for response handlers
- Implement `parseEventStream` handler alongside `parseMultipartMixed`
