### PR TITLE
fix(core): Allow permissive passthrough for CombinedError.graphQLErrors

### DIFF
--- a/.changeset/pink-penguins-grin.md
+++ b/.changeset/pink-penguins-grin.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Allow any object fitting the `GraphQLError` shape to rehydrate without passing through a `GraphQLError` constructor in `CombinedError`.

--- a/packages/core/src/utils/error.ts
+++ b/packages/core/src/utils/error.ts
@@ -16,7 +16,11 @@ const generateErrorMessage = (
 };
 
 const rehydrateGraphQlError = (error: any): GraphQLError => {
-  if (error instanceof GraphQLError) {
+  if (
+    error &&
+    error.message &&
+    (error.extensions || error.name === 'GraphQLError')
+  ) {
     return error;
   } else if (typeof error === 'object' && error.message) {
     return new GraphQLError(


### PR DESCRIPTION
## Summary

I was reminded me of having multiple copies of `graphql`, or a future where some `graphql` imports are aliased to `@0no-co/graphql.web` or `graphql-web-lite`, but not all.

Our `CombinedError` now passes through `GraphQLError`s but it isn't yet permissive enough to allow for any object that vaguely adheres to the `GraphQLError` shape to be passed through.

## Set of changes

- Allow for any object that adheres to the `GraphQLError` shape to be passed through to `CombinedError.graphQLErrors`
