### PR TITLE
fix(workspace): add GITHUB_TOKEN env

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,7 @@ jobs:
         with:
           publishedPackages: steps.changesets.outputs.publishedPackages
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           DISCORD_URQL_WEBHOOK_URL: ${{ secrets.DISCORD_URQL_WEBHOOK_URL }}
 


### PR DESCRIPTION
This was missing in latest run