### PR TITLE
fix(core): Fix multipart FormData map field format

### DIFF
--- a/.changeset/friendly-flies-smile.md
+++ b/.changeset/friendly-flies-smile.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Fix format of `map` form data field on multipart upload requests. This was erroneously set to a string rather than a string tuple.

--- a/packages/core/src/internal/fetchOptions.test.ts
+++ b/packages/core/src/internal/fetchOptions.test.ts
@@ -154,7 +154,7 @@ describe('makeFetchOptions', () => {
     });
 
     expect(form.get('map')).toMatchInlineSnapshot(
-      '"{\\"0\\":\\"variables.file\\"}"'
+      '"{\\"0\\":[\\"variables.file\\"]}"'
     );
     expect(form.get('0')).toBeInstanceOf(Blob);
   });

--- a/packages/core/src/internal/fetchOptions.ts
+++ b/packages/core/src/internal/fetchOptions.ts
@@ -87,15 +87,15 @@ const serializeBody = (
     const files = extractFiles(body.variables);
     if (files.size) {
       const form = new FormData();
-
       form.append('operations', json);
-      form.append('map', stringifyVariables({ ...[...files.keys()] }));
-
+      form.append(
+        'map',
+        stringifyVariables({
+          ...[...files.keys()].map(value => [value]),
+        })
+      );
       let index = 0;
-      for (const file of files.values()) {
-        form.append(`${index++}`, file);
-      }
-
+      for (const file of files.values()) form.append(`${index++}`, file);
       return form;
     }
     return json;


### PR DESCRIPTION
## Summary

The multipart request spec actually specifies that `map` is of type `Record<string, string[]>` rather than `Record<string, string>`. While this is easy to miss, it's likely for upload deduplication, which we don't do but have to respect.

## Set of changes

- Convert `FormData` `map` field to `[prop: string]: [string]`
