### PR TITLE
fix(persisted): persisted queries can use GETs within URL limits

### DIFF
--- a/.changeset/fair-eels-march.md
+++ b/.changeset/fair-eels-march.md
@@ -1,5 +1,5 @@
 ---
-'@urql/exchange-persisted': patch
+'@urql/exchange-persisted': major
 ---
 
 Update the `preferGetForPersistedQueries` option to include the `'force'` and `'within-url-limit'` values from the Client's `preferGetMethod` option. The default value of `true` no longer sets `OperationContext`'s `preferGetMethod` setting to `'force'`. Instead, the value of `preferGetForPersistedQueries` carries through to the `OperationContext`'s `preferGetMethod` setting for persisted queries.

--- a/.changeset/fair-eels-march.md
+++ b/.changeset/fair-eels-march.md
@@ -2,4 +2,4 @@
 '@urql/exchange-persisted': patch
 ---
 
-Update the `preferGetForPersistedQueries` option to include the 'force' and 'within-url-limit' values from the Client's `preferGetMethod` option. The default value of `true` no longer sets `OperationContext`'s `preferGetMethod` setting to `'force'`. Instead, the value of `preferGetForPersistedQueries` carries through to the `OperationContext`'s `preferGetMethod` setting for persisted queries.
+Update the `preferGetForPersistedQueries` option to include the `'force'` and `'within-url-limit'` values from the Client's `preferGetMethod` option. The default value of `true` no longer sets `OperationContext`'s `preferGetMethod` setting to `'force'`. Instead, the value of `preferGetForPersistedQueries` carries through to the `OperationContext`'s `preferGetMethod` setting for persisted queries.

--- a/.changeset/fair-eels-march.md
+++ b/.changeset/fair-eels-march.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-persisted': patch
+---
+
+Update the `preferGetForPersistedQueries` option to include the 'force' and 'within-url-limit' values from the Client's `preferGetMethod` option. The default value of `true` no longer sets `OperationContext`'s `preferGetMethod` setting to `'force'`. Instead, the value of `preferGetForPersistedQueries` carries through to the `OperationContext`'s `preferGetMethod` setting for persisted queries.

--- a/docs/advanced/persistence-and-uploads.md
+++ b/docs/advanced/persistence-and-uploads.md
@@ -61,10 +61,7 @@ const client = new Client({
 });
 ```
 
-As we can see, typically it's recommended to set `preferGetForPersistedQueries` to `true` to force
-all persisted queries to use GET requests instead of POST so that CDNs can do their job.
-It does so by setting the `preferGetMethod` option to `'force'` when it's
-updating operations.
+As we can see, typically it's recommended to set `preferGetForPersistedQueries` to `true` to encourage persisted queries to use GET requests instead of POST so that CDNs can do their job. When set to `true` or `'within-url-limit'`, persisted queries will use GET requests if the resulting URL doesn't exceed the 2048 character limit.
 
 The `fetchExchange` can see the modifications that the `persistedExchange` is
 making to operations, and understands to leave out the `query` from any request

--- a/docs/advanced/persistence-and-uploads.md
+++ b/docs/advanced/persistence-and-uploads.md
@@ -61,7 +61,10 @@ const client = new Client({
 });
 ```
 
-As we can see, typically it's recommended to set `preferGetForPersistedQueries` to `true` to encourage persisted queries to use GET requests instead of POST so that CDNs can do their job. When set to `true` or `'within-url-limit'`, persisted queries will use GET requests if the resulting URL doesn't exceed the 2048 character limit.
+As we can see, typically it's recommended to set `preferGetForPersistedQueries` to `true`
+to encourage persisted queries to use GET requests instead of POST so that CDNs can do their job.
+When set to `true` or `'within-url-limit'`, persisted queries will use GET requests if the
+resulting URL doesn't exceed the 2048 character limit.
 
 The `fetchExchange` can see the modifications that the `persistedExchange` is
 making to operations, and understands to leave out the `query` from any request

--- a/exchanges/persisted/src/persistedExchange.test.ts
+++ b/exchanges/persisted/src/persistedExchange.test.ts
@@ -119,20 +119,7 @@ it('retries query persisted query resulted in unsupported', async () => {
   expect(operations[2].extensions).toEqual(undefined);
 });
 
-it('sets `context.preferGetMethod` to `true` by default', async () => {
-  const { exchangeArgs } = makeExchangeArgs();
-
-  const res = await pipe(
-    fromValue(queryOperation),
-    persistedExchange()(exchangeArgs),
-    take(1),
-    toPromise
-  );
-
-  expect(res.operation.context.preferGetMethod).toBe(true);
-});
-
-it.each([true, false, 'force', 'within-url-limit'] as const)(
+it.each([true, 'force', 'within-url-limit'] as const)(
   'sets `context.preferGetMethod` to %s when `options.preferGetForPersistedQueries` is %s',
   async preferGetMethodValue => {
     const { exchangeArgs } = makeExchangeArgs();

--- a/exchanges/persisted/src/persistedExchange.test.ts
+++ b/exchanges/persisted/src/persistedExchange.test.ts
@@ -118,3 +118,34 @@ it('retries query persisted query resulted in unsupported', async () => {
 
   expect(operations[2].extensions).toEqual(undefined);
 });
+
+it('sets `context.preferGetMethod` to `true` by default', async () => {
+  const { exchangeArgs } = makeExchangeArgs();
+
+  const res = await pipe(
+    fromValue(queryOperation),
+    persistedExchange()(exchangeArgs),
+    take(1),
+    toPromise
+  );
+
+  expect(res.operation.context.preferGetMethod).toBe(true);
+});
+
+it.each([true, false, 'force', 'within-url-limit'] as const)(
+  'sets `context.preferGetMethod` to %s when `options.preferGetForPersistedQueries` is %s',
+  async preferGetMethodValue => {
+    const { exchangeArgs } = makeExchangeArgs();
+
+    const res = await pipe(
+      fromValue(queryOperation),
+      persistedExchange({ preferGetForPersistedQueries: preferGetMethodValue })(
+        exchangeArgs
+      ),
+      take(1),
+      toPromise
+    );
+
+    expect(res.operation.context.preferGetMethod).toBe(preferGetMethodValue);
+  }
+);

--- a/exchanges/persisted/src/persistedExchange.ts
+++ b/exchanges/persisted/src/persistedExchange.ts
@@ -44,7 +44,7 @@ export interface PersistedExchangeOptions {
    * GET requests are frequently used to make GraphQL requests more
    * cacheable on CDNs.
    *
-   * @defaultValue `true` - enabled
+   * @defaultValue `false` - disabled
    */
   preferGetForPersistedQueries?: OperationContext['preferGetMethod'];
   /** Enforces non-automatic persisted queries by ignoring APQ errors.
@@ -123,8 +123,7 @@ export const persistedExchange =
   ({ forward }) => {
     if (!options) options = {};
 
-    const preferGetForPersistedQueries =
-      options.preferGetForPersistedQueries ?? true;
+    const preferGetForPersistedQueries = options.preferGetForPersistedQueries;
     const enforcePersistedQueries = !!options.enforcePersistedQueries;
     const hashFn = options.generateHash || hash;
     const enableForMutation = !!options.enableForMutation;
@@ -165,7 +164,10 @@ export const persistedExchange =
                 sha256Hash,
               },
             };
-            if (persistedOperation.kind === 'query') {
+            if (
+              persistedOperation.kind === 'query' &&
+              preferGetForPersistedQueries
+            ) {
               persistedOperation.context.preferGetMethod =
                 preferGetForPersistedQueries;
             }

--- a/exchanges/persisted/src/persistedExchange.ts
+++ b/exchanges/persisted/src/persistedExchange.ts
@@ -44,7 +44,7 @@ export interface PersistedExchangeOptions {
    * GET requests are frequently used to make GraphQL requests more
    * cacheable on CDNs.
    *
-   * @defaultValue `false` - disabled
+   * @defaultValue `undefined` - disabled
    */
   preferGetForPersistedQueries?: OperationContext['preferGetMethod'];
   /** Enforces non-automatic persisted queries by ignoring APQ errors.


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR, but please make sure to open an issue or discuss
  your changes first, if you’re looking to submit a larger PR.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

<!-- What's the motivation of this change? What does it solve? -->

This PR aims to resolve https://github.com/urql-graphql/urql/issues/3185.

Currently, `@urql/exchange-persisted`'s `options.preferGetForPersistedQueries` doesn't allow for `persistedOperation.context.preferGetMethod` to be set to `true` or `'within-url-limit'`, and instead sets `persistedOperation.context.preferGetMethod` to `'force'` when `options.preferGetForPersistedQueries` is `true`. This leads to broken GET requests when queries become massive.

Another issue was that although the TSDocs suggest that [the default value](https://github.com/urql-graphql/urql/blob/cb628ca4e9207b1928a5e137fddbd14c33afb6e4/exchanges/persisted/src/persistedExchange.ts#L42) of `options.preferGetForPersistedQueries` is `true`, this wasn't reflected in the logic.

## Set of changes

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->

In `@urql/exchange-persisted`:
- The type of `options.preferGetForPersistedQueries` has changed from `boolean | undefined` to match the value of the [Client](https://github.com/urql-graphql/urql/blob/main/docs/api/core.md#client)'s `preferGetMethod` option, which includes `'force'` and `'within-url-limit'`.
- Sets a default value of `options.preferGetForPersistedQueries` (to `true`) to match the TSDocs.
- When `options.preferGetForPersistedQueries` is `true`, we no longer set `operation.context.preferGetMethod` to `'force'`. Instead, `operation.context.preferGetMethod` is set to `true`.
  - This extends to all values of `options.preferGetForPersistedQueries`. The value set there will be the value set in `operation.context.preferGetMethod`.
- Removes a [check on the value of `preferGetForPersistedQueries `](https://github.com/urql-graphql/urql/blob/cb628ca4e9207b1928a5e137fddbd14c33afb6e4/exchanges/persisted/src/persistedExchange.ts#L164) before setting `persistedOperation.context.preferGetMethod`. This allows `persistedOperation.context.preferGetMethod` to be set to `false` if `options.preferGetForPersistedQueries` is set to `false`.
- Adds unit tests to validate the changes described here.