### PR TITLE
fix(react-urql): Silence react render phase warning

### DIFF
--- a/.changeset/good-ads-watch.md
+++ b/.changeset/good-ads-watch.md
@@ -1,0 +1,5 @@
+---
+'urql': patch
+---
+
+Silence "Cannot update a component (%s) while rendering a different component (%s)." warning forcefully.

--- a/packages/react-urql/src/hooks/state.ts
+++ b/packages/react-urql/src/hooks/state.ts
@@ -52,6 +52,7 @@ export function deferDispatch<Dispatch extends React.Dispatch<any>>(
   value: Dispatch extends React.Dispatch<infer State> ? State : void
 ) {
   if (
+    process.env.NODE_ENV !== 'production' &&
     !!reactSharedInternals &&
     !!reactSharedInternals.ReactCurrentOwner &&
     !!reactSharedInternals.ReactCurrentOwner.current

--- a/packages/react-urql/src/hooks/state.ts
+++ b/packages/react-urql/src/hooks/state.ts
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 export const initialState = {
   fetching: false,
   stale: false,
@@ -41,3 +43,21 @@ export const hasDepsChanged = <T extends { length: number }>(a: T, b: T) => {
   for (let i = 0, l = b.length; i < l; i++) if (a[i] !== b[i]) return true;
   return false;
 };
+
+const reactSharedInternals = (React as any)
+  .__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
+
+export function deferDispatch<Dispatch extends React.Dispatch<any>>(
+  setState: Dispatch,
+  value: Dispatch extends React.Dispatch<infer State> ? State : void
+) {
+  if (
+    !!reactSharedInternals &&
+    !!reactSharedInternals.ReactCurrentOwner &&
+    !!reactSharedInternals.ReactCurrentOwner.current
+  ) {
+    Promise.resolve(value).then(setState);
+  } else {
+    setState(value);
+  }
+}

--- a/packages/react-urql/src/hooks/useMutation.ts
+++ b/packages/react-urql/src/hooks/useMutation.ts
@@ -13,7 +13,7 @@ import {
 } from '@urql/core';
 
 import { useClient } from '../context';
-import { initialState } from './state';
+import { deferDispatch, initialState } from './state';
 
 /** State of the last mutation executed by your {@link useMutation} hook.
  *
@@ -155,7 +155,7 @@ export function useMutation<
 
   const executeMutation = useCallback(
     (variables: Variables, context?: Partial<OperationContext>) => {
-      setState({ ...initialState, fetching: true });
+      deferDispatch(setState, { ...initialState, fetching: true });
 
       return pipe(
         client.executeMutation<Data, Variables>(
@@ -165,7 +165,7 @@ export function useMutation<
         toPromise
       ).then(result => {
         if (isMounted.current) {
-          setState({
+          deferDispatch(setState, {
             fetching: false,
             stale: !!result.stale,
             data: result.data,

--- a/packages/react-urql/src/hooks/useQuery.ts
+++ b/packages/react-urql/src/hooks/useQuery.ts
@@ -17,7 +17,13 @@ import {
 import { useClient } from '../context';
 import { useRequest } from './useRequest';
 import { getCacheForClient } from './cache';
-import { initialState, computeNextState, hasDepsChanged } from './state';
+
+import {
+  deferDispatch,
+  initialState,
+  computeNextState,
+  hasDepsChanged,
+} from './state';
 
 /** Input arguments for the {@link useQuery} hook.
  *
@@ -317,7 +323,7 @@ export function useQuery<
 
     const updateResult = (result: Partial<UseQueryState<Data, Variables>>) => {
       hasResult = true;
-      setState(state => {
+      deferDispatch(setState, state => {
         const nextResult = computeNextState(state[1], result);
         return state[1] !== nextResult
           ? [state[0], nextResult, state[2]]
@@ -353,7 +359,7 @@ export function useQuery<
         ...opts,
       };
 
-      setState(state => {
+      deferDispatch(setState, state => {
         const source = suspense
           ? pipe(
               client.executeQuery(request, context),

--- a/packages/react-urql/src/hooks/useSubscription.ts
+++ b/packages/react-urql/src/hooks/useSubscription.ts
@@ -13,7 +13,13 @@ import {
 
 import { useClient } from '../context';
 import { useRequest } from './useRequest';
-import { initialState, computeNextState, hasDepsChanged } from './state';
+
+import {
+  deferDispatch,
+  initialState,
+  computeNextState,
+  hasDepsChanged,
+} from './state';
 
 /** Input arguments for the {@link useSubscription} hook.
  *
@@ -257,7 +263,7 @@ export function useSubscription<
     const updateResult = (
       result: Partial<UseSubscriptionState<Data, Variables>>
     ) => {
-      setState(state => {
+      deferDispatch(setState, state => {
         const nextResult = computeNextState(state[1], result);
         if (state[1] === nextResult) return state;
         if (handlerRef.current && state[1].data !== nextResult.data) {
@@ -292,7 +298,7 @@ export function useSubscription<
         ...opts,
       });
 
-      setState(state => [source, state[1], deps]);
+      deferDispatch(setState, state => [source, state[1], deps]);
     },
     [client, args.context, request]
   );


### PR DESCRIPTION
Resolves #3088

## Summary

> **Background Note:** To be honest, I'm really sick of having to explain that this is safe to ignore and does what it's supposed to, so instead, I've decided that it's best to add a small check to silence the warning.

This is hard to reproduce, so I'm not sure if it's effective in all cases.

**Explanation:** When a different component, during its update cycle — or an external store/function during an update cycle — triggers a side-effect that dispatches a query to the `Client`, which then sends a new result to a component using `useQuery` synchronously, React will be inside a render phase and will receive an update.

This is fine. React is designed to handle updates during render phases. In fact, in other cases it doesn't actually output a warning. This warning is designed to actually catch an entirely different host of issues.

It could be argued that we're likely never responsible for triggering such a side-effect during renders. This is why it's still rare for us to get these issues. They often have different causes where different effects often “happen” to resolve synchronously during a render cycle.

In React Native, based on Promise issues we’ve seen, I suspect this actually happens due to some kind of trampoline scheduler + batching logic, which triggers render updates and effects in one synchronous tick at times.
This can also happen in other libraries, which happen to call events while they’re returning data. One would assume this is fine... because it is. React has to handle this, otherwise this kind of defer logic would always have to be added somewhere.

In short, when applied, this PR adds a micro-tick defer to any `setState` call that may happen during a render cycle (i.e. inside `subscribe` or `executeQuery` functions). These `setState` calls are at risk of happening in the same tick as a render phase.

When we detect, in development, that we're inside a render phase, we simply defer the `setState` call. This risks tearing, but is preferable to having to explain that the warning can be ignored. There may be a more hidden way of silencing the warning with some kind of lane/fiber flag, but I really don't want to dig any deeper.

For code that triggers this warning; See: https://github.com/facebook/react/blob/9c54b29b44d24f8f8090da9c7ebf569747a444df/packages/react-reconciler/src/ReactFiberWorkLoop.js#L4100-L4102

Edit: Also, the reason why this wouldn't trigger for `useSyncExternalStore` is likely because it has some flags if it ends up calling `scheduleUpdateOnFiber` with the update: https://github.com/facebook/react/blob/9c54b29b44d24f8f8090da9c7ebf569747a444df/packages/react-reconciler/src/ReactFiberHooks.js#L1819-L1824
It likely also behaves slightly differently with that `SyncLane` logic, presumably bypassing some concurrent update logic.

## Set of changes

- Defer `setState` calls in subscribable callbacks and imperative execute functions
