### PR TITLE
docs(exchanges): Add TSDocs to all exchanges

### DIFF
--- a/.changeset/wise-hairs-pump.md
+++ b/.changeset/wise-hairs-pump.md
@@ -1,0 +1,12 @@
+---
+'@urql/exchange-request-policy': patch
+'@urql/exchange-graphcache': patch
+'@urql/exchange-persisted': patch
+'@urql/exchange-populate': patch
+'@urql/exchange-context': patch
+'@urql/exchange-execute': patch
+'@urql/exchange-refocus': patch
+'@urql/exchange-retry': patch
+---
+
+Add TSDocs for all exchanges, documenting API internals.

--- a/exchanges/context/src/context.ts
+++ b/exchanges/context/src/context.ts
@@ -6,11 +6,63 @@ import {
 } from '@urql/core';
 import { fromPromise, fromValue, mergeMap, pipe } from 'wonka';
 
+/** Input parameters for the {@link contextExchange}. */
 export interface ContextExchangeArgs {
-  getContext: (
+  /** Returns a new {@link OperationContext}, optionally wrapped in a `Promise`.
+   *
+   * @remarks
+   * `getContext` is called for every {@link Operation} the `contextExchange`
+   * receives and must return a new {@link OperationContext} or a `Promise`
+   * of it.
+   *
+   * The new `OperationContext` will be used to update the `Operation`'s
+   * context before it's forwarded to the next exchange.
+   */
+  getContext(
     operation: Operation
-  ) => OperationContext | Promise<OperationContext>;
+  ): OperationContext | Promise<OperationContext>;
 }
+
+/** Exchange factory modifying the {@link OperationContext} per incoming `Operation`.
+ *
+ * @param options - A {@link ContextExchangeArgs} configuration object.
+ * @returns the created context {@link Exchange}.
+ *
+ * @remarks
+ * The `contextExchange` allows the {@link OperationContext` to be easily
+ * modified per `Operation`. This may be useful to dynamically change the
+ * `Operation`’s parameters, even when we need to do so asynchronously.
+ *
+ * You must define a {@link ContextExchangeArgs.getContext} function,
+ * which may return a `Promise<OperationContext>` or `OperationContext`.
+ *
+ * Hint: If the `getContext` function passed to this exchange returns a
+ * `Promise` it must be placed _after_ all synchronous exchanges, such as
+ * a `cacheExchange`.
+ *
+ * @example
+ * ```ts
+ * import { Client, cacheExchange, fetchExchange } from '@urql/core';
+ * import { contextExchange } from '@urql/exchange-context';
+ *
+ * const client = new Client({
+ *   url: '',
+ *   exchanges: [
+ *     cacheExchange,
+ *     contextExchange({
+ *       async getContext(operation) {
+ *         const url = await loadDynamicUrl();
+ *         return {
+ *           ...operation.context,
+ *           url,
+ *         };
+ *       },
+ *     }),
+ *     fetchExchange,
+ *   ],
+ * });
+ * ```
+ */
 
 export const contextExchange =
   ({ getContext }: ContextExchangeArgs): Exchange =>

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -38,6 +38,23 @@ type ResultMap = Map<number, Data | null>;
 type OptimisticDependencies = Map<number, Dependencies>;
 type DependentOperations = Map<string, Operations>;
 
+/** Exchange factory that creates a normalized cache exchange.
+ *
+ * @param opts - A {@link CacheExchangeOpts} configuration object.
+ * @returns the created normalized cache {@link Exchange}.
+ *
+ * @remarks
+ * Graphcache is a normalized cache, enabled by using the `cacheExchange`
+ * in place of `@urql/core`’s. A normalized GraphQL cache uses typenames
+ * and key fields in the result to share a single copy for each unique
+ * entity across all queries.
+ *
+ * The `cacheExchange` may be passed a {@link CacheExchangeOpts} object
+ * to define custom resolvers, custom updates for mutations,
+ * optimistic updates, or to add custom key fields per type.
+ *
+ * @see {@link https://urql.dev/goto/docs/graphcache} for the full Graphcache docs.
+ */
 export const cacheExchange =
   <C extends Partial<CacheExchangeOpts>>(opts?: C): Exchange =>
   ({ forward, client, dispatchDebug }) => {

--- a/exchanges/graphcache/src/default-storage/index.ts
+++ b/exchanges/graphcache/src/default-storage/index.ts
@@ -23,14 +23,34 @@ const getTransactionPromise = (transaction: IDBTransaction): Promise<any> => {
 };
 
 export interface StorageOptions {
+  /** Name of the IndexedDB database that will be used.
+   * @defaultValue `'graphcache-v4'`
+   */
   idbName?: string;
+  /** Maximum age of cache entries (in days) after which data is discarded.
+   * @defaultValue `7` days
+   */
   maxAge?: number;
 }
 
+/** Sample storage adapter persisting to IndexedDB. */
 export interface DefaultStorage extends StorageAdapter {
+  /** Clears the entire IndexedDB storage. */
   clear(): Promise<any>;
 }
 
+/** Creates a default {@link StorageAdapter} which uses IndexedDB for storage.
+ *
+ * @param opts - A {@link StorageOptions} configuration object.
+ * @returns the created {@link StorageAdapter}.
+ *
+ * @remarks
+ * The default storage uses IndexedDB to persist the normalized cache for
+ * offline use. It demonstrates that the cache can be chunked by timestamps.
+ *
+ * Note: We have no data on stability of this storage and our Offline Support
+ * for large APIs or longterm use. Proceed with caution.
+ */
 export const makeDefaultStorage = (opts?: StorageOptions): DefaultStorage => {
   if (!opts) opts = {};
 

--- a/exchanges/graphcache/src/extras/relayPagination.ts
+++ b/exchanges/graphcache/src/extras/relayPagination.ts
@@ -3,7 +3,17 @@ import { Cache, Resolver, Variables, NullArray } from '../types';
 
 export type MergeMode = 'outwards' | 'inwards';
 
+/** Input parameters for the {@link relayPagination} factory. */
 export interface PaginationParams {
+  /** Flip between inwards and outwards pagination.
+   *
+   * @remarks
+   * This is only relevant if you’re querying pages using forwards and
+   * backwards pagination at the same time.
+   * When set to `'inwards'`, its default, pages that have been queried
+   * forward are placed in front of all pages that were queried backwards.
+   * When set to `'outwards'`, the two sets are merged in reverse.
+   */
   mergeMode?: MergeMode;
 }
 
@@ -182,6 +192,25 @@ const getPage = (
   return page;
 };
 
+/** Creates a {@link Resolver} that combines pages that comply to the Relay pagination spec.
+ *
+ * @param params - A {@link PaginationParams} configuration object.
+ * @returns the created Relay pagination {@link Resolver}.
+ *
+ * @remarks
+ * `relayPagination` is a factory that creates a {@link Resolver} that can combine
+ * multiple pages on a field that complies to the Relay pagination spec into a single,
+ * combined list for infinite scrolling.
+ *
+ * This resolver will only work on fields that return a `Connection` GraphQL object
+ * type, according to the Relay pagination spec.
+ *
+ * Hint: It's not recommended to use this when you can handle infinite scrolling
+ * in your UI code instead.
+ *
+ * @see {@link https://urql.dev/goto/docs/graphcache/local-resolvers#relay-pagination} for more information.
+ * @see {@link https://urql.dev/goto/docs/basics/ui-patterns/#infinite-scrolling} for an alternate approach.
+ */
 export const relayPagination = (
   params: PaginationParams = {}
 ): Resolver<any, any, any> => {

--- a/exchanges/graphcache/src/extras/simplePagination.ts
+++ b/exchanges/graphcache/src/extras/simplePagination.ts
@@ -3,12 +3,38 @@ import { Resolver, Variables, NullArray } from '../types';
 
 export type MergeMode = 'before' | 'after';
 
+/** Input parameters for the {@link simplePagination} factory. */
 export interface PaginationParams {
+  /** The name of the field argument used to define the page’s offset. */
   offsetArgument?: string;
+  /** The name of the field argument used to define the page’s length. */
   limitArgument?: string;
+  /** Flip between forward and backwards pagination.
+   *
+   * @remarks
+   * When set to `'after'`, its default, pages are merged forwards and in order.
+   * When set to `'before'`, pages are merged in reverse, putting later pages
+   * in front of earlier ones.
+   */
   mergeMode?: MergeMode;
 }
 
+/** Creates a {@link Resolver} that combines pages of a primitive pagination field.
+ *
+ * @param options - A {@link PaginationParams} configuration object.
+ * @returns the created pagination {@link Resolver}.
+ *
+ * @remarks
+ * `simplePagination` is a factory that creates a {@link Resolver} that can combine
+ * multiple lists on a paginated field into a single, combined list for infinite
+ * scrolling.
+ *
+ * Hint: It's not recommended to use this when you can handle infinite scrolling
+ * in your UI code instead.
+ *
+ * @see {@link https://urql.dev/goto/docs/graphcache/local-resolvers#simple-pagination} for more information.
+ * @see {@link https://urql.dev/goto/docs/basics/ui-patterns/#infinite-scrolling} for an alternate approach.
+ */
 export const simplePagination = ({
   offsetArgument = 'skip',
   limitArgument = 'limit',

--- a/exchanges/graphcache/src/operations/query.ts
+++ b/exchanges/graphcache/src/operations/query.ts
@@ -59,6 +59,9 @@ export interface QueryResult {
   data: null | Data;
 }
 
+/** Reads a GraphQL query from the cache.
+ * @internal
+ */
 export const query = (
   store: Store,
   request: OperationRequest,

--- a/exchanges/graphcache/src/operations/write.ts
+++ b/exchanges/graphcache/src/operations/write.ts
@@ -53,7 +53,9 @@ export interface WriteResult {
   dependencies: Dependencies;
 }
 
-/** Writes a request given its response to the store */
+/** Writes a GraphQL response to the cache.
+ * @internal
+ */
 export const write = (
   store: Store,
   request: OperationRequest,

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -37,6 +37,9 @@ import {
 
 type RootField = 'query' | 'mutation' | 'subscription';
 
+/** Implementation of the {@link Cache} interface as created internally by the {@link cacheExchange}.
+ * @internal
+ */
 export class Store<
   C extends Partial<CacheExchangeOpts> = Partial<CacheExchangeOpts>
 > implements Cache

--- a/exchanges/graphcache/src/types.ts
+++ b/exchanges/graphcache/src/types.ts
@@ -2,77 +2,260 @@ import { AnyVariables, TypedDocumentNode } from '@urql/core';
 import { GraphQLError, DocumentNode, FragmentDefinitionNode } from 'graphql';
 import { IntrospectionData } from './ast';
 
-// Helper types
+/** Nullable GraphQL list types of `T`.
+ *
+ * @remarks
+ * Any GraphQL list of a given type `T` that is nullable is
+ * expected to contain nullable values. Nested lists are
+ * also taken into account in Graphcache.
+ */
 export type NullArray<T> = Array<null | T | NullArray<T>>;
 
+/** Dictionary of GraphQL Fragment definitions by their names.
+ *
+ * @remarks
+ * A map of {@link FragmentDefinitionNode | FragmentDefinitionNodes} by their
+ * fragment names from the original GraphQL document that Graphcache is
+ * executing.
+ */
 export interface Fragments {
   [fragmentName: string]: void | FragmentDefinitionNode;
 }
 
-// Scalar types are not entities as part of response data
+/** Non-object JSON values as serialized by a GraphQL API
+ * @see {@link https://spec.graphql.org/October2021/#sel-DAPJDHAAEJHAKmzP} for the
+ * GraphQL spec’s serialization format.
+ */
 export type Primitive = null | number | boolean | string;
 
+/** Any GraphQL scalar object
+ *
+ * @remarks
+ * A GraphQL schema may define custom scalars that are resolved
+ * and serialized as objects. These objects could also be turned
+ * on the client-side into a non-JSON object, e.g. a `Date`.
+ *
+ * @see {@link https://spec.graphql.org/October2021/#sec-Scalars} for the
+ * GraphQL spec’s information on custom scalars.
+ */
 export interface ScalarObject {
   constructor?: Function;
   [key: string]: any;
 }
 
+/** GraphQL scalar value
+ * @see {@link https://spec.graphql.org/October2021/#sec-Scalars} for the GraphQL
+ * spec’s definition of scalars
+ */
 export type Scalar = Primitive | ScalarObject;
 
+/** Fields that Graphcache expects on GraphQL object (“entity”) results.
+ *
+ * @remarks
+ * Any object that comes back from a GraphQL API will have
+ * a `__typename` field from GraphQL Object types.
+ *
+ * The `__typename` field must be present as Graphcache updates
+ * GraphQL queries with type name introspection.
+ * Furthermore, Graphcache always checks for its default key
+ * fields, `id` and `_id` to be present.
+ */
 export interface SystemFields {
+  /** GraphQL Object type name as returned by Type Name Introspection.
+   * @see {@link https://spec.graphql.org/October2021/#sec-Type-Name-Introspection} for
+   * more information on GraphQL’s Type Name introspection.
+   */
   __typename: string;
   _id?: string | number | null;
   id?: string | number | null;
 }
 
+/** Scalar values are stored separately from relations between entities.
+ * @internal
+ */
 export type EntityField = undefined | Scalar | NullArray<Scalar>;
+
+/** Values on GraphQL object (“entity”) results.
+ *
+ * @remarks
+ * Any field that comes back from a GraphQL API will have
+ * values that are scalars, other objects, or arrays
+ * of scalars or objects.
+ */
 export type DataField = Scalar | Data | NullArray<Scalar> | NullArray<Data>;
 
+/** Definition of GraphQL object (“entity”) fields.
+ *
+ * @remarks
+ * Any object that comes back from a GraphQL API will have
+ * values that are scalars, other objects, or arrays
+ * of scalars or objects, i.e. the {@link DataField} type.
+ */
 export interface DataFields {
   [fieldName: string]: DataField;
 }
 
+/** Definition of GraphQL variables objects.
+ * @remarks
+ * Variables, as passed to GraphQL queries, can only contain scalar values.
+ *
+ * @see {@link https://spec.graphql.org/October2021/#sec-Coercing-Variable-Values} for the
+ * GraphQL spec’s coercion of GraphQL variables.
+ */
 export interface Variables {
   [name: string]: Scalar | Scalar[] | Variables | NullArray<Variables>;
 }
 
+/** Definition of GraphQL objects (“entities”).
+ *
+ * @remarks
+ * An entity is expected to consist of a `__typename`
+ * fields, optionally the default `id` or `_id` key
+ * fields, and scalar values or other entities
+ * otherwise.
+ */
 export type Data = SystemFields & DataFields;
+
+/** An entity, a key of an entity, or `null`
+ *
+ * @remarks
+ * When Graphcache accepts a reference to an entity, you may pass it a key of an entity,
+ * as retrieved for instance by {@link Cache.keyOfEntity} or a partial GraphQL object
+ * (i.e. an object with a `__typename` and key field).
+ */
 export type Entity = null | Data | string;
+
+/** A key of an entity, or `null`; or a list of keys.
+ *
+ * @remarks
+ * When Graphcache accepts a reference to one or more entities, you may pass it a
+ * key, an entity, or a list of entities or keys. This is often passed to {@link Cache.link}
+ * to update a field pointing to other GraphQL objects.
+ */
 export type Link<Key = string> = null | Key | NullArray<Key>;
-export type Connection = [Variables, string];
+
+/** Arguments passed to a Graphcache field resolver.
+ *
+ * @remarks
+ * Arguments a field receives are similar to variables and can
+ * only contain scalars or other arguments objects. This
+ * is equivalent to the {@link Variables} type.
+ *
+ * @see {@link https://spec.graphql.org/October2021/#sec-Coercing-Field-Arguments} for the
+ * GraphQL spec’s coercion of field arguments.
+ */
 export type FieldArgs = Variables | null | undefined;
 
+/** Metadata about an entity’s cached field.
+ *
+ * @remarks
+ * As returned by {@link Cache.inspectFields}, `FieldInfo` specifies an entity’s cached field,
+ * split into the field’s key itself and the field’s original name and arguments.
+ */
 export interface FieldInfo {
+  /** The field’s key which combines `fieldName` and `arguments`. */
   fieldKey: string;
+  /** The field’s name, as defined on a GraphQL Object type. */
   fieldName: string;
+  /** The arguments passed to the field as found on the cache. */
   arguments: Variables | null;
 }
 
+/** A key to an entity field split back into the entity’s key and the field’s key part.
+ * @internal
+ */
 export interface KeyInfo {
   entityKey: string;
   fieldKey: string;
 }
 
-// This is an input operation
+/** Abstract type for GraphQL requests.
+ *
+ * @remarks
+ * Similarly to `@urql/core`’s `GraphQLRequest` type, `OperationRequest`
+ * requires the minimum fields that Grapcache requires to execute a
+ * GraphQL operation: its query document and variables.
+ */
 export interface OperationRequest {
   query: DocumentNode | TypedDocumentNode<any, any>;
   variables?: any;
 }
 
+/** Metadata object passed to all resolver functions.
+ *
+ * @remarks
+ * `ResolveInfo`, similar to GraphQL.js’ `GraphQLResolveInfo` object,
+ * gives your resolvers a global state of the current GraphQL
+ * document traversal.
+ *
+ * `parent`, `parenTypeName`, `parentKey`, and `parentFieldKey`
+ * are particularly useful to make reusable resolver functions that
+ * must know on which field and type they’re being called on.
+ */
 export interface ResolveInfo {
+  /** The parent GraphQL object.
+   *
+   * @remarks
+   * The GraphQL object that the resolver has been called on. Because this is
+   * a reference to raw GraphQL data, this may be incomplete or contain
+   * aliased fields!
+   */
   parent: Data;
+  /** The parent object’s typename that the resolver has been called on. */
   parentTypeName: string;
+  /** The parent object’s entity key that the resolver has been called on. */
   parentKey: string;
+  /** Current field’s key that the resolver has been called on. */
   parentFieldKey: string;
+  /** Current field that the resolver has been called on. */
   fieldName: string;
+  /** Map of fragment definitions from the {@link DocumentNode}. */
   fragments: Fragments;
+  /** Full original {@link Variables} object on the {@link OperationRequest}. */
   variables: Variables;
+  /** Error that occurred for the current field, if any.
+   *
+   * @remarks
+   * If a {@link GraphQLError.path} points at the current field, the error
+   * will be set and provided here. This can be useful to recover from an
+   * error on a specific field.
+   */
   error: GraphQLError | undefined;
+  /** Flag used to indicate whether the current GraphQL query is only partially cached.
+   *
+   * @remarks
+   * When Graphcache has {@link CacheExchangeOpts.schema} introspection information,
+   * it can automatically generate partial results and trigger a full API request
+   * in the background.
+   * Hence, this field indicates whether any data so far has only been partially
+   * resolved from the cache, and is only in use on {@link Resolver | Resolvers}.
+   *
+   * However, you can also flip this flag to `true` manually to indicate to
+   * the {@link cacheExchange} that it should still make a network request.
+   */
   partial?: boolean;
+  /** Flag used to indicate whether the current GraphQL mutation is optimistically executed.
+   *
+   * @remarks
+   * An {@link UpdateResolver} is called for both API mutation responses and
+   * optimistic mutation reuslts, as generated by {@link OptimisticMutationResolver}.
+   *
+   * Since an update sometimes needs to perform different actions if it’s run
+   * optimistically, this flag is set to `true` during optimisti cupdates.
+   */
   optimistic?: boolean;
+  /** Internal state used by Graphcache.
+   * @internal
+   */
   __internal?: unknown;
 }
 
+/** GraphQL document and variables that should be queried against the cache.
+ *
+ * @remarks
+ * `QueryInput` is a generic GraphQL request that should be executed against
+ * cached data, as accepted by {@link cache.readQuery}.
+ */
 export interface QueryInput<T = Data, V = Variables> {
   query: string | DocumentNode | TypedDocumentNode<T, V>;
   variables?: V;
@@ -131,7 +314,15 @@ export interface Cache {
   link(entity: Entity, field: string, value: Link<Entity>): void;
 }
 
-type ResolverResult =
+/** Values a {@link Resolver} may return.
+ *
+ * @remarks
+ * A resolver may return any value that a GraphQL object may contain.
+ *
+ * Additionally however, a resolver may return `undefined` to indicate that data
+ * isn’t available from the cache, i.e. to trigger a cache miss.
+ */
+export type ResolverResult =
   | DataField
   | (DataFields & { __typename?: string })
   | null
@@ -293,6 +484,16 @@ export type UpdatesConfig = {
   } | void;
 };
 
+/** Remaps result type to allow for nested optimistic mutation resolvers.
+ *
+ * @remarks
+ * An {@link OptimisticMutationResolver} can not only return partial, nested
+ * mutation result data, but may also contain more optimistic mutation resolvers
+ * for nested fields, which allows fields with arguments to optimistically be
+ * resolved to dynamic values.
+ *
+ * @see {@link OptimisticMutationConfig} for more information.
+ */
 export type MakeFunctional<T> = T extends { __typename: string }
   ? WithTypename<{
       [P in keyof T]?: MakeFunctional<T[P]>;
@@ -420,11 +621,19 @@ export interface StorageAdapter {
   onOnline?(cb: () => void): any;
 }
 
+/** Set of keys that have been modified or accessed.
+ * @internal
+ */
 export type Dependencies = Set<string>;
 
-/** The type of cache operation being executed. */
+/** The type of cache operation being executed.
+ * @internal
+ */
 export type OperationType = 'read' | 'write';
 
+/** Casts a given object type to have a required typename field.
+ * @internal
+ */
 export type WithTypename<T extends { __typename?: any }> = T & {
   __typename: NonNullable<T['__typename']>;
 };

--- a/exchanges/graphcache/src/types.ts
+++ b/exchanges/graphcache/src/types.ts
@@ -137,12 +137,86 @@ type ResolverResult =
   | null
   | undefined;
 
+/** Input parameters for the {@link cacheExchange}. */
 export type CacheExchangeOpts = {
+  /** Configures update functions which are called when the mapped fields are written to the cache.
+   *
+   * @remarks
+   * `updates` are commonly used to define additional changes to the cache for
+   * mutation or subscription fields. It may commonly be used to invalidate
+   * cached data or to modify lists after mutations.
+   * This is a map of types to fields to {@link UpdateResolver} functions.
+   *
+   * @see {@link https://urql.dev/goto/docs/graphcache/cache-updates} for the full updates docs.
+   */
   updates?: UpdatesConfig;
+  /** Configures resolvers which replace cached reuslts with custom values.
+   *
+   * @remarks
+   * `resolvers` is a map of types to fields to {@link Resolver} functions.
+   * These functions allow us to replace cached field values with a custom
+   * result, either to replace values on GraphQL results, or to resolve
+   * entities from the cache for queries that haven't been sent to the API
+   * yet.
+   *
+   * @see {@link https://urql.dev/goto/docs/graphcache/local-resolvers} for the full resolvers docs.
+   */
   resolvers?: ResolverConfig;
+  /** Configures optimistic updates to react to mutations instantly before an API response.
+   *
+   * @remarks
+   * `optimistic` is a map of mutation fields to {@link OptimisticMutationResolver} functions.
+   * These functions allow us to return result data for mutations to optimistically apply them.
+   * Optimistic updates are temporary updates to the cache’s data which allow an app to
+   * instantly reflect changes that a mutation will make.
+   *
+   * @see {@link https://urql.dev/goto/docs/graphcache/cache-updates/#optimistic-updates} for the
+   * full optimistic updates docs.
+   */
   optimistic?: OptimisticMutationConfig;
+  /** Configures keying functions for GraphQL types.
+   *
+   * @remarks
+   * `keys` is a map of GraphQL object type names to {@link KeyGenerator} functions.
+   * If a type in your API has no key field or a key field that isn't the default
+   * `id` or `_id` fields, you may define a custom key generator for the type.
+   *
+   * Hint: Graphcache will log warnings when it finds objects that have no keyable
+   * fields, which will remind you to define these functions gradually for every
+   * type that needs them.
+   *
+   * @see {@link https://urql.dev/goto/docs/graphcache/normalized-caching/#custom-keys-and-non-keyable-entities} for
+   * the full keys docs.
+   */
   keys?: KeyingConfig;
+  /** Configures Graphcache with Schema Introspection data.
+   *
+   * @remarks
+   * Passing a `schema` to Graphcache enables it to do non-heuristic fragment
+   * matching, and be certain when a fragment matches against a union or interface
+   * on your schema.
+   *
+   * It also enables a mode called “Schema Awareness”, which allows Graphcache to
+   * return partial GraphQL results, `null`-ing out fields that aren’t in the cache
+   * that are nullable on your schema, while requesting the full API response in
+   * the background.
+   *
+   * @see {@link https://urql.dev/goto/urql/docs/graphcache/schema-awareness} for
+   * the full keys docs on Schema Awareness.
+   */
   schema?: IntrospectionData;
+  /** Configures an offline storage adapter for Graphcache.
+   *
+   * @remarks
+   * A {@link StorageAdapter} allows Graphcache to write data to an external,
+   * asynchronous storage, and hydrate data from it when it first loads.
+   * This allows you to preserve normalized data between restarts/reloads.
+   *
+   * Hint: If you’re trying to use Graphcache’s Offline Support, you may
+   * want to swap out the `cacheExchange` with the {@link offlineExchange}.
+   *
+   * @see {@link https://urql.dev/goto/docs/graphcache/offline} for the full Offline Support docs.
+   */
   storage?: StorageAdapter;
 };
 
@@ -160,6 +234,17 @@ export type Resolver<
   ): Result;
 }['bivarianceHack'];
 
+/** Configures resolvers which replace cached reuslts with custom values.
+ *
+ * @remarks
+ * A `ResolverConfig` is a map of types to fields to {@link Resolver} functions.
+ * These functions allow us to replace cached field values with a custom
+ * result, either to replace values on GraphQL results, or to resolve
+ * entities from the cache for queries that haven't been sent to the API
+ * yet.
+ *
+ * @see {@link https://urql.dev/goto/docs/graphcache/local-resolvers} for the full resolvers docs.
+ */
 export type ResolverConfig = {
   [typeName: string]: {
     [fieldName: string]: Resolver | void;
@@ -179,6 +264,29 @@ export type KeyGenerator = {
   bivarianceHack(data: Data): string | null;
 }['bivarianceHack'];
 
+/** Configures update functions which are called when the mapped fields are written to the cache.
+ *
+ * @remarks
+ * `UpdatesConfig` is a map of types to fields to {@link UpdateResolver} functions.
+ * These update functions are defined to instruct the cache to make additional changes
+ * when a field is written to the cache.
+ *
+ * As changes are often made after a mutation or subscription, the `typeName` is
+ * often set to `'Mutation'` or `'Subscription'`.
+ *
+ * @see {@link https://urql.dev/goto/docs/graphcache/cache-updates} for the full updates docs.
+ *
+ * @example
+ * ```ts
+ * const updates = {
+ *   Mutation: {
+ *     deleteAuthor(_parent, args, cache) {
+ *       // Delete the Author from the cache when Mutation.deleteAuthor is sent
+ *       cache.invalidate({ __typename: 'Author', id: args.id });
+ *     },
+ *   },
+ * };
+ */
 export type UpdatesConfig = {
   [typeName: string | 'Query' | 'Mutation' | 'Subscription']: {
     [fieldName: string]: UpdateResolver | void;
@@ -196,36 +304,119 @@ export type OptimisticMutationResolver<
   Result = Link<Data> | Scalar
 > = {
   bivarianceHack(
-    vars: Args,
+    args: Args,
     cache: Cache,
     info: ResolveInfo
   ): MakeFunctional<Result>;
 }['bivarianceHack'];
 
+/** Configures optimistic result functions which are called to get a mutation’s optimistic result.
+ *
+ * @remarks
+ * `OptimisticMutationConfig` is a map of mutation fields to {@link OptimisticMutationResolver}
+ * functions, which return result data for mutations to optimistically apply them.
+ * Optimistic updates are temporary updates to the cache’s data which allow an app to
+ * instantly reflect changes that a mutation will make.
+ *
+ * Hint: Results returned from optimistic functions may be partial, and may contain functions.
+ * If the returned optimistic object contains functions on fields, these are executed as nested
+ * optimistic resolver functions.
+ *
+ * @see {@link https://urql.dev/goto/docs/graphcache/cache-updates/#optimistic-updates} for the
+ * full optimistic updates docs.
+ *
+ * @example
+ * ```ts
+ * const optimistic = {
+ *   updateProfile: (args) => ({
+ *     __typename: 'UserProfile',
+ *     id: args.id,
+ *     name: args.newName,
+ *   }),
+ * };
+ */
 export type OptimisticMutationConfig = {
   [mutationFieldName: string]: OptimisticMutationResolver;
 };
 
+/** Configures keying functions for GraphQL types.
+ *
+ * @remarks
+ * `KeyingConfig` is a map of GraphQL object type names to {@link KeyGenerator} functions.
+ * If a type in your API has no key field or a key field that isn't the default
+ * `id` or `_id` fields, you may define a custom key generator for the type.
+ *
+ * Keys are important to a normalized cache, because they’re the identity of the object
+ * that is shared across the cache, and helps the cache recognize shared/normalized data.
+ *
+ * Hint: Graphcache will log warnings when it finds objects that have no keyable
+ * fields, which will remind you to define these functions gradually for every
+ * type that needs them.
+ *
+ * @see {@link https://urql.dev/goto/docs/graphcache/normalized-caching/#custom-keys-and-non-keyable-entities} for
+ * the full keys docs.
+ *
+ * @example
+ * ```ts
+ * const keys = {
+ *   Image: data => data.url,
+ *   LatLng: () => null,
+ * };
+ * ```
+ */
 export type KeyingConfig = {
   [typename: string]: KeyGenerator;
 };
 
-export type SerializedEntry = EntityField | Connection[] | Link;
-
+/** Serialized normalized caching data. */
 export interface SerializedEntries {
   [key: string]: string | undefined;
 }
 
+/** A serialized GraphQL request for offline storage. */
 export interface SerializedRequest {
   query: string;
   variables: AnyVariables;
 }
 
+/** Interface for a storage adapter, used by the {@link offlineExchange} for Offline Support.
+ * @see {@link https://urql.dev/goto/docs/graphcache/offline} for the full Offline Support docs.
+ * @see `@urql/exchange-graphcache/default-storage` for an example implementation using IndexedDB.
+ */
 export interface StorageAdapter {
+  /** Called to rehydrate data when the {@link cacheExchange} first loads.
+   * @remarks
+   * `readData` is called when Graphcache first starts up, and loads cache entries
+   * using which it'll repopulate its normalized cache data.
+   */
   readData(): Promise<SerializedEntries>;
+  /** Called by the {@link cacheExchange} to write new data to the offline storage.
+   * @remarks
+   * `writeData` is called when Graphcache updated its cached data and wishes to
+   * persist this data to the offline storage. The data is a partial object and
+   * Graphcache does not write all its data at once.
+   */
   writeData(delta: SerializedEntries): Promise<any>;
+  /** Called to rehydrate metadata when the {@link offlineExchange} first loads.
+   * @remarks
+   * `readMetadata` is called when Graphcache first starts up, and loads
+   * metadata informing it of pending mutations that failed while the device
+   * was offline.
+   */
   readMetadata?(): Promise<null | SerializedRequest[]>;
+  /** Called by the {@link offlineExchange} to persist failed mutations.
+   * @remarks
+   * `writeMetadata` is called when a mutation failed to persist a queue
+   * of failed mutations to the offline storage that must be retried when
+   * the application is reloaded.
+   */
   writeMetadata?(json: SerializedRequest[]): void;
+  /** Called to register a callback called when the device is back online.
+   * @remarks
+   * `onOnline` is called by the {@link offlineExchange} with a callback.
+   * This callback must be called when the device comes back online and
+   * will cause all failed mutations in the queue to be retried.
+   */
   onOnline?(cb: () => void): any;
 }
 

--- a/exchanges/populate/src/populateExchange.ts
+++ b/exchanges/populate/src/populateExchange.ts
@@ -20,13 +20,43 @@ import { Exchange, Operation, stringifyVariables } from '@urql/core';
 import { getName, GraphQLFlatType, unwrapType } from './helpers/node';
 import { traverse } from './helpers/traverse';
 
-interface Options {
+/** Configuration options for the {@link populateExchange}'s behaviour */
+export interface Options {
+  /** Prevents populating fields for matching types.
+   *
+   * @remarks
+   * `skipType` may be set to a regular expression that, when matching,
+   * prevents fields to be added automatically for the given type by the
+   * `populateExchange`.
+   *
+   * @defaultValue `/^PageInfo|(Connection|Edge)$/` - Omit Relay pagination fields
+   */
   skipType?: RegExp;
+  /** Specifies a maximum depth for populated fields.
+   *
+   * @remarks
+   * `maxDepth` may be set to a maximum depth at which fields are populated.
+   * This may prevent the `populateExchange` from adding infinitely deep
+   * recursive fields or simply too many fields.
+   *
+   * @defaultValue `2` - Omit fields past a depth of 2.
+   */
   maxDepth?: number;
 }
 
-interface PopulateExchangeOpts {
+/** Input parameters for the {@link populateExchange}. */
+export interface PopulateExchangeOpts {
+  /** Introspection data for an API’s schema.
+   *
+   * @remarks
+   * `schema` must be passed Schema Introspection data for the GraphQL API
+   * this exchange is applied for.
+   * You may use the `@urql/introspection` package to generate this data.
+   *
+   * @see {@link https://spec.graphql.org/October2021/#sec-Schema-Introspection} for the Schema Introspection spec.
+   */
   schema: IntrospectionQuery;
+  /** Configuration options for the {@link populateExchange}'s behaviour */
   options?: Options;
 }
 
@@ -50,6 +80,8 @@ const SKIP_COUNT_TYPE = /^PageInfo|(Connection|Edge)$/;
 /** Creates an `Exchange` handing automatic mutation selection-set population based on the
  * query selection-sets seen.
  *
+ * @param options - A {@link PopulateExchangeOpts} configuration object.
+ * @returns the created populate {@link Exchange}.
  *
  * @remarks
  * The `populateExchange` will create an exchange that monitors queries and
@@ -62,11 +94,17 @@ const SKIP_COUNT_TYPE = /^PageInfo|(Connection|Edge)$/;
  *
  * @example
  * ```ts
- * populateExchange({ schema, options: { maxDepth: 3, skipType: /Todo/ }})
+ * populateExchange({
+ *   schema,
+ *   options: {
+ *     maxDepth: 3,
+ *     skipType: /Todo/
+ *   },
+ * });
  *
  * const query = gql`
  *   mutation { addTodo @popualte }
- * `
+ * `;
  * ```
  */
 export const populateExchange =

--- a/exchanges/refocus/src/refocusExchange.ts
+++ b/exchanges/refocus/src/refocusExchange.ts
@@ -1,6 +1,19 @@
 import { pipe, tap } from 'wonka';
 import { Exchange, Operation } from '@urql/core';
 
+/** Exchange factory that reexecutes operations after a user returns to the tab.
+ *
+ * @returns a new refocus {@link Exchange}.
+ *
+ * @remarks
+ * The `refocusExchange` will reexecute `Operation`s with the `cache-and-network`
+ * policy when a user switches back to your application's browser tab. This can
+ * effectively update all on-screen data when a user has stayed inactive for a
+ * long time.
+ *
+ * The `cache-and-network` policy will refetch data in the background, but will
+ * only refetch queries that are currently active.
+ */
 export const refocusExchange = (): Exchange => {
   return ({ client, forward }) =>
     ops$ => {

--- a/exchanges/request-policy/src/requestPolicyExchange.ts
+++ b/exchanges/request-policy/src/requestPolicyExchange.ts
@@ -11,24 +11,25 @@ const defaultTTL = 5 * 60 * 1000;
 /** Input parameters for the {@link requestPolicyExchange}. */
 export interface Options {
   /** Predicate allowing you to selectively not upgrade `Operation`s.
-  
-  @remarks
-  When `shouldUpgrade` is set, it may be used to selectively return a boolean
-  per `Operation`. This allows certain `Operation`s to not be upgraded to a
-  `cache-and-network` policy, when `false` is returned.
-  
-  By default, all `Operation`s are subject to be upgraded.
-   * operation to "cache-and-network". */
+   *
+   * @remarks
+   * When `shouldUpgrade` is set, it may be used to selectively return a boolean
+   * per `Operation`. This allows certain `Operation`s to not be upgraded to a
+   * `cache-and-network` policy, when `false` is returned.
+   *
+   * By default, all `Operation`s are subject to be upgraded.
+   * operation to "cache-and-network".
+   */
   shouldUpgrade?: (op: Operation) => boolean;
   /** The time-to-live (TTL) for which a request policy won't be upgraded.
-  
-  @remarks
-  The `ttl` defines the time frame in which the `Operation` won't be updated
-  with a `cache-and-network` request policy. If an `Operation` is sent again
-  and the `ttl` time period has expired, the policy is upgraded.
-  
-  @defaultValue `300_000` - 5min
-  */
+   *
+   * @remarks
+   * The `ttl` defines the time frame in which the `Operation` won't be updated
+   * with a `cache-and-network` request policy. If an `Operation` is sent again
+   * and the `ttl` time period has expired, the policy is upgraded.
+   *
+   * @defaultValue `300_000` - 5min
+   */
   ttl?: number;
 }
 
@@ -48,10 +49,10 @@ export interface Options {
  * @example
  * ```ts
  * requestPolicyExchange({
- *  // Upgrade when we haven't seen this operation for 1 second
- *  ttl: 1000,
- *  // and only upgrade operations that query the `todos` field.
- *  shouldUpgrade: op => op.kind === 'query' && op.query.definitions[0].name?.value === 'todos'
+ *   // Upgrade when we haven't seen this operation for 1 second
+ *   ttl: 1000,
+ *   // and only upgrade operations that query the `todos` field.
+ *   shouldUpgrade: op => op.kind === 'query' && op.query.definitions[0].name?.value === 'todos'
  * });
  * ```
  */

--- a/exchanges/retry/src/retryExchange.ts
+++ b/exchanges/retry/src/retryExchange.ts
@@ -19,32 +19,104 @@ import {
   OperationResult,
 } from '@urql/core';
 
+/** Input parameters for the {@link retryExchange}. */
 export interface RetryExchangeOptions {
+  /** Specify the minimum time to wait until retrying.
+   *
+   * @remarks
+   * `initialDelayMs` specifies the minimum time (in milliseconds) to wait
+   * until a failed operation is retried.
+   *
+   * @defaultValue `1_000` - one second
+   */
   initialDelayMs?: number;
+  /** Specifies the maximum time to wait until retrying.
+   *
+   * @remarks
+   * `maxDelayMs` specifies the maximum time (in milliseconds) to wait
+   * until a failed operation is retried. While `initialDelayMs`
+   * specifies the minimum amount of time, `randomDelay` may cause
+   * the delay to increase over multiple attempts.
+   *
+   * @defaultValue `15_000` - 15 seconds
+   */
   maxDelayMs?: number;
+  /** Enables a random exponential backoff to increase the delay over multiple retries.
+   *
+   * @remarks
+   * `randomDelay`, unless disabled, increases the time until a failed
+   * operation is retried over multiple attempts. It increases the time
+   * starting at `initialDelayMs` by 1.5x with an added factor of 0–1,
+   * until `maxDelayMs` is reached.
+   *
+   * @defaultValue `true` - enables random exponential backoff
+   */
   randomDelay?: boolean;
+  /** Specifies the maximum times an operation should be sent to the API.
+   *
+   * @remarks
+   * `maxNumberAttempts` defines the number of attempts an operation should
+   * be retried until it's considered failed.
+   *
+   * @defaultValue `2` - Retry once, i.e. two attempts
+   */
   maxNumberAttempts?: number;
-  /** Conditionally determine whether an error should be retried */
-  retryIf?: (error: CombinedError, operation: Operation) => boolean;
-  /** Conditionally update operations as they're retried (retryIf can be replaced with this) */
-  retryWith?: (
+  /** Predicate allowing you to selectively not retry `Operation`s.
+   *
+   * @remarks
+   * `retryIf` is called with a {@link CombinedError} and the {@link Operation} that
+   * failed. If this function returns false the failed `Operation` is not retried.
+   *
+   * @defaultValue `(error) => !!error.networkError` - retries only on network errors.
+   */
+  retryIf?(error: CombinedError, operation: Operation): boolean;
+  /** Transform function allowing you to selectively replace a retried `Operation` or return nullish value.
+   *
+   * @remarks
+   * `retryWhen` is called with a {@link CombinedError} and the {@link Operation} that
+   * failed. If this function returns an `Operation`, `retryExchange` will replace the
+   * failed `Operation` and retry. It won't retry the `Operation` if a nullish value
+   * is returned.
+   *
+   * The `retryIf` function, if defined, takes precedence and overrides this option.
+   */
+  retryWith?(
     error: CombinedError,
     operation: Operation
-  ) => Operation | null | undefined;
+  ): Operation | null | undefined;
 }
 
-export const retryExchange = ({
-  initialDelayMs,
-  maxDelayMs,
-  randomDelay,
-  maxNumberAttempts,
-  retryIf,
-  retryWith,
-}: RetryExchangeOptions): Exchange => {
-  const MIN_DELAY = initialDelayMs || 1000;
-  const MAX_DELAY = maxDelayMs || 15000;
-  const MAX_ATTEMPTS = maxNumberAttempts || 2;
-  const RANDOM_DELAY = randomDelay !== undefined ? !!randomDelay : true;
+/** Exchange factory that retries failed operations.
+ *
+ * @param options - A {@link RetriesExchangeOptions} configuration object.
+ * @returns the created retry {@link Exchange}.
+ *
+ * @remarks
+ * The `retryExchange` retries failed operations with specified delays
+ * and exponential backoff.
+ *
+ * You may define a {@link RetryExchangeOptions.retryIf} or
+ * {@link RetryExchangeOptions.retryWhen} function to only retry
+ * certain kinds of operations, e.g. only queries.
+ *
+ * @example
+ * ```ts
+ * retryExchange({
+ *   initialDelayMs: 1000,
+ *   maxDelayMs: 15000,
+ *   randomDelay: true,
+ *   maxNumberAttempts: 2,
+ *   retryIf: err => err && err.networkError,
+ * });
+ * ```
+ */
+export const retryExchange = (options: RetryExchangeOptions): Exchange => {
+  const { retryIf, retryWith } = options;
+  const MIN_DELAY = options.initialDelayMs || 1000;
+  const MAX_DELAY = options.maxDelayMs || 15000;
+  const MAX_ATTEMPTS = options.maxNumberAttempts || 2;
+  const RANDOM_DELAY =
+    options.randomDelay != null ? !!options.randomDelay : true;
 
   return ({ forward, dispatchDebug }) =>
     ops$ => {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -115,7 +115,7 @@ export interface ClientOptions {
    * To easily get started you should consider using the {@link dedupExchange}, {@link cacheExchange} and {@link fetchExchange}
    * these are all exported from the core package.
    *
-   * @see {@link https://formidable.com/open-source/urql/docs/architecture/#the-client-and-exchanges} for more information
+   * @see {@link https://urql.dev/goto/docs/architecture/#the-client-and-exchanges} for more information
    * on what `Exchange`s are and how they work.
    */
   exchanges: Exchange[];
@@ -198,7 +198,7 @@ export interface ClientOptions {
  * creating operations, managing consumers of active operations, sharing results for operations,
  * and more tasks as a “central hub”.
  *
- * @see {@link https://formidable.com/open-source/urql/docs/architecture/#requests-and-operations-on-the-client} for more information
+ * @see {@link https://urql.dev/goto/docs/architecture/#requests-and-operations-on-the-client} for more information
  * on what the `Client` is and does.
  */
 export interface Client {

--- a/packages/core/src/exchanges/cache.ts
+++ b/packages/core/src/exchanges/cache.ts
@@ -35,7 +35,7 @@ const shouldSkip = ({ kind }: Operation) =>
  * {@link OperationContext.additionalTypenames} for queries and mutations that
  * should invalidate one another.
  *
- * @see {@link https://formidable.com/open-source/urql/docs/basics/document-caching/} for more information on this cache.
+ * @see {@link https://urql.dev/goto/docs/basics/document-caching} for more information on this cache.
  */
 export const cacheExchange: Exchange = ({ forward, client, dispatchDebug }) => {
   const resultCache: ResultCache = new Map();

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -515,7 +515,7 @@ export interface OperationContext {
  * The {@link ExchangeIO} type describes how {@link Exchange | Exchanges} receive `Operation`s and return
  * `OperationResults`, using `teardown` `Operation`s to cancel ongoing operations.
  *
- * @see {@link https://formidable.com/open-source/urql/docs/architecture/#the-client-and-exchanges} for more information
+ * @see {@link https://urql.dev/goto/docs/architecture/#the-client-and-exchanges} for more information
  * on the flow of Exchanges.
  */
 export interface Operation<
@@ -668,8 +668,8 @@ export interface ExchangeInput {
  * Like middleware, exchanges are composed, calling each other in a pipeline-like fashion, which is facilitated by exchanges
  * calling {@link ExchangeInput.forward}, which is set to the next exchange's {@link ExchangeIO} function in the pipeline.
  *
- * @see {@link https://formidable.com/open-source/urql/docs/architecture/#the-client-and-exchanges} for more information on Exchanges.
- * @see {@link https://formidable.com/open-source/urql/docs/advanced/authoring-exchanges/} on how Exchanges are authored.
+ * @see {@link https://urql.dev/goto/docs/architecture/#the-client-and-exchanges} for more information on Exchanges.
+ * @see {@link https://urql.dev/goto/docs/advanced/authoring-exchanges} on how Exchanges are authored.
  */
 export type Exchange = (input: ExchangeInput) => ExchangeIO;
 
@@ -686,7 +686,7 @@ export type Exchange = (input: ExchangeInput) => ExchangeIO;
  * Generally, the stream of `OperationResult` returned by {@link ExchangeInput.forward} is always merged and combined with
  * the `Exchange`'s own stream of results if the `Exchange` creates and delivers results of its own.
  *
- * @see {@link https://formidable.com/open-source/urql/docs/advanced/authoring-exchanges/} on how Exchanges are authored.
+ * @see {@link https://urql.dev/goto/docs/advanced/authoring-exchanges} on how Exchanges are authored.
  */
 export type ExchangeIO = (ops$: Source<Operation>) => Source<OperationResult>;
 

--- a/packages/core/src/utils/error.ts
+++ b/packages/core/src/utils/error.ts
@@ -44,7 +44,7 @@ const rehydrateGraphQlError = (error: any): GraphQLError => {
  * is set to this error, the `CombinedError` abstracts all errors, making it easier to handle only
  * a subset of error cases.
  *
- * @see {@link https://formidable.com/open-source/urql/docs/basics/errors/} for more information on handling
+ * @see {@link https://urql.dev/goto/docs/basics/errors} for more information on handling
  * GraphQL errors and the `CombinedError`.
  */
 export class CombinedError extends Error {


### PR DESCRIPTION
Follow-up to #2962

**Note:** This only adds TSDocs to `exchanges/*` not `packages/*`.

## Summary

This adds inline TSDocs to all of our exchange packages, including Graphcache, which should make learning and using these APIs, in the presence of an editor with TS language server support, much easier.