### PR TITLE
fix(graphcache): Use stringifyDocument in offlineExchange and support extensions

### DIFF
--- a/.changeset/giant-flies-exercise.md
+++ b/.changeset/giant-flies-exercise.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Use `stringifyDocument` in `offlineExchange` rather than `print` and serialize `operation.extensions` as needed.

--- a/exchanges/graphcache/src/offlineExchange.ts
+++ b/exchanges/graphcache/src/offlineExchange.ts
@@ -135,8 +135,9 @@ export const offlineExchange =
           const operation = failedQueue[i];
           if (operation.kind === 'mutation') {
             requests.push({
-              query: stringifyDocument(ooperation.query),
+              query: stringifyDocument(operation.query),
               variables: operation.variables,
+              extensions: operation.extensions,
             });
           }
         }
@@ -191,7 +192,8 @@ export const offlineExchange =
               failedQueue.push(
                 client.createRequestOperation(
                   'mutation',
-                  createRequest(mutations[i].query, mutations[i].variables)
+                  createRequest(mutations[i].query, mutations[i].variables),
+                  mutations[i].extensions
                 )
               );
             }

--- a/exchanges/graphcache/src/offlineExchange.ts
+++ b/exchanges/graphcache/src/offlineExchange.ts
@@ -1,5 +1,5 @@
 import { pipe, merge, makeSubject, filter } from 'wonka';
-import { print, SelectionNode } from 'graphql';
+import { SelectionNode } from 'graphql';
 
 import {
   Operation,
@@ -7,6 +7,7 @@ import {
   Exchange,
   ExchangeIO,
   CombinedError,
+  stringifyDocument,
   createRequest,
   makeOperation,
 } from '@urql/core';
@@ -134,7 +135,7 @@ export const offlineExchange =
           const operation = failedQueue[i];
           if (operation.kind === 'mutation') {
             requests.push({
-              query: print(operation.query),
+              query: stringifyDocument(ooperation.query),
               variables: operation.variables,
             });
           }

--- a/exchanges/graphcache/src/types.ts
+++ b/exchanges/graphcache/src/types.ts
@@ -1,4 +1,4 @@
-import { AnyVariables, TypedDocumentNode } from '@urql/core';
+import { AnyVariables, TypedDocumentNode, RequestExtensions } from '@urql/core';
 import { GraphQLError, DocumentNode, FragmentDefinitionNode } from 'graphql';
 import { IntrospectionData } from './ast';
 
@@ -888,7 +888,8 @@ export interface SerializedEntries {
 /** A serialized GraphQL request for offline storage. */
 export interface SerializedRequest {
   query: string;
-  variables: AnyVariables;
+  variables: AnyVariables | undefined;
+  extensions: RequestExtensions | undefined;
 }
 
 /** Interface for a storage adapter, used by the {@link offlineExchange} for Offline Support.

--- a/exchanges/graphcache/src/types.ts
+++ b/exchanges/graphcache/src/types.ts
@@ -889,7 +889,7 @@ export interface SerializedEntries {
 export interface SerializedRequest {
   query: string;
   variables: AnyVariables | undefined;
-  extensions: RequestExtensions | undefined;
+  extensions?: RequestExtensions | undefined;
 }
 
 /** Interface for a storage adapter, used by the {@link offlineExchange} for Offline Support.


### PR DESCRIPTION
## Summary

Adds missing `operation.extensions` serialization and replaces `print()` usage with `stringifyDocument()` from `@urql/core`

## Set of changes

- Replace `print` with `stringifyDocument`
- Serialize `operation.extensions`
