### PR TITLE
fix(core): Add missing dedupe operation logic

### DIFF
--- a/.changeset/afraid-geckos-raise.md
+++ b/.changeset/afraid-geckos-raise.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Deduplicate operations as the `dedupExchange` did; by filtering out duplicate operations until either the original operation has been cancelled (teardown) or a first result (without `hasNext: true`) has come in.


### PR DESCRIPTION
## Summary

This adds the missing logic that handles deduplication before a response has come back for a query or subscription operation. While we already ported logic from the `dedupExchange` to the `Client` that disallowed sending new operations for operations that currently have a `hasNext` flag set or are active, we now also take care of dispatched operations that haven't received a response yet.

The tests validate that the behaviour is equivalent to before and that operations are dispatched when `reexecuteOperation` is called, since those are on a delay, so that reexecutions can come through, for `requestPolicy` upgrades (e.g. for `cache-and-network`)

## Set of changes

- Add missing `teardown` and `dispatched` checks to `Client` for `dedupExchange` replacement logic
