### PR TITLE
refactor(core): Remove getOperationName helper from @urql/core

### DIFF
--- a/.changeset/quick-seahorses-cross.md
+++ b/.changeset/quick-seahorses-cross.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Fix incorrect operation name being picked from queries that contain multiple operations.

--- a/.changeset/young-lamps-help.md
+++ b/.changeset/young-lamps-help.md
@@ -1,0 +1,6 @@
+---
+'@urql/core': major
+'@urql/exchange-execute': minor
+---
+
+Remove `getOperationName` export from `@urql/core`

--- a/exchanges/execute/src/execute.test.ts
+++ b/exchanges/execute/src/execute.test.ts
@@ -33,7 +33,6 @@ import {
   makeErrorResult,
   makeOperation,
   Client,
-  getOperationName,
   OperationResult,
 } from '@urql/core';
 
@@ -45,10 +44,8 @@ const exchangeArgs = {
   client: {},
 } as any;
 
-const expectedQueryOperationName = getOperationName(queryOperation.query);
-const expectedSubscribeOperationName = getOperationName(
-  subscriptionOperation.query
-);
+const expectedQueryOperationName = 'getUser';
+const expectedSubscribeOperationName = 'subscribeToUser';
 
 const fetchMock = (global as any).fetch as Mock;
 const mockHttpResponseData = { key: 'value' };

--- a/exchanges/execute/src/execute.ts
+++ b/exchanges/execute/src/execute.ts
@@ -17,6 +17,7 @@ import {
   subscribe,
   ExecutionArgs,
   SubscriptionArgs,
+  Kind,
 } from 'graphql';
 
 import {
@@ -27,7 +28,6 @@ import {
   mergeResultPatch,
   Operation,
   OperationResult,
-  getOperationName,
 } from '@urql/core';
 
 export interface ExecuteExchangeArgs {
@@ -150,6 +150,14 @@ export const executeExchange = ({
           }
         }
 
+        let operationName: string | undefined;
+        for (const node of operation.query.definitions) {
+          if (node.kind === Kind.OPERATION_DEFINITION) {
+            operationName = node.name ? node.name.value : undefined;
+            break;
+          }
+        }
+
         return pipe(
           makeExecuteSource(operation, {
             schema,
@@ -157,7 +165,7 @@ export const executeExchange = ({
             rootValue,
             contextValue,
             variableValues,
-            operationName: getOperationName(operation.query),
+            operationName,
             fieldResolver,
             typeResolver,
             subscribeFieldResolver,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,5 +14,4 @@ export {
   formatDocument,
   maskTypename,
   makeOperation,
-  getOperationName,
 } from './utils';

--- a/packages/core/src/utils/request.ts
+++ b/packages/core/src/utils/request.ts
@@ -169,8 +169,8 @@ export const createRequest = <
  */
 export const getOperationName = (query: DocumentNode): string | undefined => {
   for (const node of query.definitions) {
-    if (node.kind === Kind.OPERATION_DEFINITION && node.name) {
-      return node.name.value;
+    if (node.kind === Kind.OPERATION_DEFINITION) {
+      return node.name ? node.name.value : undefined;
     }
   }
 };


### PR DESCRIPTION
## Summary

I don't think there's a good reason for us to expose this, as we also don't expose `getOperationType`, et al. I think this went a step too far and removing it now with a breaking change is likely appropriate.

## Set of changes

- Remove `getOperationName` export from `@urql/core`
- Replace `getOperationName` implementation on `@urql/exchange-execute`
- Fix `getOperationName` returning first name rather than the first operation's name
