### PR TITLE
fix(core): Replace File/Blob objects with null in serialized variables

### DIFF
--- a/.changeset/afraid-seas-arrive.md
+++ b/.changeset/afraid-seas-arrive.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Replace `File` and `Blob` objects with `null` in variables if multipart request will be started.

--- a/packages/core/src/internal/fetchOptions.test.ts
+++ b/packages/core/src/internal/fetchOptions.test.ts
@@ -149,7 +149,7 @@ describe('makeFetchOptions', () => {
       ...body,
       variables: {
         ...body.variables,
-        file: { __key: expect.any(String) },
+        file: null,
       },
     });
 

--- a/packages/core/src/utils/variables.test.ts
+++ b/packages/core/src/utils/variables.test.ts
@@ -40,13 +40,8 @@ describe('stringifyVariables', () => {
 
   it('stringifies files correctly', () => {
     const file = new File([0] as any, 'test.js');
-    Object.defineProperty(file, 'lastModified', { value: 123 });
     const str = stringifyVariables(file);
-    expect(str).toBe(stringifyVariables(file));
-
-    const otherFile = new File([0] as any, 'otherFile.js');
-    Object.defineProperty(otherFile, 'lastModified', { value: 234 });
-    expect(str).not.toBe(stringifyVariables(otherFile));
+    expect(str).toBe('null');
   });
 });
 

--- a/packages/core/src/utils/variables.ts
+++ b/packages/core/src/utils/variables.ts
@@ -18,6 +18,11 @@ const stringify = (x: any): string => {
     }
     out += ']';
     return out;
+  } else if (
+    (FileConstructor !== NoopConstructor && x instanceof FileConstructor) ||
+    (BlobConstructor !== NoopConstructor && x instanceof BlobConstructor)
+  ) {
+    return 'null';
   }
 
   const keys = Object.keys(x).sort();


### PR DESCRIPTION
Resolves #3168

## Summary

Seems like some APIs/frameworks actually care about this 🤷 Currently, this will affect operation keys, however, since mutations have unique instances, we can probably get away with making the keys for variables identical for queries.

## Set of changes

- Replace `File` and `Blob` with `null` in stringified variables
