### PR TITLE
feat(core): Support GraphQLRequest.extensions and update subscriptionExchange

### DIFF
--- a/.changeset/clever-plants-greet.md
+++ b/.changeset/clever-plants-greet.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': minor
+---
+
+Update `subscriptionExchange` to receive `FetchBody` instead. In the usual usage of `subscriptionExchange` (for instance with `graphql-ws`) you can expect no breaking changes. However, the `key` and `extensions` field has been removed and instead the `forwardSubscription` function receives the full `Operation` as a second argument.

--- a/.changeset/clever-plants-greet.md
+++ b/.changeset/clever-plants-greet.md
@@ -1,5 +1,5 @@
 ---
-'@urql/core': minor
+'@urql/core': major
 ---
 
 Update `subscriptionExchange` to receive `FetchBody` instead. In the usual usage of `subscriptionExchange` (for instance with `graphql-ws`) you can expect no breaking changes. However, the `key` and `extensions` field has been removed and instead the `forwardSubscription` function receives the full `Operation` as a second argument.

--- a/.changeset/slow-glasses-attend.md
+++ b/.changeset/slow-glasses-attend.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': minor
+---
+
+Support `GraphQLRequest.extensions` as spec-extensions input to GraphQL requests.

--- a/docs/advanced/subscriptions.md
+++ b/docs/advanced/subscriptions.md
@@ -57,12 +57,9 @@ const client = createClient({
   exchanges: [
     ...defaultExchanges,
     subscriptionExchange({
-      forwardSubscription: (operation) => ({
-        subscribe: (sink) => ({
-          unsubscribe: wsClient.subscribe(
-            { query: operation.query, variables: operation.variables },
-            sink
-          ),
+      forwardSubscription: request => ({
+        subscribe: sink => ({
+          unsubscribe: wsClient.subscribe(request, sink),
         }),
       }),
     }),
@@ -94,7 +91,7 @@ const client = new Client({
   exchanges: [
     ...defaultExchanges,
     subscriptionExchange({
-      forwardSubscription: (operation) => subscriptionClient.request(operation)
+      forwardSubscription: request => subscriptionClient.request(request),
     }),
   ],
 });

--- a/packages/core/src/exchanges/subscription.test.ts
+++ b/packages/core/src/exchanges/subscription.test.ts
@@ -29,7 +29,6 @@ it('should return response data from forwardSubscription observable', async () =
       stringifyDocument(subscriptionOperation.query)
     );
     expect(operation.variables).toBe(subscriptionOperation.variables);
-    expect(operation.context).toEqual(subscriptionOperation.context);
 
     return {
       subscribe(observer) {

--- a/packages/core/src/exchanges/subscription.ts
+++ b/packages/core/src/exchanges/subscription.ts
@@ -76,6 +76,7 @@ export interface SubscriptionOperation {
   query: string;
   variables: Record<string, unknown> | undefined;
   key: string;
+  extensions: Record<string, any>;
   context: OperationContext;
 }
 
@@ -153,6 +154,7 @@ export const subscriptionExchange = ({
       key: operation.key.toString(36),
       query: stringifyDocument(operation.query),
       variables: operation.variables!,
+      extensions: { ...operation.extensions },
       context: { ...operation.context },
     });
 

--- a/packages/core/src/exchanges/subscription.ts
+++ b/packages/core/src/exchanges/subscription.ts
@@ -21,7 +21,6 @@ import {
   Exchange,
   ExecutionResult,
   Operation,
-  OperationContext,
   OperationResult,
 } from '../types';
 
@@ -66,20 +65,10 @@ export interface ObservableLike<T> {
   };
 }
 
-/** A more cross-compatible version of the {@link Operation} structure.
- *
- * @remarks
- * When the `subscriptionExchange` was first created, some transports needed a specific shape
- * of {@link GraphQLRequest} objects to be passed to them. This is a shim that is as compatible
- * with most transports out of the box as possible.
+/** A more cross-compatible version of the {@link GraphQLRequest} structure.
+ * {@link FetchBody} for more details
  */
-export interface SubscriptionOperation {
-  query: string;
-  variables: Record<string, unknown> | undefined;
-  key: string;
-  extensions: Record<string, any>;
-  context: OperationContext;
-}
+export type SubscriptionOperation = FetchBody;
 
 /** A subscription forwarding function, which must accept a {@link SubscriptionOperation}.
  *

--- a/packages/core/src/internal/fetchOptions.ts
+++ b/packages/core/src/internal/fetchOptions.ts
@@ -28,7 +28,7 @@ export function makeFetchBody<
     query: stringifyDocument(request.query),
     operationName: getOperationName(request.query),
     variables: request.variables || undefined,
-    extensions: undefined,
+    extensions: request.extensions,
   };
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -236,6 +236,10 @@ export interface GraphQLRequest<
    * generic, are sent to the GraphQL API to execute a request.
    */
   variables: Variables;
+  /** Additional metadata that a GraphQL API may accept for spec extensions.
+   * @see {@link https://github.com/graphql/graphql-over-http/blob/1928447/spec/GraphQLOverHTTP.md#request-parameters} for the GraphQL over HTTP spec
+   */
+  extensions?: Record<string, any> | undefined;
 }
 
 /** Parameters from which {@link GraphQLRequest | GraphQLRequests} are created from.

--- a/packages/core/src/utils/operation.ts
+++ b/packages/core/src/utils/operation.ts
@@ -49,11 +49,8 @@ function makeOperation<
 
 function makeOperation(kind, request, context) {
   if (!context) context = request.context;
-
   return {
-    key: request.key,
-    query: request.query,
-    variables: request.variables,
+    ...request,
     kind,
     context,
   };

--- a/packages/core/src/utils/request.ts
+++ b/packages/core/src/utils/request.ts
@@ -152,14 +152,15 @@ export const createRequest = <
   Variables extends AnyVariables = AnyVariables
 >(
   _query: string | DocumentNode | TypedDocumentNode<Data, Variables>,
-  _variables: Variables
+  _variables: Variables,
+  extensions?: Record<string, any> | undefined
 ): GraphQLRequest<Data, Variables> => {
   const variables = _variables || ({} as Variables);
   const query = keyDocument(_query);
   const printedVars = stringifyVariables(variables);
   let key = query.__key;
   if (printedVars !== '{}') key = phash(printedVars, key);
-  return { key, query, variables };
+  return { key, query, variables, extensions };
 };
 
 /** Returns the name of the `DocumentNode`'s operation, if any.


### PR DESCRIPTION
## Summary

This updates the `GraphQLRequest` type to contain an `extensions` field. This field will currently remain unavailable to bindings/UI code, but can be used to interact with spec extensions in exchanges.

Specifically, this enables us to replace `persistedFetchExchange` with a `persitedExchange` in the future that only interacts with the rest of the exchange pipeline by modifying `Operation.extensions` without triggering a `fetch` request.

The `subscriptionExchange` has been updated accordingly to receive the entire `FetchBody` type, to bring it inline with the default `fetchExchange` and `@urql/core/internal` utilities.

This is a **breaking change** as the properties `key` and `context` are now missing in the first argument that `forwardSubscription` receives. To compensate, the exchange now passes the entire `Operation` as a second argument to `forwardSubscription`. Generally this shouldn't affect integrations with libraries like `graphql-ws`.

## Set of changes

- Replace `subscriptionExchange`'s `forwardSubscription` input with `FetchBody` and add `Operation` as a second argument
- Add `GraphQLRequest.extensions` and expose it on `createRequest`
