### PR TITLE
fix(graphcache): Fix defer field state becoming sticky and affecting future fields

### DIFF
--- a/.changeset/real-queens-crash.md
+++ b/.changeset/real-queens-crash.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix regression which caused `@defer` directives from becoming “sticky” and causing every subsequent cache read to be treated as if the field was deferred.

--- a/exchanges/graphcache/src/operations/query.ts
+++ b/exchanges/graphcache/src/operations/query.ts
@@ -137,7 +137,13 @@ const readRoot = (
     return input;
   }
 
-  const iterate = makeSelectionIterator(entityKey, entityKey, select, ctx);
+  const iterate = makeSelectionIterator(
+    entityKey,
+    entityKey,
+    deferRef,
+    select,
+    ctx
+  );
 
   let node: FieldNode | void;
   let hasChanged = InMemoryData.currentForeignData;
@@ -334,7 +340,13 @@ const readSelection = (
   }
 
   const resolvers = store.resolvers[typename];
-  const iterate = makeSelectionIterator(typename, entityKey, select, ctx);
+  const iterate = makeSelectionIterator(
+    typename,
+    entityKey,
+    deferRef,
+    select,
+    ctx
+  );
 
   let hasFields = false;
   let hasPartials = false;

--- a/exchanges/graphcache/src/operations/shared.test.ts
+++ b/exchanges/graphcache/src/operations/shared.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect } from 'vitest';
+import { TypedDocumentNode, gql } from '@urql/core';
+import { FieldNode } from '@0no-co/graphql.web';
+
+import { makeSelectionIterator, deferRef } from './shared';
+import { SelectionSet } from '../ast';
+
+const selectionOfDocument = (doc: TypedDocumentNode): SelectionSet => {
+  for (const definition of doc.definitions)
+    if (definition.kind === 'OperationDefinition')
+      return definition.selectionSet.selections;
+  return [];
+};
+
+const ctx = {} as any;
+
+describe('makeSelectionIterator', () => {
+  it('emits all fields', () => {
+    const selection = selectionOfDocument(
+      gql`
+        {
+          a
+          b
+          c
+        }
+      `
+    );
+    const iterate = makeSelectionIterator('Query', 'Query', selection, ctx);
+    const result: FieldNode[] = [];
+
+    let node: FieldNode | void;
+    while ((node = iterate())) result.push(node);
+
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "alias": undefined,
+          "arguments": [],
+          "directives": [],
+          "kind": "Field",
+          "name": {
+            "kind": "Name",
+            "value": "a",
+          },
+          "selectionSet": undefined,
+        },
+        {
+          "alias": undefined,
+          "arguments": [],
+          "directives": [],
+          "kind": "Field",
+          "name": {
+            "kind": "Name",
+            "value": "b",
+          },
+          "selectionSet": undefined,
+        },
+        {
+          "alias": undefined,
+          "arguments": [],
+          "directives": [],
+          "kind": "Field",
+          "name": {
+            "kind": "Name",
+            "value": "c",
+          },
+          "selectionSet": undefined,
+        },
+      ]
+    `);
+  });
+
+  it('skips fields that are skipped or not included', () => {
+    const selection = selectionOfDocument(gql`
+      {
+        a @skip(if: true)
+        b @include(if: false)
+      }
+    `);
+
+    const iterate = makeSelectionIterator('Query', 'Query', selection, ctx);
+    const result: FieldNode[] = [];
+
+    let node: FieldNode | void;
+    while ((node = iterate())) result.push(node);
+
+    expect(result).toMatchInlineSnapshot('[]');
+  });
+
+  it('processes fragments', () => {
+    const selection = selectionOfDocument(gql`
+      {
+        a
+        ... {
+          b
+        }
+        ... {
+          ... {
+            c
+          }
+        }
+      }
+    `);
+
+    const iterate = makeSelectionIterator('Query', 'Query', selection, ctx);
+    const result: FieldNode[] = [];
+
+    let node: FieldNode | void;
+    while ((node = iterate())) result.push(node);
+
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "alias": undefined,
+          "arguments": [],
+          "directives": [],
+          "kind": "Field",
+          "name": {
+            "kind": "Name",
+            "value": "a",
+          },
+          "selectionSet": undefined,
+        },
+        {
+          "alias": undefined,
+          "arguments": [],
+          "directives": [],
+          "kind": "Field",
+          "name": {
+            "kind": "Name",
+            "value": "b",
+          },
+          "selectionSet": undefined,
+        },
+        {
+          "alias": undefined,
+          "arguments": [],
+          "directives": [],
+          "kind": "Field",
+          "name": {
+            "kind": "Name",
+            "value": "c",
+          },
+          "selectionSet": undefined,
+        },
+      ]
+    `);
+  });
+
+  it('updates deferred state as needed', () => {
+    const selection = selectionOfDocument(gql`
+      {
+        a
+        ... @defer {
+          b
+        }
+        ... {
+          ... @defer {
+            c
+          }
+        }
+        ... {
+          ... {
+            d
+          }
+        }
+        ... @defer {
+          ... {
+            e
+          }
+        }
+        ... {
+          ... {
+            f
+          }
+        }
+        ... {
+          g
+        }
+        h
+      }
+    `);
+
+    const iterate = makeSelectionIterator('Query', 'Query', selection, ctx);
+    const result: FieldNode[] = [];
+    const deferred: boolean[] = [];
+
+    let node: FieldNode | void;
+    while ((node = iterate())) {
+      result.push(node);
+      deferred.push(deferRef.current);
+    }
+
+    expect(deferred).toEqual([
+      false, // a
+      true, // b
+      true, // c
+      false, // d
+      true, // e
+      false, // f
+      false, // g
+      false, // h
+    ]);
+  });
+});

--- a/exchanges/graphcache/src/operations/shared.test.ts
+++ b/exchanges/graphcache/src/operations/shared.test.ts
@@ -25,7 +25,13 @@ describe('makeSelectionIterator', () => {
         }
       `
     );
-    const iterate = makeSelectionIterator('Query', 'Query', selection, ctx);
+    const iterate = makeSelectionIterator(
+      'Query',
+      'Query',
+      false,
+      selection,
+      ctx
+    );
     const result: FieldNode[] = [];
 
     let node: FieldNode | void;
@@ -78,7 +84,13 @@ describe('makeSelectionIterator', () => {
       }
     `);
 
-    const iterate = makeSelectionIterator('Query', 'Query', selection, ctx);
+    const iterate = makeSelectionIterator(
+      'Query',
+      'Query',
+      false,
+      selection,
+      ctx
+    );
     const result: FieldNode[] = [];
 
     let node: FieldNode | void;
@@ -102,7 +114,13 @@ describe('makeSelectionIterator', () => {
       }
     `);
 
-    const iterate = makeSelectionIterator('Query', 'Query', selection, ctx);
+    const iterate = makeSelectionIterator(
+      'Query',
+      'Query',
+      false,
+      selection,
+      ctx
+    );
     const result: FieldNode[] = [];
 
     let node: FieldNode | void;
@@ -181,16 +199,16 @@ describe('makeSelectionIterator', () => {
       }
     `);
 
-    const iterate = makeSelectionIterator('Query', 'Query', selection, ctx);
-    const result: FieldNode[] = [];
+    const iterate = makeSelectionIterator(
+      'Query',
+      'Query',
+      false,
+      selection,
+      ctx
+    );
+
     const deferred: boolean[] = [];
-
-    let node: FieldNode | void;
-    while ((node = iterate())) {
-      result.push(node);
-      deferred.push(deferRef.current);
-    }
-
+    while (iterate()) deferred.push(deferRef);
     expect(deferred).toEqual([
       false, // a
       true, // b
@@ -201,5 +219,31 @@ describe('makeSelectionIterator', () => {
       false, // g
       false, // h
     ]);
+  });
+
+  it('applies the parent’s defer state if needed', () => {
+    const selection = selectionOfDocument(gql`
+      {
+        a
+        ... @defer {
+          b
+        }
+        ... {
+          c
+        }
+      }
+    `);
+
+    const iterate = makeSelectionIterator(
+      'Query',
+      'Query',
+      true,
+      selection,
+      ctx
+    );
+
+    const deferred: boolean[] = [];
+    while (iterate()) deferred.push(deferRef);
+    expect(deferred).toEqual([true, true, true]);
   });
 });

--- a/exchanges/graphcache/src/operations/shared.ts
+++ b/exchanges/graphcache/src/operations/shared.ts
@@ -160,10 +160,10 @@ interface SelectionIterator {
 export const makeSelectionIterator = (
   typename: void | string,
   entityKey: string,
+  defer: boolean,
   selectionSet: SelectionSet,
   ctx: Context
 ): SelectionIterator => {
-  let defer = false;
   let child: SelectionIterator | void;
   let index = 0;
 
@@ -171,11 +171,9 @@ export const makeSelectionIterator = (
     let node: FieldNode | undefined;
     while (child || index < selectionSet.length) {
       node = undefined;
-      deferRef = false;
+      deferRef = defer;
       if (child) {
-        node = child();
-        deferRef = deferRef || defer;
-        if (node) {
+        if ((node = child())) {
           return node;
         } else {
           child = undefined;
@@ -204,10 +202,10 @@ export const makeSelectionIterator = (
             if (isMatching) {
               if (process.env.NODE_ENV !== 'production')
                 pushDebugNode(typename, fragment);
-              defer = isDeferred(select, ctx.variables);
               child = makeSelectionIterator(
                 typename,
                 entityKey,
+                defer || isDeferred(select, ctx.variables),
                 getSelectionSet(fragment),
                 ctx
               );

--- a/exchanges/graphcache/src/operations/shared.ts
+++ b/exchanges/graphcache/src/operations/shared.ts
@@ -160,66 +160,62 @@ interface SelectionIterator {
 export const makeSelectionIterator = (
   typename: void | string,
   entityKey: string,
-  select: SelectionSet,
+  selectionSet: SelectionSet,
   ctx: Context
 ): SelectionIterator => {
-  let childDeferred = false;
-  let childIterator: SelectionIterator | void;
+  let defer = false;
+  let child: SelectionIterator | void;
   let index = 0;
 
   return function next() {
-    if (!deferRef && childDeferred) deferRef = childDeferred;
-
-    if (childIterator) {
-      const node = childIterator();
-      if (node != null) {
-        return node;
-      }
-
-      childIterator = undefined;
-      childDeferred = false;
-      if (process.env.NODE_ENV !== 'production') {
-        popDebugNode();
-      }
-    }
-
-    while (index < select.length) {
-      const node = select[index++];
-      if (!shouldInclude(node, ctx.variables)) {
-        continue;
-      } else if (!isFieldNode(node)) {
-        // A fragment is either referred to by FragmentSpread or inline
-        const fragmentNode = !isInlineFragment(node)
-          ? ctx.fragments[getName(node)]
-          : node;
-
-        if (fragmentNode !== undefined) {
-          const isMatching = ctx.store.schema
-            ? isInterfaceOfType(ctx.store.schema, fragmentNode, typename)
-            : isFragmentHeuristicallyMatching(
-                fragmentNode,
-                typename,
-                entityKey,
-                ctx.variables
-              );
-          if (isMatching) {
-            if (process.env.NODE_ENV !== 'production') {
-              pushDebugNode(typename, fragmentNode);
-            }
-
-            childDeferred = !!isDeferred(node, ctx.variables);
-            if (!deferRef && childDeferred) deferRef = childDeferred;
-
-            return (childIterator = makeSelectionIterator(
-              typename,
-              entityKey,
-              getSelectionSet(fragmentNode)!,
-              ctx
-            ))();
-          }
+    let node: FieldNode | undefined;
+    while (child || index < selectionSet.length) {
+      node = undefined;
+      deferRef = false;
+      if (child) {
+        node = child();
+        deferRef = deferRef || defer;
+        if (node) {
+          return node;
+        } else {
+          child = undefined;
+          if (process.env.NODE_ENV !== 'production') popDebugNode();
         }
       } else {
-        return node;
+        const select = selectionSet[index++];
+        if (!shouldInclude(select, ctx.variables)) {
+          /*noop*/
+        } else if (!isFieldNode(select)) {
+          // A fragment is either referred to by FragmentSpread or inline
+          const fragment = !isInlineFragment(select)
+            ? ctx.fragments[getName(select)]
+            : select;
+          if (fragment) {
+            const isMatching =
+              !fragment.typeCondition ||
+              (ctx.store.schema
+                ? isInterfaceOfType(ctx.store.schema, fragment, typename)
+                : isFragmentHeuristicallyMatching(
+                    fragment,
+                    typename,
+                    entityKey,
+                    ctx.variables
+                  ));
+            if (isMatching) {
+              if (process.env.NODE_ENV !== 'production')
+                pushDebugNode(typename, fragment);
+              defer = isDeferred(select, ctx.variables);
+              child = makeSelectionIterator(
+                typename,
+                entityKey,
+                getSelectionSet(fragment),
+                ctx
+              );
+            }
+          }
+        } else {
+          return select;
+        }
       }
     }
   };

--- a/exchanges/graphcache/src/operations/write.ts
+++ b/exchanges/graphcache/src/operations/write.ts
@@ -226,6 +226,7 @@ const writeSelection = (
   const iterate = makeSelectionIterator(
     typename,
     entityKey || typename,
+    deferRef,
     select,
     ctx
   );


### PR DESCRIPTION
Resolves #3161

**Note:** This will need a rebase after #3165 is merged and should be merged on top.

## Summary

A rather old regression would cause `@defer` directives to manipulate the `deferRef` state and then become “sticky”, meaning that all future fields would also be considered deferred.

Instead, we need to make sure that this field resets properly and that the state returns to normal.

On a side-note, I tried to convert `makeSelectionIterator` to a generator function, since this would make it more elegant, but an initial rough implementation decreased overall cache read/write performance by 15–20%, so we'll have to investigate whether there's more we can do here. In general, traversal is the most expensive part of the cache operations, so if we can instead make it faster we'd profit from that quite a lot.

## Set of changes

- Refactor `makeSelectionIterator` to reset `deferRef`
- Add missing test cases for `makeSelectionIterator`
