### PR TITLE
fix(core): Add missing error patching and support incremental results in subscriptionExchange

### DIFF
--- a/.changeset/fuzzy-baboons-add.md
+++ b/.changeset/fuzzy-baboons-add.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': minor
+---
+
+Update `subscriptionExchange` to support incremental results out of the box. If a subscription proactively completes, results are also now updated with `hasNext: false`.

--- a/.changeset/poor-pumpkins-greet.md
+++ b/.changeset/poor-pumpkins-greet.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Fix incremental results not merging `errors` from subsequent non-incremental results.

--- a/packages/core/src/utils/result.ts
+++ b/packages/core/src/utils/result.ts
@@ -71,9 +71,9 @@ export const mergeResultPatch = (
   response?: any
 ): OperationResult => {
   let data: ExecutionResult['data'];
+  let errors = prevResult.error ? prevResult.error.graphQLErrors : [];
   let hasExtensions = !!prevResult.extensions || !!nextResult.extensions;
   const extensions = { ...prevResult.extensions, ...nextResult.extensions };
-  const errors = prevResult.error ? prevResult.error.graphQLErrors : [];
 
   let incremental = nextResult.incremental;
 
@@ -115,6 +115,7 @@ export const mergeResultPatch = (
     }
   } else {
     data = nextResult.data || prevResult.data;
+    errors = (nextResult.errors as any[]) || errors;
   }
 
   return {


### PR DESCRIPTION
## Summary

Add missing `errors` patching into `mergeResultPatch` and support incremental results in `subscriptionExchange`.
This should have no breaking changes, but only adds incremental result support to third-party exchanges.

## Set of changes

- Add `errors` merging to non-incremental result updates
- Add incremental result support to `subscriptionExchange`
