### PR TITLE
chore(workspace): upgrade pnpm action setup to avoid the deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
           node-version: 18
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2.2.2
+        uses: pnpm/action-setup@v2.2.4
         with:
           version: 7
           run_install: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: 18
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2.2.2
+        uses: pnpm/action-setup@v2.2.4
         with:
           version: 7
           run_install: false

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -29,7 +29,7 @@ jobs:
           node-version: 18
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2.2.2
+        uses: pnpm/action-setup@v2.2.4
         with:
           version: 7
           run_install: false


### PR DESCRIPTION
## Summary

Deprecation of Node 12 and the env stuff is soon so this upgrades everything so we are in the clear
