### PR TITLE
fix(core): Fix Incremental Delivery payloads deep merging and root patches

### DIFF
--- a/.changeset/hungry-coins-lie.md
+++ b/.changeset/hungry-coins-lie.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Fix defer specified on the root-type

--- a/.changeset/hungry-coins-lie.md
+++ b/.changeset/hungry-coins-lie.md
@@ -2,4 +2,5 @@
 '@urql/core': patch
 ---
 
-Fix defer specified on the root-type
+Fix incremental delivery payloads not merging data correctly, or not handling patches on root
+results.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,6 +54,7 @@
   },
   "dependencies": {
     "@0no-co/graphql.web": "^1.0.0",
+    "dset": "^3.1.2",
     "wonka": "^6.3.0"
   },
   "publishConfig": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,7 +54,6 @@
   },
   "dependencies": {
     "@0no-co/graphql.web": "^1.0.0",
-    "dset": "^3.1.2",
     "wonka": "^6.3.0"
   },
   "publishConfig": {

--- a/packages/core/src/internal/fetchSource.test.ts
+++ b/packages/core/src/internal/fetchSource.test.ts
@@ -493,7 +493,7 @@ describe('on text/event-stream', () => {
                   incremental: [
                     {
                       path: [],
-                      data: { author: { name: 'Steve' }  },
+                      data: { author: { name: 'Steve' } },
                     },
                   ],
                   hasNext: true,
@@ -523,7 +523,9 @@ describe('on text/event-stream', () => {
 
     const AuthorFragment = gql`
       fragment authorFields on Query {
-        author { name }
+        author {
+          name
+        }
       }
     `;
 

--- a/packages/core/src/internal/fetchSource.test.ts
+++ b/packages/core/src/internal/fetchSource.test.ts
@@ -459,4 +459,122 @@ describe('on text/event-stream', () => {
       },
     });
   });
+
+  it('merges deferred results on the root-type', async () => {
+    fetch.mockResolvedValue({
+      status: 200,
+      headers: {
+        get() {
+          return 'text/event-stream';
+        },
+      },
+      body: {
+        getReader: function () {
+          let cancelled = false;
+          const results = [
+            {
+              done: false,
+              value: Buffer.from(
+                wrap({
+                  hasNext: true,
+                  data: {
+                    author: {
+                      id: '1',
+                      __typename: 'Author',
+                    },
+                  },
+                })
+              ),
+            },
+            {
+              done: false,
+              value: Buffer.from(
+                wrap({
+                  incremental: [
+                    {
+                      path: [],
+                      data: { author: { name: 'Steve' }  },
+                    },
+                  ],
+                  hasNext: true,
+                })
+              ),
+            },
+            {
+              done: false,
+              value: Buffer.from(wrap({ hasNext: false })),
+            },
+            { done: true },
+          ];
+          let count = 0;
+          return {
+            cancel: function () {
+              cancelled = true;
+            },
+            read: function () {
+              if (cancelled) throw new Error('No');
+
+              return Promise.resolve(results[count++]);
+            },
+          };
+        },
+      },
+    });
+
+    const AuthorFragment = gql`
+      fragment authorFields on Query {
+        author { name }
+      }
+    `;
+
+    const streamedQueryOperation: Operation = makeOperation(
+      'query',
+      {
+        query: gql`
+          query {
+            author {
+              id
+              ...authorFields @defer
+            }
+          }
+
+          ${AuthorFragment}
+        `,
+        variables: {},
+        key: 1,
+      },
+      context
+    );
+
+    const chunks: OperationResult[] = await pipe(
+      makeFetchSource(streamedQueryOperation, 'https://test.com/graphql', {}),
+      scan((prev: OperationResult[], item) => [...prev, item], []),
+      toPromise
+    );
+
+    expect(chunks.length).toEqual(3);
+
+    expect(chunks[0].data).toEqual({
+      author: {
+        id: '1',
+        __typename: 'Author',
+      },
+    });
+
+    expect(chunks[1].data).toEqual({
+      author: {
+        id: '1',
+        name: 'Steve',
+        __typename: 'Author',
+      },
+    });
+
+    expect(chunks[2].data).toEqual({
+      author: {
+        id: '1',
+        name: 'Steve',
+        __typename: 'Author',
+      },
+    });
+  });
 });

--- a/packages/core/src/utils/result.test.ts
+++ b/packages/core/src/utils/result.test.ts
@@ -163,6 +163,43 @@ describe('mergeResultPatch', () => {
     });
   });
 
+  it('should apply incremental stream patches deeply', () => {
+    const prevResult: OperationResult = {
+      operation: queryOperation,
+      data: {
+        __typename: 'Query',
+        test: [
+          {
+            __typename: 'Test',
+          },
+        ],
+      },
+      stale: false,
+      hasNext: true,
+    };
+
+    const patch = { name: 'Test' };
+
+    const merged = mergeResultPatch(prevResult, {
+      incremental: [
+        {
+          items: [patch],
+          path: ['test', 0],
+        },
+      ],
+    });
+
+    expect(merged.data).toStrictEqual({
+      __typename: 'Query',
+      test: [
+        {
+          __typename: 'Test',
+          name: 'Test',
+        },
+      ],
+    });
+  });
+
   it('should handle null incremental stream patches', () => {
     const prevResult: OperationResult = {
       operation: queryOperation,
@@ -188,6 +225,37 @@ describe('mergeResultPatch', () => {
     expect(merged.data).toStrictEqual({
       __typename: 'Query',
       items: [{ __typename: 'Item' }],
+    });
+  });
+
+  it('should handle root incremental stream patches', () => {
+    const prevResult: OperationResult = {
+      operation: queryOperation,
+      data: {
+        __typename: 'Query',
+        item: {
+          test: true,
+        },
+      },
+      stale: false,
+      hasNext: true,
+    };
+
+    const merged = mergeResultPatch(prevResult, {
+      incremental: [
+        {
+          data: { item: { test2: false } },
+          path: [],
+        },
+      ],
+    });
+
+    expect(merged.data).toStrictEqual({
+      __typename: 'Query',
+      item: {
+        test: true,
+        test2: false,
+      },
     });
   });
 

--- a/packages/core/src/utils/result.ts
+++ b/packages/core/src/utils/result.ts
@@ -118,7 +118,7 @@ export const mergeResultPatch = (
           : { ...part[prop] };
       }
 
-      if (Array.isArray(patch.items)) {
+      if (patch.items) {
         const startIndex = +prop >= 0 ? (prop as number) : 0;
         for (let i = 0, l = patch.items.length; i < l; i++)
           part[startIndex + i] = deepMerge(

--- a/packages/core/src/utils/result.ts
+++ b/packages/core/src/utils/result.ts
@@ -5,7 +5,7 @@ import {
   IncrementalPayload,
 } from '../types';
 import { CombinedError } from './error';
-import { dset, dset as merge } from 'dset/merge';
+import { dset as merge } from 'dset/merge';
 
 /** Converts the `ExecutionResult` received for a given `Operation` to an `OperationResult`.
  *
@@ -110,14 +110,20 @@ export const mergeResultPatch = (
           part[startIndex + i] = patch.items[i];
       } else if (patch.data !== undefined) {
         if (prop) {
-          merge(part, prop as string, patch.data)
+          if (part[prop]) {
+            part[prop] = {...part[prop]}
+            merge(part, prop as string, patch.data)
+          } else {
+            part[prop] = patch.data;
+          }
         } else {
           if (part && patch.data) {
             data = Object.keys(patch.data).reduce((acc, key) => {
-              merge(acc, key, patch.data)
+              acc[key] = { ...acc[key] };
+              merge(acc, key, patch.data![key])
               return acc;
             }, part)
-          } else if (patch.data) {
+          } else {
             data = patch.data;
           }
         }

--- a/packages/core/src/utils/result.ts
+++ b/packages/core/src/utils/result.ts
@@ -49,20 +49,19 @@ export const makeResult = (
 };
 
 const deepMerge = (target: any, source: any) => {
-  if (typeof target !== 'object' || target == null) {
-    return source;
-  } else if (
-    !target.constructor ||
-    target.constructor === Object ||
-    Array.isArray(source)
-  ) {
-    target = Array.isArray(target) ? [...target] : { ...target };
-    for (const key of Object.keys(source))
-      target[key] = deepMerge(target[key], source[key]);
-    return target;
-  } else {
-    return source;
+  if (typeof target === 'object' && target != null) {
+    if (
+      !target.constructor ||
+      target.constructor === Object ||
+      Array.isArray(source)
+    ) {
+      target = Array.isArray(target) ? [...target] : { ...target };
+      for (const key of Object.keys(source))
+        target[key] = deepMerge(target[key], source[key]);
+      return target;
+    }
   }
+  return source;
 };
 
 /** Merges an incrementally delivered `ExecutionResult` into a previous `OperationResult`.

--- a/packages/core/src/utils/result.ts
+++ b/packages/core/src/utils/result.ts
@@ -111,18 +111,23 @@ export const mergeResultPatch = (
       } else if (patch.data !== undefined) {
         if (prop) {
           if (part[prop]) {
-            part[prop] = {...part[prop]}
-            merge(part, prop as string, patch.data)
+            part[prop] = { ...part[prop] };
+            merge(part, prop as string, patch.data);
           } else {
             part[prop] = patch.data;
           }
         } else {
           if (part && patch.data) {
             data = Object.keys(patch.data).reduce((acc, key) => {
-              acc[key] = { ...acc[key] };
-              merge(acc, key, patch.data![key])
+              if (acc[key]) {
+                acc[key] = { ...acc[key] };
+                merge(acc, key, patch.data![key]);
+              } else {
+                acc[key] = patch.data![key]
+              }
+
               return acc;
-            }, part)
+            }, part);
           } else {
             data = patch.data;
           }

--- a/packages/core/src/utils/result.ts
+++ b/packages/core/src/utils/result.ts
@@ -53,7 +53,7 @@ const deepMerge = (target: any, source: any) => {
     if (
       !target.constructor ||
       target.constructor === Object ||
-      Array.isArray(source)
+      Array.isArray(target)
     ) {
       target = Array.isArray(target) ? [...target] : { ...target };
       for (const key of Object.keys(source))

--- a/packages/core/src/utils/result.ts
+++ b/packages/core/src/utils/result.ts
@@ -5,6 +5,7 @@ import {
   IncrementalPayload,
 } from '../types';
 import { CombinedError } from './error';
+import { dset, dset as merge } from 'dset/merge';
 
 /** Converts the `ExecutionResult` received for a given `Operation` to an `OperationResult`.
  *
@@ -109,29 +110,14 @@ export const mergeResultPatch = (
           part[startIndex + i] = patch.items[i];
       } else if (patch.data !== undefined) {
         if (prop) {
-          part[prop] =
-            part[prop] && patch.data
-              ? { ...part[prop], ...patch.data }
-              : patch.data;
+          merge(part, prop as string, patch.data)
         } else {
           if (part && patch.data) {
             data = Object.keys(patch.data).reduce((acc, key) => {
-              if (!patch.data || !patch.data[key]) {
-                acc[key] = patch.data![key]
-              } else if (Array.isArray(patch.data[key])) {
-                // TODO: this is most likely possible
-              } else if (typeof patch.data[key] === 'object') {
-                acc[key] = {
-                  ...acc[key],
-                  ...(patch.data[key] as object)
-                };
-              } else {
-                acc[key] = patch.data![key]
-              }
-
+              merge(acc, key, patch.data)
               return acc;
             }, part)
-          } else {
+          } else if (patch.data) {
             data = patch.data;
           }
         }

--- a/packages/core/src/utils/result.ts
+++ b/packages/core/src/utils/result.ts
@@ -108,10 +108,33 @@ export const mergeResultPatch = (
         for (let i = 0, l = patch.items.length; i < l; i++)
           part[startIndex + i] = patch.items[i];
       } else if (patch.data !== undefined) {
-        part[prop] =
-          part[prop] && patch.data
-            ? { ...part[prop], ...patch.data }
-            : patch.data;
+        if (prop) {
+          part[prop] =
+            part[prop] && patch.data
+              ? { ...part[prop], ...patch.data }
+              : patch.data;
+        } else {
+          if (part && patch.data) {
+            data = Object.keys(patch.data).reduce((acc, key) => {
+              if (!patch.data || !patch.data[key]) {
+                acc[key] = patch.data![key]
+              } else if (Array.isArray(patch.data[key])) {
+                // TODO: this is most likely possible
+              } else if (typeof patch.data[key] === 'object') {
+                acc[key] = {
+                  ...acc[key],
+                  ...(patch.data[key] as object)
+                };
+              } else {
+                acc[key] = patch.data![key]
+              }
+
+              return acc;
+            }, part)
+          } else {
+            data = patch.data;
+          }
+        }
       }
     }
   } else {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,11 +245,9 @@ importers:
   packages/core:
     specifiers:
       '@0no-co/graphql.web': ^1.0.0
-      dset: ^3.1.2
       wonka: ^6.3.0
     dependencies:
       '@0no-co/graphql.web': 1.0.0
-      dset: 3.1.2
       wonka: 6.3.0
 
   packages/introspection:
@@ -6059,11 +6057,6 @@ packages:
       make-dir: 1.3.0
       p-event: 2.3.1
       pify: 3.0.0
-
-  /dset/3.1.2:
-    resolution: {integrity: sha512-g/M9sqy3oHe477Ar4voQxWtaPIFw1jTdKZuomOjhCcBx9nHUNn0pu6NopuFFrTh/TRZIKEj+76vLWFu9BNKk+Q==}
-    engines: {node: '>=4'}
-    dev: false
 
   /duplexer/0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,19 +185,6 @@ importers:
       react-dom: 17.0.2_react@17.0.2
       urql: link:../../packages/react-urql
 
-  exchanges/multipart-fetch:
-    specifiers:
-      '@urql/core': '>=4.0.0'
-      extract-files: ^11.0.0
-      graphql: ^16.6.0
-      wonka: ^6.3.0
-    dependencies:
-      '@urql/core': link:../../packages/core
-      extract-files: 11.0.0
-      wonka: 6.3.0
-    devDependencies:
-      graphql: 16.6.0
-
   exchanges/persisted:
     specifiers:
       '@urql/core': '>=4.0.0'
@@ -258,9 +245,11 @@ importers:
   packages/core:
     specifiers:
       '@0no-co/graphql.web': ^1.0.0
+      dset: ^3.1.2
       wonka: ^6.3.0
     dependencies:
       '@0no-co/graphql.web': 1.0.0
+      dset: 3.1.2
       wonka: 6.3.0
 
   packages/introspection:
@@ -6071,6 +6060,11 @@ packages:
       p-event: 2.3.1
       pify: 3.0.0
 
+  /dset/3.1.2:
+    resolution: {integrity: sha512-g/M9sqy3oHe477Ar4voQxWtaPIFw1jTdKZuomOjhCcBx9nHUNn0pu6NopuFFrTh/TRZIKEj+76vLWFu9BNKk+Q==}
+    engines: {node: '>=4'}
+    dev: false
+
   /duplexer/0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
 
@@ -7110,11 +7104,6 @@ packages:
       schema-utils: 1.0.0
       webpack: 4.46.0
       webpack-sources: 1.4.3
-
-  /extract-files/11.0.0:
-    resolution: {integrity: sha512-FuoE1qtbJ4bBVvv94CC7s0oTnKUGvQs+Rjf1L2SJFfS+HTVVjhPFtehPdQ0JiGPqVNfSSZvL5yzHHQq2Z4WNhQ==}
-    engines: {node: ^12.20 || >= 14.13}
-    dev: false
 
   /extract-zip/2.0.1_supports-color@8.1.1:
     resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}


### PR DESCRIPTION
Resolves #3122

## Summary

This deeply merges (while cloning) result sets from Incremental Delivery results, and handles deep merges on the root payload as well, which we previously didn't realise was a legal usage of `@defer`.

## Set of changes

- Add deep-clone merging of incremental delivery payloads
- Add handling of merging patches into root (i.e. `path: []`)
