### PR TITLE
fix(core/graphcache): Add missing hasNext/stale flags to cached results

### DIFF
--- a/.changeset/polite-penguins-notice.md
+++ b/.changeset/polite-penguins-notice.md
@@ -1,0 +1,6 @@
+---
+'@urql/exchange-graphcache': patch
+'@urql/core': patch
+---
+
+Add missing `hasNext` and `stale` passthroughs on caching exchanges.

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -195,8 +195,6 @@ export const cacheExchange = <C extends Partial<CacheExchangeOpts>>(
     result: OperationResult,
     pendingOperations: Operations
   ): OperationResult => {
-    const { error, extensions } = result;
-
     // Retrieve the original operation to remove changes made by formatDocument
     const originalOperation = operations.get(result.operation.key);
     const operation = originalOperation
@@ -261,7 +259,14 @@ export const cacheExchange = <C extends Partial<CacheExchangeOpts>>(
       updateDependencies(result.operation, queryDependencies);
     }
 
-    return { data, error, extensions, operation };
+    return {
+      operation,
+      data,
+      error: result.error,
+      extensions: result.extensions,
+      hasNext: result.hasNext,
+      stale: result.stale,
+    };
   };
 
   return ops$ => {
@@ -339,6 +344,7 @@ export const cacheExchange = <C extends Partial<CacheExchangeOpts>>(
             error: res.error,
             extensions: res.extensions,
             stale: shouldReexecute || isPartial,
+            hasNext: false,
           };
 
           if (!shouldReexecute) {

--- a/exchanges/graphcache/src/offlineExchange.test.ts
+++ b/exchanges/graphcache/src/offlineExchange.test.ts
@@ -226,6 +226,7 @@ describe('offline', () => {
       error: undefined,
       extensions: undefined,
       operation: expect.any(Object),
+      hasNext: false,
       stale: false,
     });
 

--- a/packages/core/src/exchanges/ssr.test.ts
+++ b/packages/core/src/exchanges/ssr.test.ts
@@ -198,6 +198,8 @@ it('resolves cached query results correctly', () => {
   expect(output).not.toHaveBeenCalled();
   expect(onPush).toHaveBeenCalledWith({
     ...queryResponse,
+    stale: false,
+    hasNext: false,
     operation: {
       ...queryResponse.operation,
       context: {
@@ -234,8 +236,9 @@ it('resolves deferred, cached query results correctly', () => {
   expect(output).toHaveBeenCalledTimes(1);
   expect(onPush).toHaveBeenCalledTimes(2);
   expect(onPush.mock.calls[1][0]).toEqual({
-    hasNext: true,
     ...queryResponse,
+    hasNext: true,
+    stale: false,
     operation: {
       ...queryResponse.operation,
       context: {
@@ -267,6 +270,8 @@ it('deletes cached results in non-suspense environments', async () => {
   expect(Object.keys(ssr.extractData()).length).toBe(0);
   expect(onPush).toHaveBeenCalledWith({
     ...queryResponse,
+    stale: false,
+    hasNext: false,
     operation: {
       ...queryResponse.operation,
       context: {


### PR DESCRIPTION
## Summary

Ensures that the `ssrExchange` and Graphcache's `cacheExchange` don't accidentally remove `hasNext` (or `stale`) flags.

## Set of changes

- Add `hasNext` passthrough to Graphcache
- Add `hasNext` passthrough to `ssrExchange`
