### PR TITLE
chore(persisted): Refactor sha256 utilities and persistedFetchExchange

### DIFF
--- a/.changeset/brave-sloths-bathe.md
+++ b/.changeset/brave-sloths-bathe.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-persisted-fetch': patch
+---
+
+Refactor `persistedFetchExchange` and SHA256 logic to save on bundlesize.

--- a/exchanges/persisted-fetch/src/sha256.ts
+++ b/exchanges/persisted-fetch/src/sha256.ts
@@ -1,47 +1,39 @@
-const globals: { crypto?: Crypto } = (typeof window !== 'undefined'
-  ? window
+const webCrypto = (typeof window !== 'undefined'
+  ? window.crypto
   : typeof self !== 'undefined'
-  ? self
-  : null) as any;
-const webCrypto = globals && globals.crypto;
+  ? self.crypto
+  : null) as typeof globalThis.crypto | null;
 
-const sha256Browser = (bytes: Uint8Array): Promise<Uint8Array> =>
-  webCrypto!.subtle
-    .digest({ name: 'SHA-256' }, bytes)
-    .then(result => new Uint8Array(result));
+let nodeCrypto: Promise<typeof import('crypto') | void> | void;
 
-let nodeCrypto: Promise<typeof import('crypto')> | void;
-if (typeof window === 'undefined' && !webCrypto) {
-  // Indirect eval'd require/import to guarantee no side-effects in module scope
-  // (optimization for minifiers)
-  try {
-    nodeCrypto = Promise.resolve(
-      new Function('require', 'return require("crypto")')(require)
-    );
-  } catch (_error) {
+const getNodeCrypto = async (): Promise<typeof import('crypto') | void> => {
+  if (!nodeCrypto) {
+    // Indirect eval'd require/import to guarantee no side-effects in module scope
+    // (optimization for minifiers)
     try {
-      nodeCrypto = new Function('return import("crypto")')();
-    } catch (_error) {}
+      nodeCrypto = new Function('require', 'return require("crypto")')(require);
+    } catch (_error) {
+      try {
+        nodeCrypto = new Function('return import("crypto")')();
+      } catch (_error) {}
+    }
   }
-}
+  return nodeCrypto;
+};
 
 export const hash = async (query: string): Promise<string> => {
-  // Node.js support
-  if (nodeCrypto) {
-    return nodeCrypto.then(crypto =>
-      crypto.createHash('sha256').update(query).digest('hex')
+  if (webCrypto) {
+    const digest = await webCrypto.subtle.digest(
+      { name: 'SHA-256' },
+      new TextEncoder().encode(query)
     );
-  } else if (webCrypto) {
-    const buf = new TextEncoder().encode(query);
-    const out = await sha256Browser(buf);
-
-    let hash = '';
-    for (let i = 0, l = out.length; i < l; i++) {
-      const hex = out[i].toString(16);
-      hash += '00'.slice(0, Math.max(0, 2 - hex.length)) + hex;
-    }
-
-    return hash;
+    return new Uint8Array(digest).reduce(
+      (prev, byte) => prev + byte.toString(16).padStart(2, '0'),
+      ''
+    );
+  } else if (await getNodeCrypto()) {
+    // Node.js support
+    return (await nodeCrypto)!.createHash('sha256').update(query).digest('hex');
   }
 
   if (process.env.NODE_ENV !== 'production') {
@@ -51,5 +43,5 @@ export const hash = async (query: string): Promise<string> => {
     );
   }
 
-  return Promise.resolve('');
+  return '';
 };


### PR DESCRIPTION
## Summary

This is a small refactor of `persistedFetchExchange` to save a couple of bytes.
Nothing else has changed and this doesn't address the `subscriptionExchange` just yet.

## Set of changes

- Refactor `sha256.ts` to save on size
- Use `padLeft` in `sha256` utility
- Minify body logic in `persistedFetchExchange`
- Strip no-op `onPush` in production
