### PR TITLE
fix(graphcache): Add missing operations record on cache result

### DIFF
--- a/.changeset/sixty-masks-itch.md
+++ b/.changeset/sixty-masks-itch.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix missing cache updates, when a query that was previously torn down restarts and retrieves results from the cache. In this case a regression caused cache updates to not be correctly applied to the queried results, since the operation wouldn’t be recognised properly

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -219,6 +219,7 @@ export const cacheExchange =
         : 'miss';
 
       results.set(operation.key, result.data);
+      operations.set(operation.key, operation);
       updateDependencies(operation, result.dependencies);
 
       return {


### PR DESCRIPTION
Resolves #3188

## Summary

A regression caused operations to not be recognised internally by Graphcache anymore when they were previously torn down and then queried from the cache without refetching. In short, the `cacheExchange` would lose its record of the `Operation` and would be unable to issue updates for the queries.

## Set of changes

- Add missing `operations.set` record entry for cached results
