### PR TITLE
fix(graphcache): Add missing retries after offline rehydration

### DIFF
--- a/.changeset/wet-crabs-dream.md
+++ b/.changeset/wet-crabs-dream.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Retry operations against offline cache and stabilize timing of flushing failed operations queue after rehydrating the storage data.

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -71,6 +71,7 @@ export const cacheExchange =
     const store = new Store<C>(opts);
 
     if (opts && opts.storage) {
+      store.data.hydrating = true;
       opts.storage.readData().then(entries => {
         hydrateData(store.data, opts!.storage!, entries);
       });

--- a/exchanges/graphcache/src/offlineExchange.ts
+++ b/exchanges/graphcache/src/offlineExchange.ts
@@ -1,4 +1,4 @@
-import { pipe, share, merge, makeSubject, filter } from 'wonka';
+import { pipe, share, merge, makeSubject, filter, onPush } from 'wonka';
 import { SelectionNode } from '@0no-co/graphql.web';
 
 import {
@@ -128,36 +128,40 @@ export const offlineExchange =
       const { source: reboundOps$, next } = makeSubject<Operation>();
       const optimisticMutations = opts.optimistic || {};
       const failedQueue: Operation[] = [];
+      let hasRehydrated = false;
+      let isFlushingQueue = false;
 
       const updateMetadata = () => {
-        const requests: SerializedRequest[] = [];
-        for (let i = 0; i < failedQueue.length; i++) {
-          const operation = failedQueue[i];
-          if (operation.kind === 'mutation') {
-            requests.push({
-              query: stringifyDocument(operation.query),
-              variables: operation.variables,
-              extensions: operation.extensions,
-            });
-          }
-        }
-        storage.writeMetadata!(requests);
-      };
-
-      let isFlushingQueue = false;
-      const flushQueue = () => {
-        if (!isFlushingQueue) {
-          isFlushingQueue = true;
-
+        if (hasRehydrated) {
+          const requests: SerializedRequest[] = [];
           for (let i = 0; i < failedQueue.length; i++) {
             const operation = failedQueue[i];
             if (operation.kind === 'mutation') {
-              next(makeOperation('teardown', operation));
+              requests.push({
+                query: stringifyDocument(operation.query),
+                variables: operation.variables,
+                extensions: operation.extensions,
+              });
             }
           }
+          storage.writeMetadata!(requests);
+        }
+      };
 
-          for (let i = 0; i < failedQueue.length; i++)
-            client.reexecuteOperation(failedQueue[i]);
+      const flushQueue = () => {
+        if (!isFlushingQueue) {
+          isFlushingQueue = true;
+          if (!hasRehydrated) {
+            storage.onOnline!(flushQueue);
+            hasRehydrated = true;
+          }
+
+          for (let i = 0; i < failedQueue.length; i++) {
+            const operation = failedQueue[i];
+            if (operation.kind === 'mutation')
+              next(makeOperation('teardown', operation));
+            next(operation);
+          }
 
           failedQueue.length = 0;
           isFlushingQueue = false;
@@ -185,31 +189,27 @@ export const offlineExchange =
         );
       };
 
-      storage
-        .readMetadata()
-        .then(mutations => {
-          if (mutations) {
-            for (let i = 0; i < mutations.length; i++) {
-              failedQueue.push(
-                client.createRequestOperation(
-                  'mutation',
-                  createRequest(mutations[i].query, mutations[i].variables),
-                  mutations[i].extensions
-                )
-              );
-            }
-
-            flushQueue();
-          }
-        })
-        .finally(() => storage.onOnline!(flushQueue));
-
       const cacheResults$ = cacheExchange({
         ...opts,
         storage: {
           ...storage,
-          readData() {
-            return storage.readData().finally(flushQueue);
+          async readData() {
+            const hydrate = storage.readData();
+            const mutations = await storage.readMetadata!();
+            if (mutations) {
+              for (let i = 0; i < mutations.length; i++) {
+                failedQueue.push(
+                  client.createRequestOperation(
+                    'mutation',
+                    createRequest(mutations[i].query, mutations[i].variables),
+                    mutations[i].extensions
+                  )
+                );
+              }
+            }
+            return hydrate.finally(() => {
+              setTimeout(flushQueue);
+            });
           },
         },
       })({
@@ -219,7 +219,17 @@ export const offlineExchange =
       });
 
       return operations$ => {
-        const opsAndRebound$ = merge([reboundOps$, operations$]);
+        const opsAndRebound$ = merge([
+          reboundOps$,
+          pipe(
+            operations$,
+            onPush(operation => {
+              if (operation.kind === 'query' && !hasRehydrated) {
+                failedQueue.push(operation);
+              }
+            })
+          ),
+        ]);
 
         return pipe(
           cacheResults$(opsAndRebound$),
@@ -232,7 +242,6 @@ export const offlineExchange =
               failedQueue.push(res.operation);
               return false;
             }
-
             return true;
           })
         );


### PR DESCRIPTION
Resolves #3093

## Summary

Adds missing retries of query operations when offline rehydration has completed and fix the timing of flushing the failed queue of operations after rehydration.

The former can lead to operations only awaiting network requests even after finishing storage rehydration, since no additional operations would be issued.

The latter can lead to stalled operations when the device is offline on load.

## Set of changes

- Add query operations to `failedQueue` while rehydrating
- Delay timing of `flushQueue` to after storage rehydration
- Move `onOnline` register to `flushQueue`
