### PR TITLE
Experiment: feat(core): Switch from graphql to @0no-co/graphql.web import

### DIFF
--- a/.changeset/tame-pumas-promise.md
+++ b/.changeset/tame-pumas-promise.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Remove dependence on `import { visit } from 'graphql';` with smaller but functionally equivalent alternative.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,13 +52,8 @@
     "prepare": "node ../../scripts/prepare/index.js",
     "prepublishOnly": "run-s clean build"
   },
-  "devDependencies": {
-    "graphql": "^16.0.0"
-  },
-  "peerDependencies": {
-    "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
-  },
   "dependencies": {
+    "@0no-co/graphql.web": "^0.1.6",
     "wonka": "^6.1.2"
   },
   "publishConfig": {

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -1,4 +1,4 @@
-import { print } from 'graphql';
+import { print } from '@0no-co/graphql.web';
 import { vi, expect, it, beforeEach, describe, afterEach } from 'vitest';
 
 /** NOTE: Testing in this file is designed to test both the client and its interaction with default Exchanges */

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -22,13 +22,11 @@ import {
   Subscription,
 } from 'wonka';
 
-import { DocumentNode } from 'graphql';
-
 import { composeExchanges } from './exchanges';
 import { fallbackExchange } from './exchanges/fallback';
 
 import {
-  TypedDocumentNode,
+  DocumentInput,
   AnyVariables,
   Exchange,
   ExchangeInput,
@@ -358,7 +356,7 @@ export interface Client {
    * ```
    */
   query<Data = any, Variables extends AnyVariables = AnyVariables>(
-    query: DocumentNode | TypedDocumentNode<Data, Variables> | string,
+    query: DocumentInput<Data, Variables>,
     variables: Variables,
     context?: Partial<OperationContext>
   ): OperationResultSource<OperationResult<Data, Variables>>;
@@ -384,7 +382,7 @@ export interface Client {
    * or asynchronously.
    */
   readQuery<Data = any, Variables extends AnyVariables = AnyVariables>(
-    query: DocumentNode | TypedDocumentNode<Data, Variables> | string,
+    query: DocumentInput<Data, Variables>,
     variables: Variables,
     context?: Partial<OperationContext>
   ): OperationResult<Data, Variables> | null;
@@ -450,7 +448,7 @@ export interface Client {
    * ```
    */
   subscription<Data = any, Variables extends AnyVariables = AnyVariables>(
-    query: DocumentNode | TypedDocumentNode<Data, Variables> | string,
+    query: DocumentInput<Data, Variables>,
     variables: Variables,
     context?: Partial<OperationContext>
   ): OperationResultSource<OperationResult<Data, Variables>>;
@@ -519,7 +517,7 @@ export interface Client {
    * ```
    */
   mutation<Data = any, Variables extends AnyVariables = AnyVariables>(
-    query: DocumentNode | TypedDocumentNode<Data, Variables> | string,
+    query: DocumentInput<Data, Variables>,
     variables: Variables,
     context?: Partial<OperationContext>
   ): OperationResultSource<OperationResult<Data, Variables>>;

--- a/packages/core/src/exchanges/ssr.ts
+++ b/packages/core/src/exchanges/ssr.ts
@@ -1,4 +1,4 @@
-import { GraphQLError } from 'graphql';
+import type { GraphQLError } from '../utils/graphql';
 import { pipe, filter, merge, map, tap } from 'wonka';
 import { Exchange, OperationResult, Operation } from '../types';
 import { addMetadata, CombinedError } from '../utils';

--- a/packages/core/src/gql.test.ts
+++ b/packages/core/src/gql.test.ts
@@ -1,4 +1,4 @@
-import { parse, print } from 'graphql';
+import { parse, print } from '@0no-co/graphql.web';
 import { vi, expect, it, beforeEach, SpyInstance } from 'vitest';
 
 import { gql } from './gql';

--- a/packages/core/src/gql.ts
+++ b/packages/core/src/gql.ts
@@ -1,5 +1,6 @@
 /* eslint-disable prefer-rest-params */
-import { DocumentNode, DefinitionNode, Kind } from 'graphql';
+import { Kind } from '@0no-co/graphql.web';
+import type { DocumentNode, DefinitionNode } from './utils/graphql';
 import { AnyVariables, TypedDocumentNode } from './types';
 import { keyDocument, stringifyDocument } from './utils';
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,4 +1,8 @@
-import type { GraphQLError, DocumentNode, DefinitionNode } from 'graphql';
+import type {
+  GraphQLError,
+  DocumentNode,
+  DefinitionNode,
+} from './utils/graphql';
 import { Subscription, Source } from 'wonka';
 import { Client } from './client';
 import { CombinedError } from './utils/error';
@@ -22,10 +26,10 @@ import { CombinedError } from './utils/error';
  *
  * @see {@link https://github.com/dotansimha/graphql-typed-document-node} for more information.
  */
-export interface TypedDocumentNode<
+export type TypedDocumentNode<
   Result = { [key: string]: any },
   Variables = { [key: string]: any }
-> extends DocumentNode {
+> = DocumentNode & {
   /** GraphQL.js Definition Nodes of the `DocumentNode`. */
   readonly definitions: ReadonlyArray<DefinitionNode>;
   /** Type to support `@graphql-typed-document-node/core`
@@ -36,12 +40,24 @@ export interface TypedDocumentNode<
    * @internal
    */
   __ensureTypesOfVariablesAndResultMatching?: (variables: Variables) => Result;
-}
+};
+
+/** Any GraphQL `DocumentNode` or query string input.
+ *
+ * @remarks
+ * Wherever any `urql` bindings or API expect a query, it accepts either a query string,
+ * a `DocumentNode`, or a {@link TypedDocumentNode}.
+ */
+export type DocumentInput<
+  Result = { [key: string]: any },
+  Variables = { [key: string]: any }
+> = string | DocumentNode | TypedDocumentNode<Result, Variables>;
 
 /** A list of errors on {@link ExecutionResult | ExecutionResults}.
  * @see {@link https://spec.graphql.org/draft/#sec-Errors.Error-Result-Format} for the GraphQL Error Result format spec.
  */
-type ErrorLike = Partial<GraphQLError> | Error;
+export type ErrorLike = Partial<GraphQLError> | Error;
+
 /** Extensions which may be placed on {@link ExecutionResult | ExecutionResults}.
  * @see {@link https://spec.graphql.org/draft/#sel-EAPHJCAACCoGu9J} for the GraphQL Error Result format spec.
  */

--- a/packages/core/src/utils/error.ts
+++ b/packages/core/src/utils/error.ts
@@ -1,4 +1,5 @@
-import { GraphQLError } from 'graphql';
+import { GraphQLError } from '@0no-co/graphql.web';
+import { ErrorLike } from '../types';
 
 const generateErrorMessage = (
   networkErr?: Error,
@@ -93,7 +94,7 @@ export class CombinedError extends Error {
 
   constructor(input: {
     networkError?: Error;
-    graphQLErrors?: Array<string | Partial<GraphQLError> | Error>;
+    graphQLErrors?: Array<string | ErrorLike>;
     response?: any;
   }) {
     const normalizedGraphQLErrors = (input.graphQLErrors || []).map(

--- a/packages/core/src/utils/graphql.ts
+++ b/packages/core/src/utils/graphql.ts
@@ -20,3 +20,7 @@ export type DocumentNode =
 export type DefinitionNode =
   | GraphQLWeb.DefinitionNode
   | OrNever<GraphQL.DefinitionNode>;
+
+export type SelectionNode =
+  | GraphQLWeb.SelectionNode
+  | OrNever<GraphQL.SelectionNode>;

--- a/packages/core/src/utils/graphql.ts
+++ b/packages/core/src/utils/graphql.ts
@@ -1,0 +1,22 @@
+import type * as GraphQLWeb from '@0no-co/graphql.web';
+import type * as GraphQL from 'graphql';
+
+type OrNever<T> = 0 extends 1 & T ? never : T;
+
+export type FieldNode = GraphQLWeb.FieldNode | OrNever<GraphQL.FieldNode>;
+
+export type InlineFragmentNode =
+  | GraphQLWeb.InlineFragmentNode
+  | OrNever<GraphQL.InlineFragmentNode>;
+
+export type GraphQLError =
+  | GraphQLWeb.GraphQLError
+  | OrNever<GraphQL.GraphQLError>;
+
+export type DocumentNode =
+  | GraphQLWeb.DocumentNode
+  | OrNever<GraphQL.DocumentNode>;
+
+export type DefinitionNode =
+  | GraphQLWeb.DefinitionNode
+  | OrNever<GraphQL.DefinitionNode>;

--- a/packages/core/src/utils/request.test.ts
+++ b/packages/core/src/utils/request.test.ts
@@ -1,6 +1,6 @@
 import { expect, it, describe } from 'vitest';
 
-import { parse, print } from 'graphql';
+import { parse, print } from '@0no-co/graphql.web';
 import { gql } from '../gql';
 import { createRequest, stringifyDocument } from './request';
 import { formatDocument } from './typenames';

--- a/packages/core/src/utils/request.ts
+++ b/packages/core/src/utils/request.ts
@@ -1,32 +1,22 @@
-import {
-  Location,
-  DefinitionNode,
-  DocumentNode,
-  Kind,
-  parse,
-  print,
-} from 'graphql';
-
+import { Kind, parse, print } from '@0no-co/graphql.web';
+import type { DocumentNode, DefinitionNode } from './graphql';
 import { HashValue, phash } from './hash';
 import { stringifyVariables } from './variables';
 
 import type {
+  DocumentInput,
   TypedDocumentNode,
   AnyVariables,
   GraphQLRequest,
   RequestExtensions,
 } from '../types';
 
-interface WritableLocation {
-  loc: Location | undefined;
-}
-
 /** A `DocumentNode` annotated with its hashed key.
  * @internal
  */
-export interface KeyedDocumentNode extends DocumentNode {
+export type KeyedDocumentNode = TypedDocumentNode & {
   __key: HashValue;
-}
+};
 
 const SOURCE_NAME = 'gql';
 const GRAPHQL_STRING_RE = /("{3}[\s\S]*"{3}|"(?:\\.|[^"])*")/g;
@@ -70,7 +60,7 @@ export const stringifyDocument = (
   }
 
   if (typeof node !== 'string' && !node.loc) {
-    (node as WritableLocation).loc = {
+    (node as any).loc = {
       start: 0,
       end: printed.length,
       source: {
@@ -78,7 +68,7 @@ export const stringifyDocument = (
         name: SOURCE_NAME,
         locationOffset: { line: 1, column: 1 },
       },
-    } as Location;
+    };
   }
 
   return printed;
@@ -157,7 +147,7 @@ export const createRequest = <
   Data = any,
   Variables extends AnyVariables = AnyVariables
 >(
-  _query: string | DocumentNode | TypedDocumentNode<Data, Variables>,
+  _query: DocumentInput<Data, Variables>,
   _variables: Variables,
   extensions?: RequestExtensions | undefined
 ): GraphQLRequest<Data, Variables> => {

--- a/packages/core/src/utils/typenames.test.ts
+++ b/packages/core/src/utils/typenames.test.ts
@@ -1,4 +1,4 @@
-import { parse, print } from 'graphql';
+import { parse, print } from '@0no-co/graphql.web';
 import { describe, it, expect } from 'vitest';
 import { collectTypesFromResponse, formatDocument } from './typenames';
 import { createRequest } from './request';

--- a/packages/core/src/utils/typenames.ts
+++ b/packages/core/src/utils/typenames.ts
@@ -1,7 +1,5 @@
-import { Kind, visit } from '@0no-co/graphql.web';
-
-import type { DocumentNode, FieldNode, InlineFragmentNode } from './graphql';
-
+import { Kind } from '@0no-co/graphql.web';
+import type { DocumentNode, SelectionNode, DefinitionNode } from './graphql';
 import { KeyedDocumentNode, keyDocument } from './request';
 
 interface EntityLike {
@@ -35,32 +33,49 @@ export const collectTypesFromResponse = (response: object): string[] => [
   ...collectTypes(response as EntityLike, new Set()),
 ];
 
-const formatNode = (node: FieldNode | InlineFragmentNode) => {
-  if (!node.selectionSet) return node;
-  for (const selection of node.selectionSet.selections)
-    if (
-      selection.kind === Kind.FIELD &&
-      selection.name.value === '__typename' &&
-      !selection.alias
-    )
-      return node;
+const formatNode = <T extends SelectionNode | DefinitionNode | DocumentNode>(
+  node: T
+): T => {
+  let hasChanged = false;
 
-  return {
-    ...node,
-    selectionSet: {
-      ...node.selectionSet,
-      selections: [
-        ...node.selectionSet.selections,
-        {
+  if ('definitions' in node) {
+    const definitions: DefinitionNode[] = [];
+    for (const definition of node.definitions) {
+      const newDefinition = formatNode(definition);
+      hasChanged = hasChanged || newDefinition !== definition;
+      definitions.push(newDefinition);
+    }
+    if (hasChanged) return { ...node, definitions };
+  } else if ('selectionSet' in node) {
+    const selections: SelectionNode[] = [];
+    let hasTypename = node.kind === Kind.OPERATION_DEFINITION;
+    if (node.selectionSet) {
+      for (const selection of node.selectionSet.selections || []) {
+        hasTypename =
+          hasTypename ||
+          (selection.kind === Kind.FIELD &&
+            selection.name.value === '__typename' &&
+            !selection.alias);
+        const newSelection = formatNode(selection);
+        hasChanged = hasChanged || newSelection !== selection;
+        selections.push(newSelection);
+      }
+      if (!hasTypename) {
+        hasChanged = true;
+        selections.push({
           kind: Kind.FIELD,
           name: {
             kind: Kind.NAME,
             value: '__typename',
           },
-        },
-      ],
-    },
-  };
+        });
+      }
+      if (hasChanged)
+        return { ...node, selectionSet: { ...node.selectionSet, selections } };
+    }
+  }
+
+  return node;
 };
 
 const formattedDocs = new Map<number, KeyedDocumentNode>();
@@ -88,11 +103,10 @@ export const formatDocument = <T extends DocumentNode>(node: T): T => {
 
   let result = formattedDocs.get(query.__key);
   if (!result) {
-    result = visit(query, {
-      Field: formatNode,
-      InlineFragment: formatNode,
-    }) as KeyedDocumentNode;
-
+    formattedDocs.set(
+      query.__key,
+      (result = formatNode(query) as KeyedDocumentNode)
+    );
     // Ensure that the hash of the resulting document won't suddenly change
     // we are marking __key as non-enumerable so when external exchanges use visit
     // to manipulate a document we won't restore the previous query due to the __key
@@ -101,8 +115,6 @@ export const formatDocument = <T extends DocumentNode>(node: T): T => {
       value: query.__key,
       enumerable: false,
     });
-
-    formattedDocs.set(query.__key, result);
   }
 
   return result as unknown as T;

--- a/packages/core/src/utils/typenames.ts
+++ b/packages/core/src/utils/typenames.ts
@@ -1,10 +1,6 @@
-import {
-  DocumentNode,
-  FieldNode,
-  InlineFragmentNode,
-  Kind,
-  visit,
-} from 'graphql';
+import { Kind, visit } from '@0no-co/graphql.web';
+
+import type { DocumentNode, FieldNode, InlineFragmentNode } from './graphql';
 
 import { KeyedDocumentNode, keyDocument } from './request';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,12 +253,11 @@ importers:
 
   packages/core:
     specifiers:
-      graphql: ^16.6.0
+      '@0no-co/graphql.web': ^0.1.6
       wonka: ^6.2.4
     dependencies:
+      '@0no-co/graphql.web': 0.1.6
       wonka: 6.2.4
-    devDependencies:
-      graphql: 16.6.0
 
   packages/introspection:
     specifiers:
@@ -467,6 +466,10 @@ importers:
       vue: 3.2.47
 
 packages:
+
+  /@0no-co/graphql.web/0.1.6:
+    resolution: {integrity: sha512-HUFsLTSjX6sTdK+CyoHNs71h0HneugTO6nQS8WwxFGarmAh3doKwZRVY39xLkdOmneSKJZIHRysjf+odHHBFhw==}
+    dev: false
 
   /@actions/artifact/1.1.1:
     resolution: {integrity: sha512-Vv4y0EW0ptEkU+Pjs5RGS/0EryTvI6s79LjSV9Gg/h+O3H/ddpjhuX/Bi/HZE4pbNPyjGtQjbdFWphkZhmgabA==}
@@ -9702,6 +9705,8 @@ packages:
 
   /match-sorter/3.1.1:
     resolution: {integrity: sha512-Qlox3wRM/Q4Ww9rv1cBmYKNJwWVX/WC+eA3+1S3Fv4EOhrqyp812ZEfVFKQk0AP6RfzmPUUOwEZBbJ8IRt8SOw==}
+    dependencies:
+      remove-accents: 0.4.2
     bundledDependencies:
       - remove-accents
 
@@ -12695,6 +12700,9 @@ packages:
       remark-stringify: 7.0.4
       unified: 8.4.2
     dev: false
+
+  /remove-accents/0.4.2:
+    resolution: {integrity: sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA==}
 
   /remove-trailing-separator/1.1.0:
     resolution: {integrity: sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==}

--- a/scripts/rollup/cleanup-plugin.mjs
+++ b/scripts/rollup/cleanup-plugin.mjs
@@ -24,6 +24,7 @@ function removeEmptyImports({ types: t }) {
 
 function cleanup() {
   const emptyImportRe = /import\s+(?:'[^']+'|"[^"]+")\s*;?/g;
+  const gqlImportRe = /(import\s+(?:[*\s{}\w\d]+)\s*from\s*'graphql';?)/g;
   const jsFilter = createFilter(/.m?js$/, null, { resolve: false });
   const dtsFilter = createFilter(/\.d\.ts(\.map)?$/, null, { resolve: false });
 
@@ -37,7 +38,9 @@ function cleanup() {
           babelrc: false
         });
       } else if (dtsFilter(chunk.fileName)) {
-        return code.replace(emptyImportRe, '');
+        return code
+          .replace(emptyImportRe, '')
+          .replace(gqlImportRe, x => '/*!@ts-ignore*/\n' + x);
       }
     },
   };


### PR DESCRIPTION
**Note:** This currently only tests feasibility and outcome of what it would look like if `@urql/core` (et al) shipped with a leaner default implementation of `graphql` internals via `@0no-co/graphql.web` while still staying TS-type compatible with `graphql`.
