### PR TITLE
fix(core): Fix multipart stream being split when content contains boundary

### DIFF
--- a/.changeset/nervous-forks-drum.md
+++ b/.changeset/nervous-forks-drum.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Fix boundary stopping `multipart/mixed` streams when it randomly occurs in response payloads.

--- a/packages/core/src/internal/fetchSource.ts
+++ b/packages/core/src/internal/fetchSource.ts
@@ -77,7 +77,7 @@ async function* parseMultipartMixed(
   response: Response
 ): AsyncIterableIterator<ExecutionResult> {
   const boundaryHeader = contentType.match(boundaryHeaderRe);
-  const boundary = '--' + (boundaryHeader ? boundaryHeader[1] : '-');
+  const boundary = '\r\n--' + (boundaryHeader ? boundaryHeader[1] : '-');
   let isPreamble = true;
   let payload: any;
   for await (const chunk of split(streamBody(response), boundary)) {


### PR DESCRIPTION
Resolve #3153

## Summary

The spec makes no stipulations as per what the boundary should be changed to when the content happens to contain the boundary. So, naturally, we'll need to split on `CRLF` with the boundary.

## Set of changes

- Add `CRLF` to boundary splitting
