### PR TITLE
fix(core): Handle both variations of multipart/mixed preamble

### DIFF
--- a/.changeset/itchy-queens-scream.md
+++ b/.changeset/itchy-queens-scream.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Handle `multipart/mixed` variations starting with boundary rather than CRLF and a boundary.


### PR DESCRIPTION
## Summary

This implements a fix for a regression in #3155.

Basically, we now split the incoming `multipart/mixed` response by `CRLF` and the boundary. However, our tests send the preamble split by `CRLF` + boundary, while some newer variations would only send the boundary as the preamble and only after use `CRLF`

This caused the first payload to be malformed and disregarded.

## Set of changes

- Add preamble recovery depending on `CRLF` splitting
