### PR TITLE
fix(auth): avoid infinite loop when didAuthError keeps returning true

### DIFF
--- a/.changeset/rotten-planes-heal.md
+++ b/.changeset/rotten-planes-heal.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-auth': patch
+---
+
+Avoid infinite loop when `didAuthError` keeps returning true

--- a/exchanges/auth/src/authExchange.ts
+++ b/exchanges/auth/src/authExchange.ts
@@ -270,6 +270,7 @@ export function authExchange(
           operation.key,
           addAuthAttemptToOperation(operation, true)
         );
+
         // check that another operation isn't already doing refresh
         if (config && !authPromise) {
           authPromise = config.refreshAuth().finally(flushQueue);
@@ -310,7 +311,9 @@ export function authExchange(
       const opsWithAuth$ = pipe(
         merge([retries.source, pendingOps$]),
         map(operation => {
-          if (bypassQueue.has(operation)) {
+          if (operation.context.authAttempt) {
+            return addAuthToOperation(operation);
+          } else if (bypassQueue.has(operation)) {
             return operation;
           } else if (authPromise) {
             if (!retryQueue.has(operation.key)) {


### PR DESCRIPTION
Discovered in https://github.com/urql-graphql/urql/discussions/3111

## Summary

In the fall-through case (edited now to not fall through) we would set the `authAttempt` back to false. Instead now we check whether it's true and just add auth to the operation rather than manipulating the context.

The test provided in the discussion won't work as we pass back `result.operation` without the manipulation happening in the `authExchange` working on that.
