### PR TITLE
fix(svelte): Move handler from mutationStore to subscriptionStore

### DIFF
--- a/.changeset/many-cats-travel.md
+++ b/.changeset/many-cats-travel.md
@@ -1,0 +1,5 @@
+---
+'@urql/svelte': major
+---
+
+Move `handler`, which combines subscription events, from `mutationStore` to `subscriptionStore`. It’s accidentally been defined and implemented on the wrong store and was meant to be on `subscriptionStore`.

--- a/packages/svelte-urql/src/mutationStore.ts
+++ b/packages/svelte-urql/src/mutationStore.ts
@@ -15,8 +15,6 @@ import {
   initialResult,
 } from './common';
 
-export type SubscriptionHandler<T, R> = (prev: R | undefined, data: T) => R;
-
 export type MutationArgs<
   Data = any,
   Variables extends AnyVariables = AnyVariables
@@ -27,19 +25,15 @@ export type MutationArgs<
 
 export function mutationStore<
   Data = any,
-  Result = Data,
   Variables extends AnyVariables = AnyVariables
->(
-  args: MutationArgs<Data, Variables>,
-  handler?: SubscriptionHandler<Data, Result>
-): OperationResultStore<Result, Variables> {
+>(args: MutationArgs<Data, Variables>): OperationResultStore<Data, Variables> {
   const request = createRequest(args.query, args.variables as Variables);
   const operation = args.client.createRequestOperation(
     'mutation',
     request,
     args.context
   );
-  const initialState: OperationResultState<Result, Variables> = {
+  const initialState: OperationResultState<Data, Variables> = {
     ...initialResult,
     operation,
     fetching: true,
@@ -58,16 +52,13 @@ export function mutationStore<
         extensions,
       }))
     ),
-    scan((result: OperationResultState<Result, Variables>, partial: any) => {
-      // If a handler has been passed, it's used to merge new data in
-      const data =
-        partial.data !== undefined
-          ? typeof handler === 'function'
-            ? handler(result.data, partial.data)
-            : partial.data
-          : result.data;
-      return { ...result, ...partial, data };
-    }, initialState),
+    scan(
+      (result: OperationResultState<Data, Variables>, partial) => ({
+        ...result,
+        ...partial,
+      }),
+      initialState
+    ),
     subscribe(result => {
       result$.set(result);
     })


### PR DESCRIPTION
## Summary

The `SubscriptionHandler` argument was accidentally defined and implemented on the `mutationStore` rather than the `subscriptionStore`.

It's now been moved, which is a breaking change.
The handler was never intended to be on the `mutationStore`!

## Set of changes

- Move handler from `mutationStore` to `subscriptionStore`
