### PR TITLE
fix(core): Improve reexecuteOperation of arbitrary operations

### DIFF
--- a/.changeset/wicked-eggs-talk.md
+++ b/.changeset/wicked-eggs-talk.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Improve dispatching of arbitrary operations using `reexecuteOperation`

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -716,10 +716,7 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
       // operation's exchange results
       if (operation.kind === 'teardown') {
         dispatchOperation(operation);
-      } else if (
-        (operation.kind !== 'query' && operation.kind !== 'subscription') ||
-        active.has(operation.key)
-      ) {
+      } else if (operation.kind === 'mutation' || active.has(operation.key)) {
         queue.push(operation);
         Promise.resolve().then(dispatchOperation);
       }

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -714,7 +714,12 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
     reexecuteOperation(operation: Operation) {
       // Reexecute operation only if any subscribers are still subscribed to the
       // operation's exchange results
-      if (operation.kind === 'mutation' || active.has(operation.key)) {
+      if (operation.kind === 'teardown') {
+        dispatchOperation(operation);
+      } else if (
+        (operation.kind !== 'query' && operation.kind !== 'subscription') ||
+        active.has(operation.key)
+      ) {
         queue.push(operation);
         Promise.resolve().then(dispatchOperation);
       }


### PR DESCRIPTION
## Summary

This covers all operation kinds in `client.reexecuteOperation`, in case we end up using it as an arbitrary dispatcher. I realised, the old behaviour may have been confusing and there isn't an alternative to this method, so it really shouldn't be.

## Set of changes

- Handle subscriptions and teardowns properly in `client.reexecuteOperation`
