### PR TITLE
fix(core): Strictly deduplicate operations for cache-and-network and network-only

### DIFF
--- a/.changeset/good-coins-know.md
+++ b/.changeset/good-coins-know.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Strictly deduplicate `cache-and-network` and `network-only` operations, while a non-stale response is being waited for.

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -583,7 +583,8 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
     if (
       operation.kind === 'mutation' ||
       operation.kind === 'teardown' ||
-      (prevReplay ? !prevReplay.hasNext : !dispatched.has(operation.key))
+      ((!prevReplay || (!prevReplay.hasNext && !prevReplay.stale)) &&
+        !dispatched.has(operation.key))
     ) {
       if (operation.kind === 'teardown') {
         dispatched.delete(operation.key);

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -579,12 +579,10 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
   const operations = makeSubject<Operation>();
 
   function nextOperation(operation: Operation) {
-    const prevReplay = replays.get(operation.key);
     if (
       operation.kind === 'mutation' ||
       operation.kind === 'teardown' ||
-      (!dispatched.has(operation.key) &&
-        (!prevReplay || (!prevReplay.hasNext && !prevReplay.stale)))
+      !dispatched.has(operation.key)
     ) {
       if (operation.kind === 'teardown') {
         dispatched.delete(operation.key);

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -583,8 +583,8 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
     if (
       operation.kind === 'mutation' ||
       operation.kind === 'teardown' ||
-      ((!prevReplay || (!prevReplay.hasNext && !prevReplay.stale)) &&
-        !dispatched.has(operation.key))
+      (!dispatched.has(operation.key) &&
+        (!prevReplay || (!prevReplay.hasNext && !prevReplay.stale)))
     ) {
       if (operation.kind === 'teardown') {
         dispatched.delete(operation.key);
@@ -665,7 +665,8 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
         result$,
         // Store replay result
         onPush(result => {
-          dispatched.delete(operation.key);
+          if (!result.hasNext && !result.stale)
+            dispatched.delete(operation.key);
           replays.set(operation.key, result);
         }),
         // Cleanup active states on end of source


### PR DESCRIPTION
Resolves #3136

## Summary

This strictly deduplicates operations issued as `cache-and-network` and `network-only`, when results are either stale or still being waited for. This will drop more redundant operations.

## Set of changes

- Drop dispatched operations when a non-stale result is still being awaited for
