### PR TITLE
fix(auth): prevent retrying the operation produced by `mutate`

### DIFF
--- a/.changeset/strange-elephants-serve.md
+++ b/.changeset/strange-elephants-serve.md
@@ -2,4 +2,4 @@
 '@urql/exchange-auth': patch
 ---
 
-Fix case where we would retry the operation created by `mutate` when it failed auth
+Fix operations created by `utilities.mutate()` erroneously being retried and sent again like a regular operation

--- a/.changeset/strange-elephants-serve.md
+++ b/.changeset/strange-elephants-serve.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-auth': patch
+---
+
+Fix case where we would retry the operation created by `mutate` when it failed auth

--- a/exchanges/auth/src/authExchange.ts
+++ b/exchanges/auth/src/authExchange.ts
@@ -200,7 +200,7 @@ export function authExchange(
   init: (utilities: AuthUtilities) => Promise<AuthConfig>
 ): Exchange {
   return ({ client, forward }) => {
-    const bypassQueue = new Set<OperationInstance>();
+    const bypassQueue = new Set<OperationInstance | undefined>();
     const retries = makeSubject<Operation>();
 
     let retryQueue = new Map<number, Operation>();
@@ -352,9 +352,7 @@ export function authExchange(
         result$,
         filter(result => {
           if (
-            ((result.operation.context._instance &&
-              !bypassQueue.has(result.operation.context._instance)) ||
-              !result.operation.context._instance) &&
+            !bypassQueue.has(result.operation.context._instance) &&
             result.error &&
             didAuthError(result) &&
             !result.operation.context.authAttempt
@@ -363,10 +361,7 @@ export function authExchange(
             return false;
           }
 
-          if (
-            result.operation.context._instance &&
-            bypassQueue.has(result.operation.context._instance)
-          ) {
+          if (bypassQueue.has(result.operation.context._instance)) {
             bypassQueue.delete(result.operation.context._instance);
           }
 

--- a/exchanges/auth/src/authExchange.ts
+++ b/exchanges/auth/src/authExchange.ts
@@ -311,10 +311,10 @@ export function authExchange(
       const opsWithAuth$ = pipe(
         merge([retries.source, pendingOps$]),
         map(operation => {
-          if (operation.context.authAttempt) {
-            return addAuthToOperation(operation);
-          } else if (bypassQueue.has(operation)) {
+          if (bypassQueue.has(operation)) {
             return operation;
+          } else if (operation.context.authAttempt) {
+            return addAuthToOperation(operation);
           } else if (authPromise) {
             if (!retryQueue.has(operation.key)) {
               retryQueue.set(
@@ -341,6 +341,7 @@ export function authExchange(
         result$,
         filter(result => {
           if (
+            !bypassQueue.has(result.operation) &&
             result.error &&
             didAuthError(result) &&
             !result.operation.context.authAttempt


### PR DESCRIPTION
## Summary

There were scenario's where the `operation` would get altered and hence we wouldn't see it in the bypassQueue, now to make sure the first thing we do is we add the operation in the `bypassQueue` by the mutation identity.

Secondly we prevent ever calling `didAuthError` on operations produced by `utils.mutate` and last but not least we have started cleaning up the Set when results do come in.

## Set of changes

- assert on a `operationc.context._identity` match
- key the bypassQueue by `operationc.context._identity`
- clear the queue after a result comes in
