### PR TITLE
fix(core): Add alternative rethrow method by wrapping yield

### DIFF
--- a/.changeset/silent-numbers-look.md
+++ b/.changeset/silent-numbers-look.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Ensure network errors are always issued with `CombinedError`s, while downstream errors are re-thrown.

--- a/packages/core/src/internal/fetchSource.ts
+++ b/packages/core/src/internal/fetchSource.ts
@@ -104,6 +104,7 @@ async function* fetchOperation(
   url: string,
   fetchOptions: RequestInit
 ) {
+  let networkMode = true;
   let abortController: AbortController | void;
   let result: OperationResult | null = null;
   let response: Response;
@@ -132,16 +133,18 @@ async function* fetchOperation(
     }
 
     for await (const payload of results) {
+      networkMode = false;
       yield (result = result
         ? mergeResultPatch(result, payload, response)
         : makeResult(operation, payload, response));
+      networkMode = true;
     }
 
     if (!result) {
       yield (result = makeResult(operation, {}, response));
     }
   } catch (error: any) {
-    if (result) {
+    if (!networkMode) {
       throw error;
     }
 


### PR DESCRIPTION
## Summary

Originally, we introduced a check called `hasResult`, which determined whether we'd rethrow an error, or treat it as a network error.
This check must now be changed to further isolate the non-network errors to the `yield` operation in our response streams. Specifically, when yielding, the resulting error may come from downstream exchanges, bindings, or the UI framework.

We now detect this differently by wrapping the `yield` in a boolean flag.

I currently don't know how to reproduce the original error. It's possible that either this isn't effective or that the entire rethrow approach isn't needed anymore. Further testing is needed.

## Set of changes

- Replace rethrow check with boolean flag checking whether we're yielding to downstream code
