### PR TITLE
fix(graphcache): Fix offlineExchange duplicating offline mutations

### DIFF
--- a/.changeset/warm-poets-battle.md
+++ b/.changeset/warm-poets-battle.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix `offlineExchange` duplicating offline mutations in failed queue.

--- a/exchanges/graphcache/src/offlineExchange.ts
+++ b/exchanges/graphcache/src/offlineExchange.ts
@@ -1,4 +1,4 @@
-import { pipe, merge, makeSubject, filter } from 'wonka';
+import { pipe, share, merge, makeSubject, filter } from 'wonka';
 import { SelectionNode } from '@0no-co/graphql.web';
 
 import {
@@ -180,7 +180,8 @@ export const offlineExchange =
             }
 
             return true;
-          })
+          }),
+          share
         );
       };
 


### PR DESCRIPTION
Resolves #3142

## Summary

Fixes a missing `share` call in `offlineExchange` which would lead to duplicated offline mutations being queued up.

## Set of changes

- Add missing `forward` `share` call
