### PR TITLE
feat(core): Add support for graphql.js’ built-in TypedQueryDocumentNode

### DIFF
--- a/.changeset/hungry-panthers-fly.md
+++ b/.changeset/hungry-panthers-fly.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Add support for `graphql`’s built-in `TypedQueryDocumentNode` typings for type inference.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,4 +1,4 @@
-import type { GraphQLError, DocumentNode } from 'graphql';
+import type { GraphQLError, DocumentNode, DefinitionNode } from 'graphql';
 import { Subscription, Source } from 'wonka';
 import { Client } from './client';
 import { CombinedError } from './utils/error';
@@ -26,10 +26,16 @@ export interface TypedDocumentNode<
   Result = { [key: string]: any },
   Variables = { [key: string]: any }
 > extends DocumentNode {
-  /** Type to check whether `Variables` and `Result` are assignable types.
+  /** GraphQL.js Definition Nodes of the `DocumentNode`. */
+  readonly definitions: ReadonlyArray<DefinitionNode>;
+  /** Type to support `@graphql-typed-document-node/core`
    * @internal
    */
   __apiType?: (variables: Variables) => Result;
+  /** Type to support `TypedQueryDocumentNode` from `graphql`
+   * @internal
+   */
+  __ensureTypesOfVariablesAndResultMatching?: (variables: Variables) => Result;
 }
 
 /** A list of errors on {@link ExecutionResult | ExecutionResults}.


### PR DESCRIPTION
## Summary

`graphql.js` now has a built-in type for typed `DocumentNode`s, which we must adopt to support tools that rely on this type instead of `@graphql-typed-document-node/core`.

We can maintain our prior approach of having a copied type to maintain backwards- and forwards- compatibility by extending our own type with the type property carrying the types we need. The only difference to the other package is that `graphql.js` uses a different name for the property: https://github.com/graphql/graphql-js/blob/e171a14/src/utilities/typedQueryDocumentNode.ts#L8-L22

This has been tested with the following ts file:

```ts
import { Client, TypedDocumentNode } from '@urql/core';
import type { TypedQueryDocumentNode } from 'graphql';
import type { TypedDocumentNode as LegacyTypedDocumentNode } from '@graphql-typed-document-node/core';

type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
type Variables = Exact<{ [key: string]: never; }>;

const client = new Client({ url: 'test', exchanges: [] });

const x: TypedQueryDocumentNode<{ data: { hello: 'world' } }, Variables> = {} as any;
const y: LegacyTypedDocumentNode<{ data: { hello: 'world' } }, Variables> = {} as any;
const z: TypedDocumentNode<{ data: { hello: 'world' } }, Variables> = {} as any;

const { data: xData } = client.readQuery(x, {})!;
const { data: yData } = client.readQuery(y, {})!;
const { data: zData } = client.readQuery(z, {})!;

let test = xData;
test = yData;
test = zData;
```

## Set of changes

- Add `__ensureTypesOfVariablesAndResultMatching` property to `TypedDocumentNode`
