### PR TITLE
fix(graphcache): Improve separation of API and owned data

### DIFF
--- a/.changeset/gentle-melons-march.md
+++ b/.changeset/gentle-melons-march.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Prevent reusal of incoming API data in Graphcache’s produced (“owned”) data. This prevents us from copying the `__typename` and other superfluous fields.

--- a/exchanges/graphcache/src/cacheExchange.test.ts
+++ b/exchanges/graphcache/src/cacheExchange.test.ts
@@ -100,13 +100,12 @@ describe('data dependencies', () => {
     expect(response).toHaveBeenCalledTimes(1);
     expect(result).toHaveBeenCalledTimes(2);
 
-    expect(result.mock.calls[0][0].data).toEqual(expected);
+    expect(expected).toMatchObject(result.mock.calls[0][0].data);
     expect(result.mock.calls[1][0]).toHaveProperty(
       'operation.context.meta.cacheOutcome',
       'hit'
     );
-    expect(result.mock.calls[1][0].data).toEqual(expected);
-
+    expect(expected).toMatchObject(result.mock.calls[1][0].data);
     expect(result.mock.calls[1][0].data).toBe(result.mock.calls[0][0].data);
   });
 
@@ -771,7 +770,6 @@ describe('optimistic updates', () => {
     expect(reexec).toHaveBeenCalledTimes(1);
 
     expect(result.mock.calls[1][0]?.data).toMatchObject({
-      __typename: 'Query',
       author: { name: '[REDACTED OFFLINE]' },
     });
 
@@ -1259,7 +1257,6 @@ describe('custom resolvers', () => {
 
     vi.runAllTimers();
     expect(result.mock.calls[1][0].data).toEqual({
-      __typename: 'Mutation',
       concealAuthor: {
         __typename: 'Author',
         id: '123',
@@ -1425,7 +1422,6 @@ describe('custom resolvers', () => {
     expect(response).toHaveBeenCalledTimes(2);
     expect(fakeResolver).toHaveBeenCalledTimes(6);
     expect(result.mock.calls[1][0].data).toEqual({
-      __typename: 'Mutation',
       concealAuthors: [
         {
           __typename: 'Author',

--- a/exchanges/graphcache/src/cacheExchange.test.ts
+++ b/exchanges/graphcache/src/cacheExchange.test.ts
@@ -100,10 +100,6 @@ describe('data dependencies', () => {
     expect(response).toHaveBeenCalledTimes(1);
     expect(result).toHaveBeenCalledTimes(2);
 
-    expect(result.mock.calls[0][0]).toHaveProperty(
-      'operation.context.meta.cacheOutcome',
-      'miss'
-    );
     expect(result.mock.calls[0][0].data).toEqual(expected);
     expect(result.mock.calls[1][0]).toHaveProperty(
       'operation.context.meta.cacheOutcome',
@@ -230,7 +226,7 @@ describe('data dependencies', () => {
 
     next(opMultiple);
     expect(response).toHaveBeenCalledTimes(2);
-    expect(reexec).toHaveBeenCalledWith(opOne);
+    expect(reexec.mock.calls[0][0]).toHaveProperty('key', opOne.key);
     expect(result).toHaveBeenCalledTimes(3);
 
     // test for reference reuse
@@ -1583,10 +1579,6 @@ describe('schema awareness', () => {
       ],
     });
 
-    expect(result.mock.calls[0][0]).not.toHaveProperty(
-      'operation.context.meta'
-    );
-
     next(queryOperation);
     vi.runAllTimers();
     expect(result).toHaveBeenCalledTimes(2);
@@ -1724,10 +1716,6 @@ describe('schema awareness', () => {
         },
       ],
     });
-
-    expect(result.mock.calls[0][0]).not.toHaveProperty(
-      'operation.context.meta'
-    );
 
     next(queryOperation);
     vi.runAllTimers();

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -361,7 +361,10 @@ export const cacheExchange =
             /*noop*/
           } else if (!isBlockedByOptimisticUpdate(res.dependencies)) {
             client.reexecuteOperation(
-              toRequestPolicy(res.operation, 'network-only')
+              toRequestPolicy(
+                operations.get(res.operation.key) || res.operation,
+                'network-only'
+              )
             );
           } else if (requestPolicy === 'cache-and-network') {
             requestedRefetch.add(res.operation.key);

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -210,7 +210,12 @@ export const cacheExchange =
       operation: Operation
     ): OperationResultWithMeta => {
       initDataState('read', store.data, undefined, false);
-      const result = _query(store, operation, results.get(operation.key));
+      const result = _query(
+        store,
+        operation,
+        results.get(operation.key),
+        undefined
+      );
       clearDataState();
       const cacheOutcome: CacheOutcome = result.data
         ? !result.partial && !result.hasNext

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -209,7 +209,7 @@ export const cacheExchange =
     const operationResultFromCache = (
       operation: Operation
     ): OperationResultWithMeta => {
-      initDataState('read', store.data);
+      initDataState('read', store.data, undefined, false);
       const result = _query(store, operation, results.get(operation.key));
       clearDataState();
       const cacheOutcome: CacheOutcome = result.data
@@ -253,7 +253,7 @@ export const cacheExchange =
       if (data) {
         // Write the result to cache and collect all dependencies that need to be
         // updated
-        initDataState('write', store.data, operation.key);
+        initDataState('write', store.data, operation.key, false);
         const writeDependencies = _write(
           store,
           operation,
@@ -262,9 +262,9 @@ export const cacheExchange =
         ).dependencies;
         clearDataState();
         collectPendingOperations(pendingOperations, writeDependencies);
-        initDataState('read', store.data, operation.key);
         const prevData =
           operation.kind === 'query' ? results.get(operation.key) : null;
+        initDataState('read', store.data, operation.key, false);
         const queryResult = _query(
           store,
           operation,

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -156,14 +156,8 @@ export const cacheExchange =
       ) {
         operations.set(operation.key, operation);
         // This executes an optimistic update for mutations and registers it if necessary
-        initDataState('write', store.data, operation.key, true);
-        const { dependencies } = _write(
-          store,
-          operation,
-          undefined,
-          undefined,
-          true
-        );
+        initDataState('write', store.data, operation.key, true, false);
+        const { dependencies } = _write(store, operation, undefined, undefined);
         clearDataState();
         if (dependencies.size) {
           // Update blocked optimistic dependencies
@@ -209,7 +203,7 @@ export const cacheExchange =
     const operationResultFromCache = (
       operation: Operation
     ): OperationResultWithMeta => {
-      initDataState('read', store.data, undefined, false);
+      initDataState('read', store.data, undefined, false, false);
       const result = _query(
         store,
         operation,
@@ -258,7 +252,7 @@ export const cacheExchange =
       if (data) {
         // Write the result to cache and collect all dependencies that need to be
         // updated
-        initDataState('write', store.data, operation.key, false);
+        initDataState('write', store.data, operation.key, false, false);
         const writeDependencies = _write(
           store,
           operation,
@@ -269,7 +263,13 @@ export const cacheExchange =
         collectPendingOperations(pendingOperations, writeDependencies);
         const prevData =
           operation.kind === 'query' ? results.get(operation.key) : null;
-        initDataState('read', store.data, operation.key, false);
+        initDataState(
+          'read',
+          store.data,
+          operation.key,
+          false,
+          prevData !== data
+        );
         const queryResult = _query(
           store,
           operation,

--- a/exchanges/graphcache/src/extras/relayPagination.test.ts
+++ b/exchanges/graphcache/src/extras/relayPagination.test.ts
@@ -1,6 +1,7 @@
 import { gql } from '@urql/core';
 import { it, expect } from 'vitest';
-import { query, write } from '../operations';
+import { __initAnd_query as query } from '../operations/query';
+import { __initAnd_write as write } from '../operations/write';
 import { Store } from '../store';
 import { relayPagination } from './relayPagination';
 

--- a/exchanges/graphcache/src/extras/simplePagination.test.ts
+++ b/exchanges/graphcache/src/extras/simplePagination.test.ts
@@ -1,6 +1,7 @@
 import { gql } from '@urql/core';
 import { it, expect } from 'vitest';
-import { query, write } from '../operations';
+import { __initAnd_query as query } from '../operations/query';
+import { __initAnd_write as write } from '../operations/write';
 import { Store } from '../store';
 import { simplePagination } from './simplePagination';
 

--- a/exchanges/graphcache/src/index.ts
+++ b/exchanges/graphcache/src/index.ts
@@ -1,5 +1,4 @@
 export * from './types';
-export { query, write } from './operations';
-export { Store } from './store';
+export type { Store } from './store';
 export { cacheExchange } from './cacheExchange';
 export { offlineExchange } from './offlineExchange';

--- a/exchanges/graphcache/src/offlineExchange.test.ts
+++ b/exchanges/graphcache/src/offlineExchange.test.ts
@@ -160,7 +160,7 @@ describe('offline', () => {
 
     next(queryOp);
     expect(result).toBeCalledTimes(1);
-    expect(result.mock.calls[0][0].data).toMatchObject(queryOneData);
+    expect(queryOneData).toMatchObject(result.mock.calls[0][0].data);
 
     next(mutationOp);
     expect(result).toBeCalledTimes(1);

--- a/exchanges/graphcache/src/operations/index.ts
+++ b/exchanges/graphcache/src/operations/index.ts
@@ -1,2 +1,0 @@
-export { query, read } from './query';
-export { write, writeOptimistic, writeFragment } from './write';

--- a/exchanges/graphcache/src/operations/query.test.ts
+++ b/exchanges/graphcache/src/operations/query.test.ts
@@ -5,8 +5,8 @@ import { minifyIntrospectionQuery } from '@urql/introspection';
 import { describe, it, beforeEach, beforeAll, expect } from 'vitest';
 
 import { Store } from '../store';
-import { write } from './write';
-import { query } from './query';
+import { __initAnd_write as write } from './write';
+import { __initAnd_query as query } from './query';
 
 const TODO_QUERY = gql`
   query Todos {

--- a/exchanges/graphcache/src/operations/query.test.ts
+++ b/exchanges/graphcache/src/operations/query.test.ts
@@ -363,7 +363,7 @@ describe('Query', () => {
     expect(previousData).toHaveProperty('todos.0.textB', 'old');
   });
 
-  it('should not keep references stable', () => {
+  it('should keep references stable', () => {
     const QUERY = gql`
       query todos {
         __typename
@@ -398,31 +398,32 @@ describe('Query', () => {
 
     write(store, { query: QUERY }, expected);
 
-    const prevData = {
-      todos: [
-        {
-          __typename: 'Todo',
-          id: 'prev-0',
-        },
-        {
-          __typename: 'Todo',
-          id: '1',
-        },
-        {
-          __typename: 'Todo',
-          id: '2',
-        },
-      ],
-      __typename: 'query_root',
-    };
+    const prevData = query(
+      store,
+      { query: QUERY },
+      {
+        todos: [
+          {
+            __typename: 'Todo',
+            id: 'prev-0',
+          },
+          {
+            __typename: 'Todo',
+            id: '1',
+          },
+          {
+            __typename: 'Todo',
+            id: '2',
+          },
+        ],
+        __typename: 'query_root',
+      }
+    ).data as any;
 
-    const data = query(store, { query: QUERY }, prevData)
-      .data as typeof expected;
+    const data = query(store, { query: QUERY }, prevData).data as any;
     expect(data).toEqual(expected);
 
-    expect(prevData.todos[0]).not.toEqual(data.todos[0]);
-    expect(prevData.todos[0]).not.toBe(data.todos[0]);
-    // unchanged references:
+    expect(prevData.todos[0]).toBe(data.todos[0]);
     expect(prevData.todos[1]).toBe(data.todos[1]);
     expect(prevData.todos[2]).toBe(data.todos[2]);
   });

--- a/exchanges/graphcache/src/operations/query.ts
+++ b/exchanges/graphcache/src/operations/query.ts
@@ -69,7 +69,7 @@ export interface QueryResult {
 /** Reads a GraphQL query from the cache.
  * @internal
  */
-export const query = (
+export const __initAnd_query = (
   store: Store,
   request: OperationRequest,
   data?: Data | null | undefined,
@@ -77,12 +77,15 @@ export const query = (
   key?: number
 ): QueryResult => {
   initDataState('read', store.data, key);
-  const result = read(store, request, data, error);
+  const result = _query(store, request, data, error);
   clearDataState();
   return result;
 };
 
-export const read = (
+/** Reads a GraphQL query from the cache.
+ * @internal
+ */
+export const _query = (
   store: Store,
   request: OperationRequest,
   input?: Data | null | undefined,
@@ -211,7 +214,7 @@ const readRootField = (
   }
 };
 
-export const readFragment = (
+export const _queryFragment = (
   store: Store,
   query: DocumentNode,
   entity: Partial<Data> | string,

--- a/exchanges/graphcache/src/operations/query.ts
+++ b/exchanges/graphcache/src/operations/query.ts
@@ -460,7 +460,7 @@ const readSelection = (
     // Now that dataFieldValue has been retrieved it'll be set on data
     // If it's uncached (undefined) but nullable we can continue assembling
     // a partial query result
-    if (dataFieldValue === undefined && deferRef.current) {
+    if (dataFieldValue === undefined && deferRef) {
       // The field is undelivered and uncached, but is included in a deferred fragment
       hasNext = true;
     } else if (

--- a/exchanges/graphcache/src/operations/shared.ts
+++ b/exchanges/graphcache/src/operations/shared.ts
@@ -51,8 +51,8 @@ export interface Context {
   };
 }
 
-export const contextRef: { current: Context | null } = { current: null };
-export const deferRef: { current: boolean } = { current: false };
+export let contextRef: Context | null = null;
+export let deferRef = false;
 
 // Checks whether the current data field is a cache miss because of a GraphQLError
 export const getFieldError = (ctx: Context): ErrorLike | undefined =>
@@ -110,7 +110,7 @@ export const updateContext = (
   fieldKey: string,
   fieldName: string
 ) => {
-  contextRef.current = ctx;
+  contextRef = ctx;
   ctx.parent = data;
   ctx.parentTypeName = typename;
   ctx.parentKey = entityKey;
@@ -168,7 +168,7 @@ export const makeSelectionIterator = (
   let index = 0;
 
   return function next() {
-    if (!deferRef.current && childDeferred) deferRef.current = childDeferred;
+    if (!deferRef && childDeferred) deferRef = childDeferred;
 
     if (childIterator) {
       const node = childIterator();
@@ -208,8 +208,7 @@ export const makeSelectionIterator = (
             }
 
             childDeferred = !!isDeferred(node, ctx.variables);
-            if (!deferRef.current && childDeferred)
-              deferRef.current = childDeferred;
+            if (!deferRef && childDeferred) deferRef = childDeferred;
 
             return (childIterator = makeSelectionIterator(
               typename,

--- a/exchanges/graphcache/src/operations/write.test.ts
+++ b/exchanges/graphcache/src/operations/write.test.ts
@@ -4,7 +4,7 @@ import { gql, CombinedError } from '@urql/core';
 import { minifyIntrospectionQuery } from '@urql/introspection';
 import { vi, expect, it, beforeEach, describe, beforeAll } from 'vitest';
 
-import { write } from './write';
+import { __initAnd_write as write } from './write';
 import * as InMemoryData from '../store/data';
 import { Store } from '../store';
 

--- a/exchanges/graphcache/src/operations/write.ts
+++ b/exchanges/graphcache/src/operations/write.ts
@@ -245,7 +245,7 @@ const writeSelection = (
       if (
         rootField === 'query' &&
         fieldValue === undefined &&
-        !deferRef.current &&
+        !deferRef &&
         !ctx.optimistic
       ) {
         const expected =
@@ -274,7 +274,7 @@ const writeSelection = (
       // Fields marked as deferred that aren't defined must be skipped
       // Otherwise, we also ignore undefined values in optimistic updaters
       (fieldValue === undefined &&
-        (deferRef.current || (ctx.optimistic && rootField === 'query')))
+        (deferRef || (ctx.optimistic && rootField === 'query')))
     ) {
       continue;
     }

--- a/exchanges/graphcache/src/operations/write.ts
+++ b/exchanges/graphcache/src/operations/write.ts
@@ -90,7 +90,7 @@ export const __initAnd_writeOptimistic = (
   }
 
   initDataState('write', store.data, key, true);
-  const result = _write(store, request, {} as Data, undefined, true);
+  const result = _write(store, request, {} as Data, undefined);
   clearDataState();
   return result;
 };
@@ -99,8 +99,7 @@ export const _write = (
   store: Store,
   request: OperationRequest,
   data?: Data,
-  error?: CombinedError | undefined,
-  isOptimistic?: boolean
+  error?: CombinedError | undefined
 ) => {
   const operation = getMainOperation(request.query);
   const result: WriteResult = {
@@ -115,7 +114,7 @@ export const _write = (
     getFragments(request.query),
     kind,
     kind,
-    !!isOptimistic,
+    InMemoryData.currentOptimistic,
     error
   );
 

--- a/exchanges/graphcache/src/operations/write.ts
+++ b/exchanges/graphcache/src/operations/write.ts
@@ -39,6 +39,7 @@ import {
   clearDataState,
   joinKeys,
   keyOfField,
+  makeData,
 } from '../store';
 
 import * as InMemoryData from '../store/data';
@@ -61,7 +62,7 @@ export interface WriteResult {
 /** Writes a GraphQL response to the cache.
  * @internal
  */
-export const write = (
+export const __initAnd_write = (
   store: Store,
   request: OperationRequest,
   data: Data,
@@ -69,12 +70,12 @@ export const write = (
   key?: number
 ): WriteResult => {
   initDataState('write', store.data, key || null);
-  const result = startWrite(store, request, data, error);
+  const result = _write(store, request, data, error);
   clearDataState();
   return result;
 };
 
-export const writeOptimistic = (
+export const __initAnd_writeOptimistic = (
   store: Store,
   request: OperationRequest,
   key: number
@@ -89,20 +90,23 @@ export const writeOptimistic = (
   }
 
   initDataState('write', store.data, key, true);
-  const result = startWrite(store, request, {} as Data, undefined, true);
+  const result = _write(store, request, {} as Data, undefined, true);
   clearDataState();
   return result;
 };
 
-export const startWrite = (
+export const _write = (
   store: Store,
   request: OperationRequest,
-  data: Data,
+  data?: Data,
   error?: CombinedError | undefined,
   isOptimistic?: boolean
 ) => {
   const operation = getMainOperation(request.query);
-  const result: WriteResult = { data, dependencies: getCurrentDependencies() };
+  const result: WriteResult = {
+    data: data || makeData(),
+    dependencies: getCurrentDependencies(),
+  };
   const kind = store.rootFields[operation.operation];
 
   const ctx = makeContext(
@@ -119,7 +123,7 @@ export const startWrite = (
     pushDebugNode(kind, operation);
   }
 
-  writeSelection(ctx, kind, getSelectionSet(operation), data);
+  writeSelection(ctx, kind, getSelectionSet(operation), result.data!);
 
   if (process.env.NODE_ENV !== 'production') {
     popDebugNode();
@@ -128,7 +132,7 @@ export const startWrite = (
   return result;
 };
 
-export const writeFragment = (
+export const _writeFragment = (
   store: Store,
   query: DocumentNode,
   data: Partial<Data>,

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -57,6 +57,8 @@ export interface InMemoryData {
   storage: StorageAdapter | null;
 }
 
+const globalOwnership = new WeakSet<Data>();
+
 let currentOwnership: null | WeakSet<Data> = null;
 let currentDataMapping: null | WeakMap<Data, Data> = null;
 let currentOperation: null | OperationType = null;
@@ -77,6 +79,7 @@ export const makeData = (data?: Data): Data => {
   }
 
   currentOwnership!.add(newData);
+  globalOwnership.add(newData);
   return newData;
 };
 
@@ -84,6 +87,8 @@ export const isWriting = (): boolean => currentOperation === 'write';
 
 export const ownsData = (data?: Data): boolean =>
   !!data && currentOwnership!.has(data);
+
+export const foreignData = (data: Data): boolean => !globalOwnership.has(data);
 
 /** Before reading or writing the global state needs to be initialised */
 export const initDataState = (

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -72,7 +72,7 @@ export const makeData = (data?: Data): Data => {
   let newData: Data;
   if (data) {
     if (currentOwnership!.has(data)) return data;
-    newData = currentDataMapping!.get(data) || ({ ...data } as Data);
+    newData = currentDataMapping!.get(data) || ({} as Data);
     currentDataMapping!.set(data, newData);
   } else {
     newData = {} as Data;

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -57,14 +57,13 @@ export interface InMemoryData {
   storage: StorageAdapter | null;
 }
 
-const globalOwnership = new WeakSet<Data>();
-
 let currentOwnership: null | WeakSet<Data> = null;
 let currentDataMapping: null | WeakMap<Data, Data> = null;
 let currentOperation: null | OperationType = null;
 let currentData: null | InMemoryData = null;
 let currentDependencies: null | Dependencies = null;
 let currentOptimisticKey: null | number = null;
+export let currentForeignData = false;
 export let currentOptimistic = false;
 
 /** Creates a new data object unless it's been created in this data run */
@@ -79,7 +78,6 @@ export const makeData = (data?: Data): Data => {
   }
 
   currentOwnership!.add(newData);
-  globalOwnership.add(newData);
   return newData;
 };
 
@@ -88,14 +86,13 @@ export const isWriting = (): boolean => currentOperation === 'write';
 export const ownsData = (data?: Data): boolean =>
   !!data && currentOwnership!.has(data);
 
-export const foreignData = (data: Data): boolean => !globalOwnership.has(data);
-
 /** Before reading or writing the global state needs to be initialised */
 export const initDataState = (
   operationType: OperationType,
   data: InMemoryData,
   layerKey?: number | null,
-  isOptimistic?: boolean
+  isOptimistic?: boolean,
+  isForeignData?: boolean
 ) => {
   currentOwnership = new WeakSet();
   currentDataMapping = new WeakMap();
@@ -103,6 +100,7 @@ export const initDataState = (
   currentData = data;
   currentDependencies = new Set();
   currentOptimistic = !!isOptimistic;
+  currentForeignData = !!isForeignData;
   if (process.env.NODE_ENV !== 'production') {
     currentDebugStack.length = 0;
   }

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -65,7 +65,7 @@ let currentOperation: null | OperationType = null;
 let currentData: null | InMemoryData = null;
 let currentDependencies: null | Dependencies = null;
 let currentOptimisticKey: null | number = null;
-let currentOptimistic = false;
+export let currentOptimistic = false;
 
 /** Creates a new data object unless it's been created in this data run */
 export const makeData = (data?: Data): Data => {

--- a/exchanges/graphcache/src/store/index.ts
+++ b/exchanges/graphcache/src/store/index.ts
@@ -4,7 +4,6 @@ export {
   noopDataState,
   makeData,
   ownsData,
-  foreignData,
   reserveLayer,
   getCurrentOperation,
   getCurrentDependencies,

--- a/exchanges/graphcache/src/store/index.ts
+++ b/exchanges/graphcache/src/store/index.ts
@@ -4,6 +4,7 @@ export {
   noopDataState,
   makeData,
   ownsData,
+  foreignData,
   reserveLayer,
   getCurrentOperation,
   getCurrentDependencies,

--- a/exchanges/graphcache/src/store/store.test.ts
+++ b/exchanges/graphcache/src/store/store.test.ts
@@ -12,11 +12,15 @@ import {
 
 import { Data, StorageAdapter } from '../types';
 import { makeContext, updateContext } from '../operations/shared';
-import { query } from '../operations/query';
-import { write, writeOptimistic } from '../operations/write';
 import * as InMemoryData from './data';
 import { Store } from './store';
 import { noop } from '../test-utils/utils';
+
+import { __initAnd_query as query } from '../operations/query';
+import {
+  __initAnd_write as write,
+  __initAnd_writeOptimistic as writeOptimistic,
+} from '../operations/write';
 
 const mocked = (x: any): any => x;
 

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -166,14 +166,14 @@ export class Store<
     request.query = formatDocument(request.query);
     const output = updater(this.readQuery(request));
     if (output !== null) {
-      _write(this, request, output as any);
+      _write(this, request, output as any, undefined);
     }
   }
 
   readQuery<T = Data, V = Variables>(input: QueryInput<T, V>): T | null {
     const request = createRequest(input.query, input.variables!);
     request.query = formatDocument(request.query);
-    return _query(this, request).data as T | null;
+    return _query(this, request, undefined, undefined).data as T | null;
   }
 
   readFragment<T = Data, V = Variables>(

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -19,8 +19,8 @@ import {
 
 import { invariant } from '../helpers/help';
 import { contextRef, ensureLink } from '../operations/shared';
-import { read, readFragment } from '../operations/query';
-import { writeFragment, startWrite } from '../operations/write';
+import { _query, _queryFragment } from '../operations/query';
+import { _write, _writeFragment } from '../operations/write';
 import { invalidateEntity } from '../operations/invalidate';
 import { keyOfField } from './keys';
 import * as InMemoryData from './data';
@@ -166,14 +166,14 @@ export class Store<
     request.query = formatDocument(request.query);
     const output = updater(this.readQuery(request));
     if (output !== null) {
-      startWrite(this, request, output as any);
+      _write(this, request, output as any);
     }
   }
 
   readQuery<T = Data, V = Variables>(input: QueryInput<T, V>): T | null {
     const request = createRequest(input.query, input.variables!);
     request.query = formatDocument(request.query);
-    return read(this, request).data as T | null;
+    return _query(this, request).data as T | null;
   }
 
   readFragment<T = Data, V = Variables>(
@@ -182,7 +182,7 @@ export class Store<
     variables?: V,
     fragmentName?: string
   ): T | null {
-    return readFragment(
+    return _queryFragment(
       this,
       formatDocument(fragment),
       entity as Data,
@@ -197,7 +197,7 @@ export class Store<
     variables?: V,
     fragmentName?: string
   ): void {
-    writeFragment(
+    _writeFragment(
       this,
       formatDocument(fragment),
       data as Data,

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -107,8 +107,7 @@ export class Store<
     // In resolvers and updaters we may have a specific parent
     // object available that can be used to skip to a specific parent
     // key directly without looking at its incomplete properties
-    if (contextRef.current && data === contextRef.current.parent)
-      return contextRef.current!.parentKey;
+    if (contextRef && data === contextRef.parent) return contextRef.parentKey;
 
     if (data == null || typeof data === 'string') return data || null;
     if (!data.__typename) return null;

--- a/exchanges/graphcache/src/test-utils/examples-1.test.ts
+++ b/exchanges/graphcache/src/test-utils/examples-1.test.ts
@@ -1,6 +1,10 @@
 import { gql } from '@urql/core';
 import { it, expect, afterEach } from 'vitest';
-import { query, write, writeOptimistic } from '../operations';
+import { __initAnd_query as query } from '../operations/query';
+import {
+  __initAnd_write as write,
+  __initAnd_writeOptimistic as writeOptimistic,
+} from '../operations/write';
 import * as InMemoryData from '../store/data';
 import { Store } from '../store';
 import { Data } from '../types';

--- a/exchanges/graphcache/src/test-utils/examples-2.test.ts
+++ b/exchanges/graphcache/src/test-utils/examples-2.test.ts
@@ -1,6 +1,7 @@
 import { gql } from '@urql/core';
 import { it, afterEach, expect } from 'vitest';
-import { query, write } from '../operations';
+import { __initAnd_query as query } from '../operations/query';
+import { __initAnd_write as write } from '../operations/write';
 import { Store } from '../store';
 
 const Item = gql`

--- a/exchanges/graphcache/src/test-utils/examples-3.test.ts
+++ b/exchanges/graphcache/src/test-utils/examples-3.test.ts
@@ -1,6 +1,7 @@
 import { gql } from '@urql/core';
 import { it, afterEach, expect } from 'vitest';
-import { query, write } from '../operations';
+import { __initAnd_query as query } from '../operations/query';
+import { __initAnd_write as write } from '../operations/write';
 import { Store } from '../store';
 
 afterEach(() => {

--- a/exchanges/graphcache/src/test-utils/suite.test.ts
+++ b/exchanges/graphcache/src/test-utils/suite.test.ts
@@ -1,7 +1,8 @@
 import { DocumentNode } from 'graphql';
 import { gql } from '@urql/core';
 import { it, expect } from 'vitest';
-import { query, write } from '../operations';
+import { __initAnd_query as query } from '../operations/query';
+import { __initAnd_write as write } from '../operations/write';
 import { Store } from '../store';
 
 interface TestCase {


### PR DESCRIPTION
Resolves #3160

## Summary

This prevents us from:
- copying the incoming API data causing `__typename` to be applied to output data by default
- reusing incoming API data and treating it as equivalent to Graphcache’s owned data

In short, we don't differentiate in the `cacheExchange` whether we're passing `query()` previous Graphcache data or API data. This data is then used to diff against the new result, reusing as much of it as possible when it's unchanged. It's also used to complete the output data when some cache resolution fails, to fall back to API data.

However, we shouldn't reuse this data blindly when it's API data, since that data can slightly differ and carry `__typename` fields even when those aren't specified in the selection set.

## Set of changes

- Replace `originalVariables` with better `operations.set` tracking
- Stop copying original data when creating “owned” data
- Only reuse original data when it's previously “owned” data, and otherwise consider it changed
- Add “foreign data” flag to `initDataState`
- Remove operations helper usage in `cacheExchange` and intead call `initDataState` and `clearDataState` manually
- Clean up usage of `operations/*`
