### PR TITLE
refactor(core): Prevent result cloning in Client

### DIFF
--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -709,14 +709,14 @@ describe('shared sources behavior', () => {
     expect(resultTwo).toHaveBeenCalledWith({
       data: 1,
       operation: queryOperation,
-      stale: false,
+      stale: true,
       hasNext: false,
     });
 
     vi.advanceTimersByTime(1);
 
     // With cache-first we don't expect a new operation to be issued
-    expect(resultTwo).toHaveBeenCalledTimes(1);
+    expect(resultTwo).toHaveBeenCalledTimes(2);
   });
 
   it('dispatches the correct request policy on subsequent sources', async () => {

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -834,12 +834,30 @@ describe('shared sources behavior', () => {
       hasNext: false,
     });
 
+    expect(resultOne).toHaveBeenCalledWith({
+      data: 1,
+      operation,
+      stale: true,
+      hasNext: false,
+    });
+
+    expect(resultTwo).toHaveBeenCalledTimes(1);
+    expect(resultOne).toHaveBeenCalledTimes(2);
+
     vi.advanceTimersByTime(1);
 
     // With network-only we expect a new operation to be issued, hence a new result
     expect(resultTwo).toHaveBeenCalledTimes(2);
+    expect(resultOne).toHaveBeenCalledTimes(3);
 
     expect(resultTwo).toHaveBeenCalledWith({
+      data: 2,
+      operation,
+      stale: false,
+      hasNext: false,
+    });
+
+    expect(resultOne).toHaveBeenCalledWith({
       data: 2,
       operation,
       stale: false,

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -761,21 +761,16 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
             replay &&
             (replay.stale || replay.hasNext)
           ) {
-            let hasResult = false;
-            return merge([
-              pipe(
+            return pipe(
+              merge([
                 source,
-                onPush(() => {
-                  hasResult = true;
-                })
-              ),
-              pipe(
-                fromValue(replay),
-                filter(replay => {
-                  return !hasResult && replay === replays.get(operation.key);
-                })
-              ),
-            ]);
+                pipe(
+                  fromValue(replay),
+                  filter(replay => replay === replays.get(operation.key))
+                ),
+              ]),
+              switchMap(fromValue)
+            );
           } else {
             return source;
           }

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -637,12 +637,7 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
                 value$,
                 pipe(
                   operations.source,
-                  // React only to matching operations, excluding the one that this stream dispatches
-                  filter(
-                    op =>
-                      op.key === operation.key &&
-                      op.context.requestPolicy !== 'cache-only'
-                  ),
+                  filter(op => op.key === operation.key),
                   take(1),
                   map(() => {
                     result.stale = true;


### PR DESCRIPTION
## Summary

This gets rid of the last `{ ...result }` cloning code that we had left in the `Client`.

## Set of changes

- Remove `{ ...result, stale: true }` in favour of direct assignment
- Prevent issuing additional `stale: true` result for own result
