### PR TITLE
fix(core): allow for merging defer specified on the root-type

### DIFF
--- a/.changeset/hungry-coins-lie.md
+++ b/.changeset/hungry-coins-lie.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Fix defer specified on the root-type

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,6 +54,7 @@
   },
   "dependencies": {
     "@0no-co/graphql.web": "^1.0.0",
+    "dset": "^3.1.2",
     "wonka": "^6.3.0"
   },
   "publishConfig": {

--- a/packages/core/src/internal/fetchSource.test.ts
+++ b/packages/core/src/internal/fetchSource.test.ts
@@ -493,7 +493,7 @@ describe('on text/event-stream', () => {
                   incremental: [
                     {
                       path: [],
-                      data: { author: { name: 'Steve' }  },
+                      data: { author: { name: 'Steve' } },
                     },
                   ],
                   hasNext: true,
@@ -523,7 +523,9 @@ describe('on text/event-stream', () => {
 
     const AuthorFragment = gql`
       fragment authorFields on Query {
-        author { name }
+        author {
+          name
+        }
       }
     `;
 

--- a/packages/core/src/internal/fetchSource.test.ts
+++ b/packages/core/src/internal/fetchSource.test.ts
@@ -459,4 +459,122 @@ describe('on text/event-stream', () => {
       },
     });
   });
+
+  it('merges deferred results on the root-type', async () => {
+    fetch.mockResolvedValue({
+      status: 200,
+      headers: {
+        get() {
+          return 'text/event-stream';
+        },
+      },
+      body: {
+        getReader: function () {
+          let cancelled = false;
+          const results = [
+            {
+              done: false,
+              value: Buffer.from(
+                wrap({
+                  hasNext: true,
+                  data: {
+                    author: {
+                      id: '1',
+                      __typename: 'Author',
+                    },
+                  },
+                })
+              ),
+            },
+            {
+              done: false,
+              value: Buffer.from(
+                wrap({
+                  incremental: [
+                    {
+                      path: [],
+                      data: { author: { name: 'Steve' }  },
+                    },
+                  ],
+                  hasNext: true,
+                })
+              ),
+            },
+            {
+              done: false,
+              value: Buffer.from(wrap({ hasNext: false })),
+            },
+            { done: true },
+          ];
+          let count = 0;
+          return {
+            cancel: function () {
+              cancelled = true;
+            },
+            read: function () {
+              if (cancelled) throw new Error('No');
+
+              return Promise.resolve(results[count++]);
+            },
+          };
+        },
+      },
+    });
+
+    const AuthorFragment = gql`
+      fragment authorFields on Query {
+        author { name }
+      }
+    `;
+
+    const streamedQueryOperation: Operation = makeOperation(
+      'query',
+      {
+        query: gql`
+          query {
+            author {
+              id
+              ...authorFields @defer
+            }
+          }
+
+          ${AuthorFragment}
+        `,
+        variables: {},
+        key: 1,
+      },
+      context
+    );
+
+    const chunks: OperationResult[] = await pipe(
+      makeFetchSource(streamedQueryOperation, 'https://test.com/graphql', {}),
+      scan((prev: OperationResult[], item) => [...prev, item], []),
+      toPromise
+    );
+
+    expect(chunks.length).toEqual(3);
+
+    expect(chunks[0].data).toEqual({
+      author: {
+        id: '1',
+        __typename: 'Author',
+      },
+    });
+
+    expect(chunks[1].data).toEqual({
+      author: {
+        id: '1',
+        name: 'Steve',
+        __typename: 'Author',
+      },
+    });
+
+    expect(chunks[2].data).toEqual({
+      author: {
+        id: '1',
+        name: 'Steve',
+        __typename: 'Author',
+      },
+    });
+  });
 });

--- a/packages/core/src/utils/result.ts
+++ b/packages/core/src/utils/result.ts
@@ -5,7 +5,7 @@ import {
   IncrementalPayload,
 } from '../types';
 import { CombinedError } from './error';
-import { dset, dset as merge } from 'dset/merge';
+import { dset as merge } from 'dset/merge';
 
 /** Converts the `ExecutionResult` received for a given `Operation` to an `OperationResult`.
  *
@@ -110,14 +110,20 @@ export const mergeResultPatch = (
           part[startIndex + i] = patch.items[i];
       } else if (patch.data !== undefined) {
         if (prop) {
-          merge(part, prop as string, patch.data)
+          if (part[prop]) {
+            part[prop] = {...part[prop]}
+            merge(part, prop as string, patch.data)
+          } else {
+            part[prop] = patch.data;
+          }
         } else {
           if (part && patch.data) {
             data = Object.keys(patch.data).reduce((acc, key) => {
-              merge(acc, key, patch.data)
+              acc[key] = { ...acc[key] };
+              merge(acc, key, patch.data![key])
               return acc;
             }, part)
-          } else if (patch.data) {
+          } else {
             data = patch.data;
           }
         }

--- a/packages/core/src/utils/result.ts
+++ b/packages/core/src/utils/result.ts
@@ -111,18 +111,23 @@ export const mergeResultPatch = (
       } else if (patch.data !== undefined) {
         if (prop) {
           if (part[prop]) {
-            part[prop] = {...part[prop]}
-            merge(part, prop as string, patch.data)
+            part[prop] = { ...part[prop] };
+            merge(part, prop as string, patch.data);
           } else {
             part[prop] = patch.data;
           }
         } else {
           if (part && patch.data) {
             data = Object.keys(patch.data).reduce((acc, key) => {
-              acc[key] = { ...acc[key] };
-              merge(acc, key, patch.data![key])
+              if (acc[key]) {
+                acc[key] = { ...acc[key] };
+                merge(acc, key, patch.data![key]);
+              } else {
+                acc[key] = patch.data![key]
+              }
+
               return acc;
-            }, part)
+            }, part);
           } else {
             data = patch.data;
           }

--- a/packages/core/src/utils/result.ts
+++ b/packages/core/src/utils/result.ts
@@ -5,6 +5,7 @@ import {
   IncrementalPayload,
 } from '../types';
 import { CombinedError } from './error';
+import { dset, dset as merge } from 'dset/merge';
 
 /** Converts the `ExecutionResult` received for a given `Operation` to an `OperationResult`.
  *
@@ -109,29 +110,14 @@ export const mergeResultPatch = (
           part[startIndex + i] = patch.items[i];
       } else if (patch.data !== undefined) {
         if (prop) {
-          part[prop] =
-            part[prop] && patch.data
-              ? { ...part[prop], ...patch.data }
-              : patch.data;
+          merge(part, prop as string, patch.data)
         } else {
           if (part && patch.data) {
             data = Object.keys(patch.data).reduce((acc, key) => {
-              if (!patch.data || !patch.data[key]) {
-                acc[key] = patch.data![key]
-              } else if (Array.isArray(patch.data[key])) {
-                // TODO: this is most likely possible
-              } else if (typeof patch.data[key] === 'object') {
-                acc[key] = {
-                  ...acc[key],
-                  ...(patch.data[key] as object)
-                };
-              } else {
-                acc[key] = patch.data![key]
-              }
-
+              merge(acc, key, patch.data)
               return acc;
             }, part)
-          } else {
+          } else if (patch.data) {
             data = patch.data;
           }
         }

--- a/packages/core/src/utils/result.ts
+++ b/packages/core/src/utils/result.ts
@@ -108,10 +108,33 @@ export const mergeResultPatch = (
         for (let i = 0, l = patch.items.length; i < l; i++)
           part[startIndex + i] = patch.items[i];
       } else if (patch.data !== undefined) {
-        part[prop] =
-          part[prop] && patch.data
-            ? { ...part[prop], ...patch.data }
-            : patch.data;
+        if (prop) {
+          part[prop] =
+            part[prop] && patch.data
+              ? { ...part[prop], ...patch.data }
+              : patch.data;
+        } else {
+          if (part && patch.data) {
+            data = Object.keys(patch.data).reduce((acc, key) => {
+              if (!patch.data || !patch.data[key]) {
+                acc[key] = patch.data![key]
+              } else if (Array.isArray(patch.data[key])) {
+                // TODO: this is most likely possible
+              } else if (typeof patch.data[key] === 'object') {
+                acc[key] = {
+                  ...acc[key],
+                  ...(patch.data[key] as object)
+                };
+              } else {
+                acc[key] = patch.data![key]
+              }
+
+              return acc;
+            }, part)
+          } else {
+            data = patch.data;
+          }
+        }
       }
     }
   } else {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,19 +185,6 @@ importers:
       react-dom: 17.0.2_react@17.0.2
       urql: link:../../packages/react-urql
 
-  exchanges/multipart-fetch:
-    specifiers:
-      '@urql/core': '>=4.0.0'
-      extract-files: ^11.0.0
-      graphql: ^16.6.0
-      wonka: ^6.3.0
-    dependencies:
-      '@urql/core': link:../../packages/core
-      extract-files: 11.0.0
-      wonka: 6.3.0
-    devDependencies:
-      graphql: 16.6.0
-
   exchanges/persisted:
     specifiers:
       '@urql/core': '>=4.0.0'
@@ -258,9 +245,11 @@ importers:
   packages/core:
     specifiers:
       '@0no-co/graphql.web': ^1.0.0
+      dset: ^3.1.2
       wonka: ^6.3.0
     dependencies:
       '@0no-co/graphql.web': 1.0.0
+      dset: 3.1.2
       wonka: 6.3.0
 
   packages/introspection:
@@ -6071,6 +6060,11 @@ packages:
       p-event: 2.3.1
       pify: 3.0.0
 
+  /dset/3.1.2:
+    resolution: {integrity: sha512-g/M9sqy3oHe477Ar4voQxWtaPIFw1jTdKZuomOjhCcBx9nHUNn0pu6NopuFFrTh/TRZIKEj+76vLWFu9BNKk+Q==}
+    engines: {node: '>=4'}
+    dev: false
+
   /duplexer/0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
 
@@ -7110,11 +7104,6 @@ packages:
       schema-utils: 1.0.0
       webpack: 4.46.0
       webpack-sources: 1.4.3
-
-  /extract-files/11.0.0:
-    resolution: {integrity: sha512-FuoE1qtbJ4bBVvv94CC7s0oTnKUGvQs+Rjf1L2SJFfS+HTVVjhPFtehPdQ0JiGPqVNfSSZvL5yzHHQq2Z4WNhQ==}
-    engines: {node: ^12.20 || >= 14.13}
-    dev: false
 
   /extract-zip/2.0.1_supports-color@8.1.1:
     resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}


### PR DESCRIPTION
Fixes https://github.com/urql-graphql/urql/issues/3122

## Summary

A `incremental` path is specified starting from the root-field which means that if a user specifies a fragment on the root-type that we get an empty path, in the patching we assume that `path[0]` will always be defined, however here that is not the case.

I don't really like the current solution as we would have to deeply merge results in cases like the following

```gql
query {
  ... on Query @defer {
    todo {
      x {
        expensiveField
      }
    }
  }
  todo { x { y } }
}
```

however I am not sure whether this is worth it, my main worry is that the server implementation seems to support this. I wanted to get thoughts on this before comitting to it as the idiomatic way would be to do

```gql
query {
  todo {
    x {
      ... on X @ defer { expensiveField }
      y
    }
  }
}
```

I have extended the proposal by leveraging [`dset/merge`](https://github.com/lukeed/dset/tree/master#merging) which seems intended for defer/stream in its current state. The byte size is 200bytes which is low enough and it will future-proof of for all types of nesting
