### PR TITLE
fix(core): Fix regression that broke cache-and-network

### DIFF
--- a/.changeset/moody-hats-attend.md
+++ b/.changeset/moody-hats-attend.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Fix regression which would disallow `network-only` operations after `cache-and-network` completed.

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -663,8 +663,18 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
         result$,
         // Store replay result
         onPush(result => {
-          if (!result.hasNext && !result.stale)
+          if (result.stale) {
+            // If the current result has queued up an operation of the same
+            // key, then `stale` refers to it
+            for (const operation of queue) {
+              if (operation.key === result.operation.key) {
+                dispatched.delete(operation.key);
+                break;
+              }
+            }
+          } else if (!result.hasNext) {
             dispatched.delete(operation.key);
+          }
           replays.set(operation.key, result);
         }),
         // Cleanup active states on end of source


### PR DESCRIPTION
Resolves regression from #3157

## Summary

This prevents us from blocking `network-only` operations which follow `cache-and-network` operations, if the latter has queued them up while the cached result comes in.

In other words, if `result.stale` is set, we still allow `dispatched.delete` to remove the key and unblock it if the current operations queue contains that operation. This basically is the equivalent of saying that we unblock operations, even if they're marked as `stale` if a new operation for them is already waiting to be sent.

## Set of changes

- Allow operations to be run if they're queued up already while a `result.stale` marked result comes in
