### PR TITLE
fix(core): Fix immediate cancellation of fetch requests

### DIFF
--- a/packages/core/src/exchanges/fetch.test.ts
+++ b/packages/core/src/exchanges/fetch.test.ts
@@ -147,37 +147,49 @@ describe('on teardown', () => {
     expect(true).toEqual(false);
   };
 
-  it('does not start the outgoing request on immediate teardowns', () => {
-    fetch.mockResolvedValue(new Response('text', { status: 200 }));
+  it('does not start the outgoing request on immediate teardowns', async () => {
+    fetch.mockImplementation(async () => {
+      await new Promise(() => {
+        /*noop*/
+      });
+    });
 
     const { unsubscribe } = pipe(
       fromValue(queryOperation),
       fetchExchange(exchangeArgs),
       subscribe(fail)
     );
-
-    unsubscribe();
-    expect(fetch).toHaveBeenCalledTimes(0);
-    expect(abort).toHaveBeenCalledTimes(0);
-  });
-
-  it('aborts the outgoing request', async () => {
-    fetch.mockResolvedValue(new Response('text', { status: 200 }));
-
-    const { unsubscribe } = pipe(
-      fromValue(queryOperation),
-      fetchExchange(exchangeArgs),
-      subscribe(fail)
-    );
-
-    await Promise.resolve();
 
     unsubscribe();
 
     // NOTE: We can only observe the async iterator's final run after a macro tick
     await new Promise(resolve => setTimeout(resolve));
+    expect(fetch).toHaveBeenCalledTimes(0);
+    expect(abort).toHaveBeenCalledTimes(1);
+  });
+
+  it('aborts the outgoing request', async () => {
+    fetch.mockResolvedValue({
+      status: 200,
+      headers: new Map([['Content-Type', 'application/json']]),
+      text: vi.fn().mockResolvedValue('{ "data": null }'),
+    });
+
+    const { unsubscribe } = pipe(
+      fromValue(queryOperation),
+      fetchExchange(exchangeArgs),
+      subscribe(() => {
+        /*noop*/
+      })
+    );
+
+    await new Promise(resolve => setTimeout(resolve));
+    unsubscribe();
+
+    // NOTE: We can only observe the async iterator's final run after a macro tick
+    await new Promise(resolve => setTimeout(resolve));
     expect(fetch).toHaveBeenCalledTimes(1);
-    expect(abort).toHaveBeenCalled();
+    expect(abort).toHaveBeenCalledTimes(1);
   });
 
   it('does not call the query', () => {


### PR DESCRIPTION
Follow-up to #3043

## Summary

The async generator implementation has regressed on the previous one since it doesn't include a delay that respects immediate `teardown` signals. This is because no `yield` was present after the initial microtick and before the `fetch` call.

I'm still trying to find a more elegant solution to this, but it doesn't seem possible to yield without emitting a value, and async generators may not abort on `await` statements, which seems counterintuitive.

Changeset hasn't been added since it's a follow-up fix.

## Set of changes

- Add `yield` after microtick delay to allow `fetchOperation` to abort early
- Update tests to correctly detect missing early-terminations
