### PR TITLE
Fix typo in docs/advanced/debugging.md

### DIFF
--- a/docs/advanced/debugging.md
+++ b/docs/advanced/debugging.md
@@ -133,7 +133,7 @@ custom exchanges:
 - ✅ **Create unique event types** : Key events should be easily identifiable and have a unique
   names.
 - ❌ **Don't listen to debug events inside your exchange**: While it's possible to call
-  `client.subscsubscribeToDebugTarget` in an exchange it's only valuable when creating a debugging
+  `client.subscribeToDebugTarget` in an exchange it's only valuable when creating a debugging
   exchange, like the `devtoolsExchange`.
 - ❌ **Don't send warnings in debug events**: Informing your user about warnings isn't effective
   when the event isn't seen. You should still rely on `console.warn` so all users see your important


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR, but please make sure to open an issue or discuss
  your changes first, if you’re looking to submit a larger PR.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

The changes in this PR updates a typo in documentation, regarding a function call.
This could cause confusion for the readers of the documentation.

The statement is the following: 
> While it's possible to call
  `client.subscsubscribeToDebugTarget` in an exchange it's only valuable when creating a debugging

Besides the typo, the statement is true. Though, the typo assumes that the `subscsubscribeToDebugTarget` method is available on the `client` object, [which it isn't](https://github.com/urql-graphql/urql/blob/ff5d7397a14497193e28bfc69b719abe8dcdcaf8/packages/core/src/client.ts#L720).
<!-- What's the motivation of this change? What does it solve? -->

## Set of changes

- Altered the content of `docs/advanced/debugging.md`

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->
