### PR TITLE
chore: Upgrade to wonka@^6.3.0

### DIFF
--- a/.changeset/eighty-pigs-joke.md
+++ b/.changeset/eighty-pigs-joke.md
@@ -1,0 +1,19 @@
+---
+'@urql/exchange-multipart-fetch': patch
+'@urql/exchange-request-policy': patch
+'@urql/exchange-graphcache': patch
+'@urql/preact': patch
+'@urql/svelte': patch
+'@urql/exchange-persisted': patch
+'urql': patch
+'@urql/exchange-populate': patch
+'@urql/exchange-context': patch
+'@urql/exchange-execute': patch
+'@urql/exchange-refocus': patch
+'@urql/vue': patch
+'@urql/exchange-retry': patch
+'@urql/exchange-auth': patch
+'@urql/core': patch
+---
+
+Upgrade to `wonka@^6.3.0`

--- a/exchanges/auth/package.json
+++ b/exchanges/auth/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@urql/core": ">=3.2.2",
-    "wonka": "^6.2.6"
+    "wonka": "^6.3.0"
   },
   "devDependencies": {
     "@urql/core": "workspace:*",

--- a/exchanges/context/package.json
+++ b/exchanges/context/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@urql/core": ">=3.2.2",
-    "wonka": "^6.2.6"
+    "wonka": "^6.3.0"
   },
   "devDependencies": {
     "@urql/core": "workspace:*",

--- a/exchanges/execute/package.json
+++ b/exchanges/execute/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@urql/core": ">=3.2.2",
-    "wonka": "^6.2.6"
+    "wonka": "^6.3.0"
   },
   "peerDependencies": {
     "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"

--- a/exchanges/graphcache/package.json
+++ b/exchanges/graphcache/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "@0no-co/graphql.web": "^1.0.0",
     "@urql/core": ">=3.2.2",
-    "wonka": "^6.2.6"
+    "wonka": "^6.3.0"
   },
   "devDependencies": {
     "@cypress/react": "^7.0.2",

--- a/exchanges/multipart-fetch/package.json
+++ b/exchanges/multipart-fetch/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@urql/core": ">=3.2.2",
     "extract-files": "^11.0.0",
-    "wonka": "^6.2.6"
+    "wonka": "^6.3.0"
   },
   "devDependencies": {
     "@urql/core": "workspace:*",

--- a/exchanges/persisted/package.json
+++ b/exchanges/persisted/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@urql/core": ">=3.2.2",
-    "wonka": "^6.2.6"
+    "wonka": "^6.3.0"
   },
   "devDependencies": {
     "@urql/core": "workspace:*",

--- a/exchanges/populate/package.json
+++ b/exchanges/populate/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@urql/core": ">=3.2.2",
-    "wonka": "^6.2.6"
+    "wonka": "^6.3.0"
   },
   "peerDependencies": {
     "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"

--- a/exchanges/refocus/package.json
+++ b/exchanges/refocus/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@urql/core": ">=3.2.2",
-    "wonka": "^6.2.6"
+    "wonka": "^6.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/exchanges/request-policy/package.json
+++ b/exchanges/request-policy/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@urql/core": ">=3.2.2",
-    "wonka": "^6.2.6"
+    "wonka": "^6.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/exchanges/retry/package.json
+++ b/exchanges/retry/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@urql/core": ">=3.2.2",
-    "wonka": "^6.2.6"
+    "wonka": "^6.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
       "react-is": "^17.0.2",
       "styled-components": "^5.2.3",
       "vite": "^3.2.4",
-      "wonka": "^6.2.6"
+      "wonka": "^6.3.0"
     }
   },
   "devDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@0no-co/graphql.web": "^1.0.0",
-    "wonka": "^6.2.6"
+    "wonka": "^6.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/preact-urql/package.json
+++ b/packages/preact-urql/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@urql/core": "^3.2.2",
-    "wonka": "^6.2.6"
+    "wonka": "^6.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/react-urql/package.json
+++ b/packages/react-urql/package.json
@@ -61,6 +61,6 @@
   },
   "dependencies": {
     "@urql/core": "^3.2.2",
-    "wonka": "^6.2.6"
+    "wonka": "^6.3.0"
   }
 }

--- a/packages/svelte-urql/package.json
+++ b/packages/svelte-urql/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@urql/core": "^3.2.2",
-    "wonka": "^6.2.6"
+    "wonka": "^6.3.0"
   },
   "devDependencies": {
     "@urql/core": "workspace:*",

--- a/packages/vue-urql/package.json
+++ b/packages/vue-urql/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@urql/core": "^3.2.2",
-    "wonka": "^6.2.6"
+    "wonka": "^6.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   react-is: ^17.0.2
   styled-components: ^5.2.3
   vite: ^3.2.4
-  wonka: ^6.2.6
+  wonka: ^6.3.0
 
 importers:
 
@@ -129,10 +129,10 @@ importers:
     specifiers:
       '@urql/core': '>=3.2.2'
       graphql: ^16.6.0
-      wonka: ^6.2.6
+      wonka: ^6.3.0
     dependencies:
       '@urql/core': link:../../packages/core
-      wonka: 6.2.6
+      wonka: 6.3.0
     devDependencies:
       graphql: 16.6.0
 
@@ -140,10 +140,10 @@ importers:
     specifiers:
       '@urql/core': '>=3.2.2'
       graphql: ^16.6.0
-      wonka: ^6.2.6
+      wonka: ^6.3.0
     dependencies:
       '@urql/core': link:../../packages/core
-      wonka: 6.2.6
+      wonka: 6.3.0
     devDependencies:
       graphql: 16.6.0
 
@@ -151,10 +151,10 @@ importers:
     specifiers:
       '@urql/core': '>=3.2.2'
       graphql: ^16.6.0
-      wonka: ^6.2.6
+      wonka: ^6.3.0
     dependencies:
       '@urql/core': link:../../packages/core
-      wonka: 6.2.6
+      wonka: 6.3.0
     devDependencies:
       graphql: 16.6.0
 
@@ -170,11 +170,11 @@ importers:
       react: ^17.0.2
       react-dom: ^17.0.2
       urql: workspace:*
-      wonka: ^6.2.6
+      wonka: ^6.3.0
     dependencies:
       '@0no-co/graphql.web': 1.0.0_graphql@16.6.0
       '@urql/core': link:../../packages/core
-      wonka: 6.2.6
+      wonka: 6.3.0
     devDependencies:
       '@cypress/react': 7.0.2_kxqn2c7raunyx4zfzvxjupflne
       '@urql/exchange-execute': link:../execute
@@ -190,11 +190,11 @@ importers:
       '@urql/core': '>=3.2.2'
       extract-files: ^11.0.0
       graphql: ^16.6.0
-      wonka: ^6.2.6
+      wonka: ^6.3.0
     dependencies:
       '@urql/core': link:../../packages/core
       extract-files: 11.0.0
-      wonka: 6.2.6
+      wonka: 6.3.0
     devDependencies:
       graphql: 16.6.0
 
@@ -202,10 +202,10 @@ importers:
     specifiers:
       '@urql/core': '>=3.2.2'
       graphql: ^16.6.0
-      wonka: ^6.2.6
+      wonka: ^6.3.0
     dependencies:
       '@urql/core': link:../../packages/core
-      wonka: 6.2.6
+      wonka: 6.3.0
     devDependencies:
       graphql: 16.6.0
 
@@ -213,10 +213,10 @@ importers:
     specifiers:
       '@urql/core': '>=3.2.2'
       graphql: ^16.6.0
-      wonka: ^6.2.6
+      wonka: ^6.3.0
     dependencies:
       '@urql/core': link:../../packages/core
-      wonka: 6.2.6
+      wonka: 6.3.0
     devDependencies:
       graphql: 16.6.0
 
@@ -225,10 +225,10 @@ importers:
       '@types/react': ^17.0.39
       '@urql/core': '>=3.2.2'
       graphql: ^16.6.0
-      wonka: ^6.2.6
+      wonka: ^6.3.0
     dependencies:
       '@urql/core': link:../../packages/core
-      wonka: 6.2.6
+      wonka: 6.3.0
     devDependencies:
       '@types/react': 17.0.52
       graphql: 16.6.0
@@ -237,10 +237,10 @@ importers:
     specifiers:
       '@urql/core': '>=3.2.2'
       graphql: ^16.6.0
-      wonka: ^6.2.6
+      wonka: ^6.3.0
     dependencies:
       '@urql/core': link:../../packages/core
-      wonka: 6.2.6
+      wonka: 6.3.0
     devDependencies:
       graphql: 16.6.0
 
@@ -248,20 +248,20 @@ importers:
     specifiers:
       '@urql/core': '>=3.2.2'
       graphql: ^16.6.0
-      wonka: ^6.2.6
+      wonka: ^6.3.0
     dependencies:
       '@urql/core': link:../../packages/core
-      wonka: 6.2.6
+      wonka: 6.3.0
     devDependencies:
       graphql: 16.6.0
 
   packages/core:
     specifiers:
       '@0no-co/graphql.web': ^1.0.0
-      wonka: ^6.2.6
+      wonka: ^6.3.0
     dependencies:
       '@0no-co/graphql.web': 1.0.0
-      wonka: 6.2.6
+      wonka: 6.3.0
 
   packages/introspection:
     specifiers:
@@ -310,10 +310,10 @@ importers:
       '@urql/core': ^3.2.2
       graphql: ^16.6.0
       preact: ^10.13.0
-      wonka: ^6.2.6
+      wonka: ^6.3.0
     dependencies:
       '@urql/core': link:../core
-      wonka: 6.2.6
+      wonka: 6.3.0
     devDependencies:
       '@testing-library/preact': 2.0.1_preact@10.13.1
       graphql: 16.6.0
@@ -336,10 +336,10 @@ importers:
       react-ssr-prepass: ^1.1.2
       react-test-renderer: ^17.0.1
       vite: ^3.2.4
-      wonka: ^6.2.6
+      wonka: ^6.3.0
     dependencies:
       '@urql/core': link:../core
-      wonka: 6.2.6
+      wonka: 6.3.0
     devDependencies:
       '@cypress/react': 7.0.2_omnm57pgrvq3mbg7qqmuk7p7le
       '@cypress/vite-dev-server': 5.0.4
@@ -446,10 +446,10 @@ importers:
       '@urql/core': ^3.2.2
       graphql: ^16.6.0
       svelte: ^3.20.0
-      wonka: ^6.2.6
+      wonka: ^6.3.0
     dependencies:
       '@urql/core': link:../core
-      wonka: 6.2.6
+      wonka: 6.3.0
     devDependencies:
       graphql: 16.6.0
       svelte: 3.37.0
@@ -460,10 +460,10 @@ importers:
       '@vue/test-utils': ^2.3.0
       graphql: ^16.6.0
       vue: ^3.2.47
-      wonka: ^6.2.6
+      wonka: ^6.3.0
     dependencies:
       '@urql/core': link:../core
-      wonka: 6.2.6
+      wonka: 6.3.0
     devDependencies:
       '@vue/test-utils': 2.3.0_vue@3.2.47
       graphql: 16.6.0
@@ -15636,8 +15636,8 @@ packages:
       execa: 1.0.0
     dev: true
 
-  /wonka/6.2.6:
-    resolution: {integrity: sha512-ExUBenRwEyf8YswAVOFZDmAdiUMgpnuyDV28G9bF+73o2hnhAG9tLqnn7LmtWgB2KCFQdWywbUfvUW3UgxARew==}
+  /wonka/6.3.0:
+    resolution: {integrity: sha512-7np+Kj4OnDQeEN0kafYLkPFKj1Qo+k7mNgyMHSgOeg+9AEvJbL8ipTBgSCTQfGcgVo6TPNU4T5+AZ2rAOyVrAw==}
     dev: false
 
   /word-wrap/1.2.3:


### PR DESCRIPTION
Related #3102

## Summary

Upgrades to `wonka@^6.3.0`; this time while issuing a changeset to inform of the change.

## Set of changes

- Upgrade all packages that need it to `wonka@^6.3.0`
