### PR TITLE
feat(core): Wrap ExchangeIO in share calls in composeExchanges (QOL)

### DIFF
--- a/.changeset/cuddly-actors-look.md
+++ b/.changeset/cuddly-actors-look.md
@@ -1,0 +1,11 @@
+---
+'@urql/exchange-multipart-fetch': minor
+'@urql/exchange-graphcache': minor
+'@urql/exchange-persisted': minor
+'@urql/exchange-context': minor
+'@urql/exchange-execute': minor
+'@urql/exchange-retry': minor
+'@urql/exchange-auth': minor
+---
+
+Update exchanges to drop redundant `share` calls, since `@urql/core`’s `composeExchanges` utility now automatically does so for us.

--- a/.changeset/five-lies-collect.md
+++ b/.changeset/five-lies-collect.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Update `Exchange` contract and `composeExchanges` utility to remove the need to manually call `share` on either incoming `Source<Operation>` or `forward()`’s `Source<OperationResult>`. This is now taken care of internally in `composeExchanges` and should make it easier for you to create custom exchanges and for us to explain them.

--- a/exchanges/auth/src/authExchange.test.ts
+++ b/exchanges/auth/src/authExchange.test.ts
@@ -5,6 +5,7 @@ import {
   toPromise,
   take,
   makeSubject,
+  share,
   publish,
   scan,
   tap,
@@ -41,7 +42,8 @@ const makeExchangeArgs = () => {
         pipe(
           op$,
           tap(op => operations.push(op)),
-          map(result)
+          map(result),
+          share
         ),
       client: new Client({
         url: '/api',

--- a/exchanges/auth/src/authExchange.ts
+++ b/exchanges/auth/src/authExchange.ts
@@ -8,7 +8,6 @@ import {
   makeSubject,
   toPromise,
   merge,
-  share,
 } from 'wonka';
 
 import {
@@ -300,15 +299,13 @@ export function authExchange(
         return config ? config.addAuthToOperation(operation) : operation;
       }
 
-      const sharedOps$ = pipe(operations$, share);
-
       const teardownOps$ = pipe(
-        sharedOps$,
+        operations$,
         filter(operation => operation.kind === 'teardown')
       );
 
       const pendingOps$ = pipe(
-        sharedOps$,
+        operations$,
         filter(operation => operation.kind !== 'teardown')
       );
 
@@ -337,7 +334,7 @@ export function authExchange(
         filter(Boolean)
       ) as Source<Operation>;
 
-      const result$ = pipe(merge([opsWithAuth$, teardownOps$]), forward, share);
+      const result$ = pipe(merge([opsWithAuth$, teardownOps$]), forward);
 
       return pipe(
         result$,

--- a/exchanges/context/src/context.ts
+++ b/exchanges/context/src/context.ts
@@ -4,6 +4,7 @@ import {
   Operation,
   OperationContext,
 } from '@urql/core';
+
 import { fromPromise, fromValue, mergeMap, pipe } from 'wonka';
 
 /** Input parameters for the {@link contextExchange}. */

--- a/exchanges/execute/src/execute.ts
+++ b/exchanges/execute/src/execute.ts
@@ -1,13 +1,4 @@
-import {
-  Source,
-  pipe,
-  share,
-  filter,
-  takeUntil,
-  mergeMap,
-  merge,
-  make,
-} from 'wonka';
+import { Source, pipe, filter, takeUntil, mergeMap, merge, make } from 'wonka';
 
 import {
   GraphQLSchema,
@@ -131,11 +122,9 @@ const makeExecuteSource = (
 export const executeExchange =
   (options: ExecuteExchangeArgs): Exchange =>
   ({ forward }) => {
-    return ops$ => {
-      const sharedOps$ = share(ops$);
-
+    return operations$ => {
       const executedOps$ = pipe(
-        sharedOps$,
+        operations$,
         filter((operation: Operation) => {
           return (
             operation.kind === 'query' ||
@@ -146,7 +135,7 @@ export const executeExchange =
         mergeMap((operation: Operation) => {
           const { key } = operation;
           const teardown$ = pipe(
-            sharedOps$,
+            operations$,
             filter(op => op.kind === 'teardown' && op.key === key)
           );
 
@@ -192,7 +181,7 @@ export const executeExchange =
       );
 
       const forwardedOps$ = pipe(
-        sharedOps$,
+        operations$,
         filter(operation => operation.kind === 'teardown'),
         forward
       );

--- a/exchanges/graphcache/src/cacheExchange.test.ts
+++ b/exchanges/graphcache/src/cacheExchange.test.ts
@@ -12,6 +12,7 @@ import { vi, expect, it, describe } from 'vitest';
 import {
   Source,
   pipe,
+  share,
   map,
   merge,
   mergeMap,
@@ -86,7 +87,7 @@ describe('data dependencies', () => {
 
     const { source: ops$, next } = makeSubject<Operation>();
     const result = vi.fn();
-    const forward: ExchangeIO = ops$ => pipe(ops$, map(response));
+    const forward: ExchangeIO = ops$ => pipe(ops$, map(response), share);
 
     pipe(
       cacheExchange({})({ forward, client, dispatchDebug })(ops$),
@@ -137,7 +138,7 @@ describe('data dependencies', () => {
 
     const { source: ops$, next } = makeSubject<Operation>();
     const result = vi.fn();
-    const forward: ExchangeIO = ops$ => pipe(ops$, map(response));
+    const forward: ExchangeIO = ops$ => pipe(ops$, map(response), share);
 
     pipe(
       cacheExchange({})({ forward, client, dispatchDebug })(ops$),
@@ -214,7 +215,7 @@ describe('data dependencies', () => {
       return undefined as any;
     });
 
-    const forward: ExchangeIO = ops$ => pipe(ops$, map(response));
+    const forward: ExchangeIO = ops$ => pipe(ops$, map(response), share);
     const result = vi.fn();
 
     pipe(
@@ -358,7 +359,8 @@ describe('data dependencies', () => {
     });
 
     const result = vi.fn();
-    const forward: ExchangeIO = ops$ => pipe(ops$, delay(1), map(response));
+    const forward: ExchangeIO = ops$ =>
+      pipe(ops$, delay(1), map(response), share);
 
     const updates = {
       Mutation: {
@@ -459,7 +461,7 @@ describe('data dependencies', () => {
       return undefined as any;
     });
 
-    const forward: ExchangeIO = ops$ => pipe(ops$, map(response));
+    const forward: ExchangeIO = ops$ => pipe(ops$, map(response), share);
     const result = vi.fn();
 
     pipe(
@@ -519,7 +521,8 @@ describe('data dependencies', () => {
     });
 
     const result = vi.fn();
-    const forward: ExchangeIO = ops$ => pipe(ops$, delay(1), map(response));
+    const forward: ExchangeIO = ops$ =>
+      pipe(ops$, delay(1), map(response), share);
 
     const updates = {
       Mutation: {
@@ -581,7 +584,8 @@ describe('data dependencies', () => {
     });
 
     const result = vi.fn();
-    const forward: ExchangeIO = ops$ => pipe(ops$, delay(1), map(response));
+    const forward: ExchangeIO = ops$ =>
+      pipe(ops$, delay(1), map(response), share);
 
     const updates = {
       Mutation: {
@@ -661,7 +665,7 @@ describe('data dependencies', () => {
     });
 
     const result = vi.fn();
-    const forward: ExchangeIO = ops$ => pipe(ops$, map(response));
+    const forward: ExchangeIO = ops$ => pipe(ops$, map(response), share);
 
     pipe(
       cacheExchange({})({ forward, client, dispatchDebug })(ops$),
@@ -748,7 +752,8 @@ describe('optimistic updates', () => {
     });
 
     const result = vi.fn();
-    const forward: ExchangeIO = ops$ => pipe(ops$, delay(1), map(response));
+    const forward: ExchangeIO = ops$ =>
+      pipe(ops$, delay(1), map(response), share);
 
     const optimistic = {
       concealAuthor: vi.fn(() => optimisticMutationData.concealAuthor) as any,
@@ -858,7 +863,8 @@ describe('optimistic updates', () => {
     });
 
     const result = vi.fn();
-    const forward: ExchangeIO = ops$ => pipe(ops$, delay(3), map(response));
+    const forward: ExchangeIO = ops$ =>
+      pipe(ops$, delay(3), map(response), share);
 
     const optimistic = {
       concealAuthor: vi.fn(() => optimisticMutationData.concealAuthor) as any,
@@ -957,7 +963,8 @@ describe('optimistic updates', () => {
         ops$,
         delay(1),
         filter(x => x.kind !== 'mutation'),
-        map(response)
+        map(response),
+        share
       );
 
     const optimistic = {
@@ -1071,7 +1078,8 @@ describe('optimistic updates', () => {
     });
 
     const result = vi.fn();
-    const forward: ExchangeIO = ops$ => pipe(ops$, delay(1), map(response));
+    const forward: ExchangeIO = ops$ =>
+      pipe(ops$, delay(1), map(response), share);
 
     const optimistic = {
       addAuthor: vi.fn(() => optimisticMutationData.addAuthor) as any,
@@ -1138,7 +1146,7 @@ describe('custom resolvers', () => {
       return undefined as any;
     });
 
-    const forward: ExchangeIO = ops$ => pipe(ops$, map(response));
+    const forward: ExchangeIO = ops$ => pipe(ops$, map(response), share);
 
     const result = vi.fn();
     const fakeResolver = vi.fn();
@@ -1225,7 +1233,8 @@ describe('custom resolvers', () => {
     });
 
     const result = vi.fn();
-    const forward: ExchangeIO = ops$ => pipe(ops$, delay(1), map(response));
+    const forward: ExchangeIO = ops$ =>
+      pipe(ops$, delay(1), map(response), share);
 
     const fakeResolver = vi.fn();
 
@@ -1377,7 +1386,8 @@ describe('custom resolvers', () => {
     });
 
     const result = vi.fn();
-    const forward: ExchangeIO = ops$ => pipe(ops$, delay(1), map(response));
+    const forward: ExchangeIO = ops$ =>
+      pipe(ops$, delay(1), map(response), share);
 
     const fakeResolver = vi.fn();
     const called: any[] = [];
@@ -1540,7 +1550,8 @@ describe('schema awareness', () => {
     });
 
     const result = vi.fn();
-    const forward: ExchangeIO = ops$ => pipe(ops$, delay(1), map(response));
+    const forward: ExchangeIO = ops$ =>
+      pipe(ops$, delay(1), map(response), share);
 
     pipe(
       cacheExchange({
@@ -1683,7 +1694,8 @@ describe('schema awareness', () => {
     });
 
     const result = vi.fn();
-    const forward: ExchangeIO = ops$ => pipe(ops$, delay(1), map(response));
+    const forward: ExchangeIO = ops$ =>
+      pipe(ops$, delay(1), map(response), share);
 
     pipe(
       cacheExchange({
@@ -1859,13 +1871,15 @@ describe('commutativity', () => {
     `;
 
     const forward = (ops$: Source<Operation>): Source<OperationResult> =>
-      merge([
-        pipe(
-          ops$,
-          filter(() => false)
-        ) as any,
-        res$,
-      ]);
+      share(
+        merge([
+          pipe(
+            ops$,
+            filter(() => false)
+          ) as any,
+          res$,
+        ])
+      );
 
     const optimistic = {
       node: () => ({
@@ -1953,13 +1967,15 @@ describe('commutativity', () => {
     `;
 
     const forward = (ops$: Source<Operation>): Source<OperationResult> =>
-      merge([
-        pipe(
-          ops$,
-          filter(() => false)
-        ) as any,
-        res$,
-      ]);
+      share(
+        merge([
+          pipe(
+            ops$,
+            filter(() => false)
+          ) as any,
+          res$,
+        ])
+      );
 
     pipe(
       cacheExchange()({ forward, client, dispatchDebug })(ops$),
@@ -2074,13 +2090,15 @@ describe('commutativity', () => {
     `;
 
     const forward = (ops$: Source<Operation>): Source<OperationResult> =>
-      merge([
-        pipe(
-          ops$,
-          filter(() => false)
-        ) as any,
-        res$,
-      ]);
+      share(
+        merge([
+          pipe(
+            ops$,
+            filter(() => false)
+          ) as any,
+          res$,
+        ])
+      );
 
     const optimistic = {
       node: () => ({
@@ -2177,13 +2195,15 @@ describe('commutativity', () => {
     `;
 
     const forward = (ops$: Source<Operation>): Source<OperationResult> =>
-      merge([
-        pipe(
-          ops$,
-          filter(() => false)
-        ) as any,
-        res$,
-      ]);
+      share(
+        merge([
+          pipe(
+            ops$,
+            filter(() => false)
+          ) as any,
+          res$,
+        ])
+      );
 
     pipe(
       cacheExchange()({ forward, client, dispatchDebug })(ops$),
@@ -2286,13 +2306,15 @@ describe('commutativity', () => {
     `;
 
     const forward = (ops$: Source<Operation>): Source<OperationResult> =>
-      merge([
-        pipe(
-          ops$,
-          filter(() => false)
-        ) as any,
-        res$,
-      ]);
+      share(
+        merge([
+          pipe(
+            ops$,
+            filter(() => false)
+          ) as any,
+          res$,
+        ])
+      );
 
     pipe(
       cacheExchange()({ forward, client, dispatchDebug })(ops$),
@@ -2438,13 +2460,15 @@ describe('commutativity', () => {
     `;
 
     const forward = (ops$: Source<Operation>): Source<OperationResult> =>
-      merge([
-        pipe(
-          ops$,
-          filter(() => false)
-        ) as any,
-        res$,
-      ]);
+      share(
+        merge([
+          pipe(
+            ops$,
+            filter(() => false)
+          ) as any,
+          res$,
+        ])
+      );
 
     pipe(
       cacheExchange()({ forward, client, dispatchDebug })(ops$),

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -295,12 +295,10 @@ export const cacheExchange =
       };
     };
 
-    return ops$ => {
-      const sharedOps$ = pipe(ops$, share);
-
+    return operations$ => {
       // Filter by operations that are cacheable and attempt to query them from the cache
       const cacheOps$ = pipe(
-        sharedOps$,
+        operations$,
         filter(
           op =>
             op.kind === 'query' && op.context.requestPolicy !== 'network-only'
@@ -310,7 +308,7 @@ export const cacheExchange =
       );
 
       const nonCacheOps$ = pipe(
-        sharedOps$,
+        operations$,
         filter(
           op =>
             op.kind !== 'query' || op.context.requestPolicy === 'network-only'
@@ -402,8 +400,7 @@ export const cacheExchange =
       const result$ = pipe(
         merge([nonCacheOps$, cacheMissOps$]),
         map(prepareForwardedOperation),
-        forward,
-        share
+        forward
       );
 
       // Results that can immediately be resolved

--- a/exchanges/graphcache/src/offlineExchange.test.ts
+++ b/exchanges/graphcache/src/offlineExchange.test.ts
@@ -8,7 +8,7 @@ import {
 import { print } from 'graphql';
 import { vi, expect, it, describe } from 'vitest';
 
-import { pipe, map, makeSubject, tap, publish } from 'wonka';
+import { pipe, share, map, makeSubject, tap, publish } from 'wonka';
 import { queryResponse } from '../../../packages/core/src/test-utils';
 import { offlineExchange } from './offlineExchange';
 
@@ -88,7 +88,7 @@ describe('storage', () => {
 
     const { source: ops$ } = makeSubject<Operation>();
     const result = vi.fn();
-    const forward: ExchangeIO = ops$ => pipe(ops$, map(response));
+    const forward: ExchangeIO = ops$ => pipe(ops$, map(response), share);
 
     vi.useFakeTimers();
     pipe(
@@ -141,7 +141,7 @@ describe('offline', () => {
 
     const { source: ops$, next } = makeSubject<Operation>();
     const result = vi.fn();
-    const forward: ExchangeIO = ops$ => pipe(ops$, map(response));
+    const forward: ExchangeIO = ops$ => pipe(ops$, map(response), share);
 
     pipe(
       offlineExchange({
@@ -164,7 +164,7 @@ describe('offline', () => {
 
     next(mutationOp);
     expect(result).toBeCalledTimes(1);
-    expect(storage.writeMetadata).toBeCalledTimes(1);
+    expect(storage.writeMetadata).toHaveBeenCalled();
     expect(storage.writeMetadata).toHaveBeenCalledWith([
       {
         query: `mutation {
@@ -278,7 +278,7 @@ describe('offline', () => {
 
     const { source: ops$, next } = makeSubject<Operation>();
     const result = vi.fn();
-    const forward: ExchangeIO = ops$ => pipe(ops$, map(response));
+    const forward: ExchangeIO = ops$ => pipe(ops$, map(response), share);
 
     pipe(
       offlineExchange({
@@ -296,7 +296,7 @@ describe('offline', () => {
     );
 
     next(mutationOp);
-    expect(storage.writeMetadata).toBeCalledTimes(1);
+    expect(storage.writeMetadata).toHaveBeenCalled();
     expect(storage.writeMetadata).toHaveBeenCalledWith([
       {
         query: `mutation {
@@ -313,7 +313,7 @@ describe('offline', () => {
     await onOnlineCalled;
 
     flush!();
-    expect(reexecuteOperation).toHaveBeenCalledTimes(1);
+    expect(reexecuteOperation).toHaveBeenCalled();
     expect((reexecuteOperation.mock.calls[0][0] as any).key).toEqual(1);
     expect(print((reexecuteOperation.mock.calls[0][0] as any).query)).toEqual(
       print(gql`

--- a/exchanges/graphcache/src/offlineExchange.ts
+++ b/exchanges/graphcache/src/offlineExchange.ts
@@ -1,4 +1,4 @@
-import { pipe, merge, makeSubject, share, filter } from 'wonka';
+import { pipe, merge, makeSubject, filter } from 'wonka';
 import { print, SelectionNode } from 'graphql';
 
 import {
@@ -214,10 +214,8 @@ export const offlineExchange =
         forward,
       });
 
-      return ops$ => {
-        const sharedOps$ = pipe(ops$, share);
-
-        const opsAndRebound$ = merge([reboundOps$, sharedOps$]);
+      return operations$ => {
+        const opsAndRebound$ = merge([reboundOps$, operations$]);
 
         return pipe(
           cacheResults$(opsAndRebound$),

--- a/exchanges/multipart-fetch/src/multipartFetchExchange.ts
+++ b/exchanges/multipart-fetch/src/multipartFetchExchange.ts
@@ -1,4 +1,4 @@
-import { filter, merge, mergeMap, pipe, share, takeUntil, onPush } from 'wonka';
+import { filter, merge, mergeMap, pipe, takeUntil, onPush } from 'wonka';
 import { extractFiles } from 'extract-files';
 import { Exchange } from '@urql/core';
 
@@ -15,16 +15,15 @@ import {
  */
 export const multipartFetchExchange: Exchange =
   ({ forward, dispatchDebug }) =>
-  ops$ => {
-    const sharedOps$ = share(ops$);
+  operations$ => {
     const fetchResults$ = pipe(
-      sharedOps$,
+      operations$,
       filter(operation => {
         return operation.kind === 'query' || operation.kind === 'mutation';
       }),
       mergeMap(operation => {
         const teardown$ = pipe(
-          sharedOps$,
+          operations$,
           filter(op => op.kind === 'teardown' && op.key === operation.key)
         );
 
@@ -100,7 +99,7 @@ export const multipartFetchExchange: Exchange =
     );
 
     const forward$ = pipe(
-      sharedOps$,
+      operations$,
       filter(operation => {
         return operation.kind !== 'query' && operation.kind !== 'mutation';
       }),

--- a/exchanges/persisted/src/persistedExchange.ts
+++ b/exchanges/persisted/src/persistedExchange.ts
@@ -6,7 +6,6 @@ import {
   merge,
   mergeMap,
   pipe,
-  share,
 } from 'wonka';
 
 import {
@@ -131,15 +130,14 @@ export const persistedExchange =
 
     return operations$ => {
       const retries = makeSubject<Operation>();
-      const sharedOps$ = share(operations$);
 
       const forwardedOps$ = pipe(
-        sharedOps$,
+        operations$,
         filter(operation => !operationFilter(operation))
       );
 
       const persistedOps$ = pipe(
-        sharedOps$,
+        operations$,
         filter(operationFilter),
         map(async operation => {
           const persistedOperation = makeOperation(operation.kind, operation, {

--- a/packages/core/src/exchanges/cache.ts
+++ b/packages/core/src/exchanges/cache.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
-import { filter, map, merge, pipe, share, tap } from 'wonka';
+import { filter, map, merge, pipe, tap } from 'wonka';
 
 import { Client } from '../client';
 import { Exchange, Operation, OperationResult } from '../types';
@@ -55,10 +55,8 @@ export const cacheExchange: Exchange = ({ forward, client, dispatchDebug }) => {
       resultCache.has(operation.key));
 
   return ops$ => {
-    const sharedOps$ = share(ops$);
-
     const cachedOps$ = pipe(
-      sharedOps$,
+      ops$,
       filter(op => !shouldSkip(op) && isOperationCached(op)),
       map(operation => {
         const cachedResult = resultCache.get(operation.key);
@@ -98,12 +96,12 @@ export const cacheExchange: Exchange = ({ forward, client, dispatchDebug }) => {
     const forwardedOps$ = pipe(
       merge([
         pipe(
-          sharedOps$,
+          ops$,
           filter(op => !shouldSkip(op) && !isOperationCached(op)),
           map(mapTypeNames)
         ),
         pipe(
-          sharedOps$,
+          ops$,
           filter(op => shouldSkip(op))
         ),
       ]),

--- a/packages/core/src/exchanges/compose.ts
+++ b/packages/core/src/exchanges/compose.ts
@@ -1,3 +1,4 @@
+import { share } from 'wonka';
 import type { ExchangeIO, Exchange, ExchangeInput } from '../types';
 
 /** Composes an array of Exchanges into a single one.
@@ -21,7 +22,9 @@ export const composeExchanges =
       (forward, exchange) =>
         exchange({
           client,
-          forward,
+          forward(operations$) {
+            return share(forward(share(operations$)));
+          },
           dispatchDebug(event) {
             dispatchDebug({
               timestamp: Date.now(),

--- a/packages/core/src/exchanges/fetch.ts
+++ b/packages/core/src/exchanges/fetch.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
-import { filter, merge, mergeMap, pipe, share, takeUntil, onPush } from 'wonka';
+import { filter, merge, mergeMap, pipe, takeUntil, onPush } from 'wonka';
 
 import { Exchange } from '../types';
 import {
@@ -28,9 +28,8 @@ import {
  */
 export const fetchExchange: Exchange = ({ forward, dispatchDebug }) => {
   return ops$ => {
-    const sharedOps$ = share(ops$);
     const fetchResults$ = pipe(
-      sharedOps$,
+      ops$,
       filter(operation => {
         return operation.kind === 'query' || operation.kind === 'mutation';
       }),
@@ -53,7 +52,7 @@ export const fetchExchange: Exchange = ({ forward, dispatchDebug }) => {
           makeFetchSource(operation, url, fetchOptions),
           takeUntil(
             pipe(
-              sharedOps$,
+              ops$,
               filter(op => op.kind === 'teardown' && op.key === operation.key)
             )
           )
@@ -86,7 +85,7 @@ export const fetchExchange: Exchange = ({ forward, dispatchDebug }) => {
     );
 
     const forward$ = pipe(
-      sharedOps$,
+      ops$,
       filter(operation => {
         return operation.kind !== 'query' && operation.kind !== 'mutation';
       }),

--- a/packages/core/src/exchanges/ssr.ts
+++ b/packages/core/src/exchanges/ssr.ts
@@ -1,5 +1,5 @@
 import { GraphQLError } from 'graphql';
-import { pipe, share, filter, merge, map, tap } from 'wonka';
+import { pipe, filter, merge, map, tap } from 'wonka';
 import { Exchange, OperationResult, Operation } from '../types';
 import { addMetadata, CombinedError } from '../utils';
 import { reexecuteOperation } from './cache';
@@ -218,10 +218,8 @@ export const ssrExchange = (params: SSRExchangeParams = {}): SSRExchange => {
           ? !!params.isClient
           : !client.suspense;
 
-      const sharedOps$ = share(ops$);
-
       let forwardedOps$ = pipe(
-        sharedOps$,
+        ops$,
         filter(
           operation =>
             !data[operation.key] ||
@@ -234,7 +232,7 @@ export const ssrExchange = (params: SSRExchangeParams = {}): SSRExchange => {
       // NOTE: Since below we might delete the cached entry after accessing
       // it once, cachedOps$ needs to be merged after forwardedOps$
       let cachedOps$ = pipe(
-        sharedOps$,
+        ops$,
         filter(
           operation =>
             !!data[operation.key] &&

--- a/packages/core/src/exchanges/subscription.ts
+++ b/packages/core/src/exchanges/subscription.ts
@@ -4,7 +4,6 @@ import {
   merge,
   mergeMap,
   pipe,
-  share,
   Subscription,
   Source,
   takeUntil,
@@ -198,14 +197,13 @@ export const subscriptionExchange =
       });
 
     return ops$ => {
-      const sharedOps$ = share(ops$);
       const subscriptionResults$ = pipe(
-        sharedOps$,
+        ops$,
         filter(isSubscriptionOperationFn),
         mergeMap(operation => {
           const { key } = operation;
           const teardown$ = pipe(
-            sharedOps$,
+            ops$,
             filter(op => op.kind === 'teardown' && op.key === key)
           );
 
@@ -217,7 +215,7 @@ export const subscriptionExchange =
       );
 
       const forward$ = pipe(
-        sharedOps$,
+        ops$,
         filter(op => !isSubscriptionOperationFn(op)),
         forward
       );

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -670,6 +670,21 @@ export interface ExchangeInput {
  *
  * @see {@link https://urql.dev/goto/docs/architecture/#the-client-and-exchanges} for more information on Exchanges.
  * @see {@link https://urql.dev/goto/docs/advanced/authoring-exchanges} on how Exchanges are authored.
+ *
+ * @example
+ * ```ts
+ * import { pipe, onPush } from 'wonka';
+ * import { Exchange } from '@urql/core';
+ *
+ * const debugExchange: Exchange => {
+ *   return ops$ => pipe(
+ *     ops$,
+ *     onPush(operation => console.log(operation)),
+ *     forward,
+ *     onPush(result => console.log(result)),
+ *   );
+ * };
+ * ```
  */
 export type Exchange = (input: ExchangeInput) => ExchangeIO;
 


### PR DESCRIPTION
## Summary

This is a small quality of life improvement for the `composeExchanges` helper in `@urql/core` that should make it easier for users to write and understand `Exchange`s.
It simply removes the need for `share` to be called manually on `Exchange`s by wrapping the `ExchangeIO` function in share calls automatically.

This shortens our docs on "Authoring Exchanges" by a whole large section, simplifies some exchanges, and shouldn't have any negative consequences, except for mocked `ExchangeIO` in tests requiring a `share` call now.

## Set of changes

- Wrap `forward`'s argument and return value in `share` in `composeExchanges`
- Add invariant in development that enforces exchanges to call `forward` just once
- Update all exchanges to remove redundant `share` calls