### PR TITLE
feat(core): Allow partial context in makeOperation (QOL)

### DIFF
--- a/.changeset/dry-days-wait.md
+++ b/.changeset/dry-days-wait.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Allow `makeOperation` to be called with a partial `OperationContext` when it’s called to copy an operation. When it receives an `Operation` as a second argument now, the third argument, the context, will be spread into the prior `operation.context`.

--- a/packages/core/src/exchanges/cache.ts
+++ b/packages/core/src/exchanges/cache.ts
@@ -170,7 +170,6 @@ export const cacheExchange: Exchange = ({ forward, client, dispatchDebug }) => {
 export const reexecuteOperation = (client: Client, operation: Operation) => {
   return client.reexecuteOperation(
     makeOperation(operation.kind, operation, {
-      ...operation.context,
       requestPolicy: 'network-only',
     })
   );

--- a/packages/core/src/utils/operation.ts
+++ b/packages/core/src/utils/operation.ts
@@ -9,14 +9,17 @@ import {
 /** Creates a {@link Operation} from the given parameters.
  *
  * @param kind - The {@link OperationType} of GraphQL operation, i.e. `query`, `mutation`, or `subscription`.
- * @param request - The {@link GraphQLRequest} used as a template for the `Operation`.
+ * @param request - The {@link GraphQLRequest} or {@link Operation} used as a template for the new `Operation`.
  * @param context - The {@link OperationContext} `context` data for the `Operation`.
- * @returns An {@link Operation}.
+ * @returns A new {@link Operation}.
  *
  * @remarks
  * This method is both used to create new {@link Operation | Operations} as well as copy and modify existing
  * operations. While it’s not required to use this function to copy an `Operation`, it is recommended, in case
  * additional dynamic logic is added to them in the future.
+ *
+ * Hint: When an {@link Operation} is passed to the `request` argument, the `context` argument does not have to be
+ * a complete {@link OperationContext} and will instead be combined with passed {@link Operation.context}.
  *
  * @example
  * An example of copying an existing `Operation` to modify its `context`:
@@ -25,7 +28,7 @@ import {
  * makeOperation(
  *   operation.kind,
  *   operation,
- *   { ...operation.context, requestPolicy: 'cache-first' },
+ *   { requestPolicy: 'cache-first' },
  * );
  * ```
  */
@@ -44,15 +47,20 @@ function makeOperation<
 >(
   kind: OperationType,
   request: Operation<Data, Variables>,
-  context?: OperationContext
+  context?: Partial<OperationContext>
 ): Operation<Data, Variables>;
 
 function makeOperation(kind, request, context) {
-  if (!context) context = request.context;
   return {
     ...request,
     kind,
-    context,
+    context:
+      context && request.kind
+        ? {
+            ...request.context,
+            ...context,
+          }
+        : context || request.context,
   };
 }
 
@@ -66,7 +74,6 @@ export const addMetadata = (
   meta: OperationContext['meta']
 ) => {
   return makeOperation(operation.kind, operation, {
-    ...operation.context,
     meta: {
       ...operation.context.meta,
       ...meta,


### PR DESCRIPTION
## Summary

This is a small quality of life improvement for the `makeOperation` helper in `@urql/core` that'll mainly benefit users rather than the core code.

When `makeOperation` is called with an `Operation` rather than a request, we should spread `OperationContext` and allow a partial one.

```ts
// before
makeOperation(operation.kind, operation, {
  ...operation.context,
  requestPolicy: 'cache-and-network',
});

// after
makeOperation(operation.kind, operation, {
  requestPolicy: 'cache-and-network',
});

## Set of changes

- Allow partial `OperationContext` for when `makeOperation` is called on an `Operation` rather than a `GraphQLRequest`
