### PR TITLE
fix(graphcache): Mark deferred, uncached results as partial

### DIFF
--- a/.changeset/rich-taxis-end.md
+++ b/.changeset/rich-taxis-end.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Apply `hasNext: true` and fallthrough logic to cached queries that contain deferred, uncached fields. Deferred query results will now be fetched against the API correctly, even if prior requests have been incomplete.

--- a/exchanges/graphcache/e2e-tests/query.spec.tsx
+++ b/exchanges/graphcache/e2e-tests/query.spec.tsx
@@ -191,7 +191,7 @@ describe('Graphcache Queries', () => {
 
     cy.get('#first-data').should('have.text', 'Data: title');
     cy.get('#second-data').should('have.text', 'Data: foo');
-    cy.get('#second-stale').should('have.text', 'Stale: true');
+    cy.get('#second-stale').should('have.text', 'Stale: false');
     // TODO: ideally we would be able to keep the error here but...
     // cy.get('#first-error').should('have.text', 'Error: [GraphQL] Test');
     // cy.get('#second-error').should('have.text', 'Error: [GraphQL] Test');

--- a/exchanges/graphcache/src/cacheExchange.test.ts
+++ b/exchanges/graphcache/src/cacheExchange.test.ts
@@ -2411,9 +2411,9 @@ describe('commutativity', () => {
   });
 
   it('applies deferred results to previous layers', () => {
-    let normalData: any;
-    let deferredData: any;
-    let combinedData: any;
+    let normalData: OperationResult | undefined;
+    let deferredData: OperationResult | undefined;
+    let combinedData: OperationResult | undefined;
 
     const client = createClient({
       url: 'http://0.0.0.0',
@@ -2475,11 +2475,11 @@ describe('commutativity', () => {
       tap(result => {
         if (result.operation.kind === 'query') {
           if (result.operation.key === 1) {
-            deferredData = result.data;
+            deferredData = result;
           } else if (result.operation.key === 42) {
-            combinedData = result.data;
+            combinedData = result;
           } else {
-            normalData = result.data;
+            normalData = result;
           }
         }
       }),
@@ -2530,9 +2530,9 @@ describe('commutativity', () => {
       },
     });
 
-    expect(normalData).toHaveProperty('node.id', 2);
-    expect(combinedData).not.toHaveProperty('deferred');
-    expect(combinedData).toHaveProperty('node.id', 2);
+    expect(normalData).toHaveProperty('data.node.id', 2);
+    expect(combinedData).not.toHaveProperty('data.deferred');
+    expect(combinedData).toHaveProperty('data.node.id', 2);
 
     nextRes({
       ...queryResponse,
@@ -2548,8 +2548,11 @@ describe('commutativity', () => {
       hasNext: true,
     });
 
-    expect(deferredData).toHaveProperty('deferred.id', 1);
-    expect(combinedData).toHaveProperty('deferred.id', 1);
-    expect(combinedData).toHaveProperty('node.id', 2);
+    expect(deferredData).toHaveProperty('hasNext', true);
+    expect(deferredData).toHaveProperty('data.deferred.id', 1);
+
+    expect(combinedData).toHaveProperty('hasNext', false);
+    expect(combinedData).toHaveProperty('data.deferred.id', 1);
+    expect(combinedData).toHaveProperty('data.node.id', 2);
   });
 });

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -366,7 +366,7 @@ export const cacheExchange =
             data: res.data,
             error: res.error,
             extensions: res.extensions,
-            stale: shouldReexecute && res.outcome === 'partial',
+            stale: shouldReexecute && !res.hasNext,
             hasNext: shouldReexecute && res.hasNext,
           };
 

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -348,7 +348,6 @@ export const cacheExchange =
         ),
         map((res: OperationResultWithMeta): OperationResult => {
           const { requestPolicy } = res.operation.context;
-          const isPartial = res.outcome === 'partial';
 
           // We reexecute requests marked as `cache-and-network`, and partial responses,
           // if we wouldn't cause a request loop
@@ -367,7 +366,7 @@ export const cacheExchange =
             data: res.data,
             error: res.error,
             extensions: res.extensions,
-            stale: shouldReexecute && isPartial,
+            stale: shouldReexecute && res.outcome === 'partial',
             hasNext: shouldReexecute && res.hasNext,
           };
 

--- a/exchanges/graphcache/src/operations/query.ts
+++ b/exchanges/graphcache/src/operations/query.ts
@@ -61,6 +61,7 @@ import {
 export interface QueryResult {
   dependencies: Dependencies;
   partial: boolean;
+  hasNext: boolean;
   data: null | Data;
 }
 
@@ -121,6 +122,7 @@ export const read = (
   return {
     dependencies: getCurrentDependencies(),
     partial: ctx.partial || !data,
+    hasNext: ctx.hasNext,
     data: data || null,
   };
 };
@@ -334,6 +336,7 @@ const readSelection = (
 
   let hasFields = false;
   let hasPartials = false;
+  let hasNext = false;
   let hasChanged = typename !== input.__typename;
   let node: FieldNode | void;
   const output = makeData(input);
@@ -455,7 +458,7 @@ const readSelection = (
     // a partial query result
     if (dataFieldValue === undefined && deferRef.current) {
       // The field is undelivered and uncached, but is included in a deferred fragment
-      hasFields = true;
+      hasNext = true;
     } else if (
       dataFieldValue === undefined &&
       ((store.schema && isFieldNullable(store.schema, typename, fieldName)) ||
@@ -481,6 +484,7 @@ const readSelection = (
   }
 
   ctx.partial = ctx.partial || hasPartials;
+  ctx.hasNext = ctx.hasNext || hasNext;
   return isQuery && hasPartials && !hasFields
     ? undefined
     : hasChanged

--- a/exchanges/graphcache/src/operations/shared.ts
+++ b/exchanges/graphcache/src/operations/shared.ts
@@ -43,6 +43,7 @@ export interface Context {
   fieldName: string;
   error: ErrorLike | undefined;
   partial: boolean;
+  hasNext: boolean;
   optimistic: boolean;
   __internal: {
     path: Array<string | number>;
@@ -79,6 +80,7 @@ export const makeContext = (
     fieldName: '',
     error: undefined,
     partial: false,
+    hasNext: false,
     optimistic: !!optimistic,
     __internal: {
       path: [],


### PR DESCRIPTION
Resolves #3161

## Summary

Previously, as `hasNext` wasn't consistently handled across the `urql` codebase prior to `v4`, we didn't have a signal and logic to handle partial, deferred results. We can now add the `hasNext` flag to `@urql/exchange-graphcache` and let deferred, uncached results fall through the usual cached result handling, and instead, pass the query on to the API.

## Set of changes

- Add `hasNext` flag to cached query results
- Handle `hasNext` cache results in `cacheExchange` and pass them on
- Increase consistency of `stale` flag for `cache-only` operations
