### PR TITLE
fix(core): Handle fetch rejections and pass to makeErrorResult

### DIFF
--- a/.changeset/eight-kangaroos-wave.md
+++ b/.changeset/eight-kangaroos-wave.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Handle `fetch` rejections in `makeFetchSource` and properly hand them over to `CombinedError`s.

--- a/packages/core/src/internal/fetchSource.test.ts
+++ b/packages/core/src/internal/fetchSource.test.ts
@@ -106,6 +106,19 @@ describe('on error', () => {
     });
   });
 
+  it('handles network errors', async () => {
+    const error = new Error('test');
+    fetch.mockRejectedValue(error);
+
+    const fetchOptions = {};
+    const data = await pipe(
+      makeFetchSource(queryOperation, 'https://test.com/graphql', fetchOptions),
+      toPromise
+    );
+
+    expect(data).toHaveProperty('error.networkError', error);
+  });
+
   it('returns error data', async () => {
     const fetchOptions = {};
     const data = await pipe(

--- a/packages/core/src/internal/fetchSource.ts
+++ b/packages/core/src/internal/fetchSource.ts
@@ -107,7 +107,7 @@ async function* fetchOperation(
   let networkMode = true;
   let abortController: AbortController | void;
   let result: OperationResult | null = null;
-  let response: Response;
+  let response: Response | void;
 
   try {
     if (typeof AbortController !== 'undefined') {
@@ -151,11 +151,12 @@ async function* fetchOperation(
 
     yield makeErrorResult(
       operation,
-      (response!.status < 200 || response!.status >= 300) &&
-        response!.statusText
-        ? new Error(response!.statusText)
+      response &&
+        (response.status < 200 || response.status >= 300) &&
+        response.statusText
+        ? new Error(response.statusText)
         : error,
-      response!
+      response
     );
   } finally {
     if (abortController) abortController.abort();


### PR DESCRIPTION
Resolves #3128

## Summary

We had a missing catch case, where `!response` wasn't handled, which can happen if `fetch` rejects immediately rather than delivering a failed response. This would happen in particular due to offline network errors or broken connection attempts.

This is a regression introduced in the fetch refactor, and was introduced because we don't have two catch handlers anymore, hence `response!` was an invalid non-undefined assertion.

## Set of changes

- Add missing `!response` case
- Add test
