### PR TITLE
Fix re-rendering when another component reuses the same query

### DIFF
--- a/.changeset/fifty-sheep-battle.md
+++ b/.changeset/fifty-sheep-battle.md
@@ -2,4 +2,4 @@
 'urql': patch
 ---
 
-Fix re-rendering when another component reuses the same query without a change in the result
+Avoid unnecessary re-render when two components use the same query but receive unchanging results, due to differing operations

--- a/.changeset/fifty-sheep-battle.md
+++ b/.changeset/fifty-sheep-battle.md
@@ -1,0 +1,5 @@
+---
+'urql': patch
+---
+
+Fix re-rendering when another component reuses the same query without a change in the result

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ There are multiple commands you can run in the root folder to test your changes:
 
 ```sh
 # TypeScript checks:
-pnpnm run check
+pnpm run check
 
 # Linting (prettier & eslint):
 pnpm run lint

--- a/packages/react-urql/src/hooks/state.ts
+++ b/packages/react-urql/src/hooks/state.ts
@@ -9,6 +9,14 @@ export const initialState = {
   operation: undefined,
 };
 
+// Two operations are considered equal if they have the same key
+const areOperationsEqual = (
+  a: { key: number } | undefined,
+  b: { key: number } | undefined
+) => {
+  return a === b || !!(a && b && a.key === b.key);
+};
+
 /**
  * Checks if two objects are shallowly different with a special case for
  * 'operation' where it compares the key if they are not the otherwise equal
@@ -16,11 +24,11 @@ export const initialState = {
 const isShallowDifferent = <T extends Record<string, any>>(a: T, b: T) => {
   for (const key in a) if (!(key in b)) return true;
   for (const key in b) {
-    if (a[key] !== b[key]) {
-      // Two operations are considered equal if they have the same key
-      if (key === 'operation' && a.operation?.key === b.operation?.key) {
-        continue;
-      }
+    if (
+      key === 'operation'
+        ? !areOperationsEqual(a[key], b[key])
+        : a[key] !== b[key]
+    ) {
       return true;
     }
   }

--- a/packages/react-urql/src/hooks/state.ts
+++ b/packages/react-urql/src/hooks/state.ts
@@ -9,10 +9,21 @@ export const initialState = {
   operation: undefined,
 };
 
-const isShallowDifferent = (a: any, b: any) => {
-  if (typeof a != 'object' || typeof b != 'object') return a !== b;
-  for (const x in a) if (!(x in b)) return true;
-  for (const x in b) if (a[x] !== b[x]) return true;
+/**
+ * Checks if two objects are shallowly different with a special case for
+ * 'operation' where it compares the key if they are not the otherwise equal
+ */
+const isShallowDifferent = <T extends Record<string, any>>(a: T, b: T) => {
+  for (const key in a) if (!(key in b)) return true;
+  for (const key in b) {
+    if (a[key] !== b[key]) {
+      // Two operations are considered equal if they have the same key
+      if (key === 'operation' && a.operation?.key === b.operation?.key) {
+        continue;
+      }
+      return true;
+    }
+  }
   return false;
 };
 
@@ -27,7 +38,7 @@ export const computeNextState = <T extends Stateish>(
   prevState: T,
   result: Partial<T>
 ): T => {
-  const newState = {
+  const newState: T = {
     ...prevState,
     ...result,
     data:


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR, but please make sure to open an issue or discuss
  your changes first, if you’re looking to submit a larger PR.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary
When component A uses `useQuery` and has already loaded a result and then component B mounts and uses the same query, it currently causes component A to re-render because `operation` is not shallowly equal even though nothing about the result is changing.

This is a performance issue because it causes unnecessary re-renders.

It also can cause an infinite render loop with lazily loaded components because it can trigger a state update further up the tree during the initial render of the lazily loaded component which makes React back out of the render (which happened in my application, although I've had trouble creating a minimal reproduction). This issue is resolved with this change in my application.
<!-- What's the motivation of this change? What does it solve? -->

## Set of changes
- Added a special case to `isShallowDifferent` for `operation` where it checks the operation key if the `operation`s are not equal
- Fixed a typo in `CONTRIBUTING.md`
<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->
