### PR TITLE
fix(core): Fix early closing of subscriptions

### DIFF
--- a/.changeset/nice-flowers-think.md
+++ b/.changeset/nice-flowers-think.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Fix `hasNext` being defaulted to `false` when a new subscription event is received on the `subscriptionExchange` that doesn't have `hasNext` set.

--- a/packages/core/src/utils/result.ts
+++ b/packages/core/src/utils/result.ts
@@ -141,7 +141,8 @@ export const mergeResultPatch = (
       ? new CombinedError({ graphQLErrors: errors, response })
       : undefined,
     extensions: hasExtensions ? extensions : undefined,
-    hasNext: !!nextResult.hasNext,
+    hasNext:
+      nextResult.hasNext != null ? nextResult.hasNext : prevResult.hasNext,
     stale: false,
   };
 };


### PR DESCRIPTION
## Summary

Fixes an issue where `hasNext` would be updated to `false` and a subscription would be ended early when the `subscriptionExchange`’s sink doesn't actually set `hasNext: true` on a following result.

This is a similar issue to the missing `defaultHasNext` in `makeResult` we had to add.

## Set of changes

- Add default `hasNext` value to merged results
- Add unit tests
