### PR TITLE
refactor(bindings): Allow hasNext mutation results to update repeatedly

### DIFF
--- a/.changeset/mighty-nails-learn.md
+++ b/.changeset/mighty-nails-learn.md
@@ -1,0 +1,8 @@
+---
+'@urql/preact': minor
+'@urql/svelte': minor
+'urql': minor
+'@urql/vue': minor
+---
+
+Allow mutations to update their results in bindings when `hasNext: true` is set, which indicates deferred or streamed results.

--- a/packages/preact-urql/src/hooks/useMutation.ts
+++ b/packages/preact-urql/src/hooks/useMutation.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useRef, useEffect } from 'preact/hooks';
-import { pipe, toPromise } from 'wonka';
+import { pipe, onPush, filter, toPromise, take } from 'wonka';
 
 import {
   AnyVariables,
@@ -153,26 +153,27 @@ export function useMutation<
   const executeMutation = useCallback(
     (variables: Variables, context?: Partial<OperationContext>) => {
       setState({ ...initialState, fetching: true });
-
       return pipe(
         client.executeMutation<Data, Variables>(
           createRequest<Data, Variables>(query, variables),
           context || {}
         ),
+        onPush(result => {
+          if (isMounted.current) {
+            setState({
+              fetching: false,
+              stale: result.stale,
+              data: result.data,
+              error: result.error,
+              extensions: result.extensions,
+              operation: result.operation,
+            });
+          }
+        }),
+        filter(result => !result.hasNext),
+        take(1),
         toPromise
-      ).then(result => {
-        if (isMounted.current) {
-          setState({
-            fetching: false,
-            stale: !!result.stale,
-            data: result.data,
-            error: result.error,
-            extensions: result.extensions,
-            operation: result.operation,
-          });
-        }
-        return result;
-      });
+      );
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [client, query, setState]

--- a/packages/react-urql/src/hooks/useMutation.ts
+++ b/packages/react-urql/src/hooks/useMutation.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
-import { pipe, toPromise } from 'wonka';
+import { pipe, onPush, filter, toPromise, take } from 'wonka';
 
 import {
   AnyVariables,
@@ -153,26 +153,27 @@ export function useMutation<
   const executeMutation = useCallback(
     (variables: Variables, context?: Partial<OperationContext>) => {
       deferDispatch(setState, { ...initialState, fetching: true });
-
       return pipe(
         client.executeMutation<Data, Variables>(
           createRequest<Data, Variables>(query, variables),
           context || {}
         ),
+        onPush(result => {
+          if (isMounted.current) {
+            deferDispatch(setState, {
+              fetching: false,
+              stale: result.stale,
+              data: result.data,
+              error: result.error,
+              extensions: result.extensions,
+              operation: result.operation,
+            });
+          }
+        }),
+        filter(result => !result.hasNext),
+        take(1),
         toPromise
-      ).then(result => {
-        if (isMounted.current) {
-          deferDispatch(setState, {
-            fetching: false,
-            stale: !!result.stale,
-            data: result.data,
-            error: result.error,
-            extensions: result.extensions,
-            operation: result.operation,
-          });
-        }
-        return result;
-      });
+      );
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [client, query, setState]

--- a/packages/svelte-urql/src/mutationStore.ts
+++ b/packages/svelte-urql/src/mutationStore.ts
@@ -112,7 +112,7 @@ export function mutationStore<
       args.client.executeRequestOperation(operation),
       map(({ stale, data, error, extensions, operation }) => ({
         fetching: false,
-        stale: !!stale,
+        stale,
         data,
         error,
         operation,


### PR DESCRIPTION
Related #3102

## Summary

This allows all bindings to handle mutations with multiple results, as indicated by the `hasNext: true` flag on their results.

## Set of changes

- Add `onPush` logic to each bindings’ mutation handler and apply `filter(...), take(1), toPromise`
