### PR TITLE
fix(graphcache): Prevent offlineExchange from issuing duplicate operations

### DIFF
--- a/.changeset/hungry-zebras-count.md
+++ b/.changeset/hungry-zebras-count.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Prevent `offlineExchange` from issuing duplicate operations.

--- a/exchanges/graphcache/src/offlineExchange.ts
+++ b/exchanges/graphcache/src/offlineExchange.ts
@@ -151,11 +151,16 @@ export const offlineExchange =
       const flushQueue = () => {
         if (!isFlushingQueue) {
           isFlushingQueue = true;
+
+          const sent = new Set<number>();
           for (let i = 0; i < failedQueue.length; i++) {
             const operation = failedQueue[i];
-            if (operation.kind === 'mutation')
-              next(makeOperation('teardown', operation));
-            next(operation);
+            if (operation.kind === 'mutation' || !sent.has(operation.key)) {
+              if (operation.kind !== 'subscription')
+                next(makeOperation('teardown', operation));
+              sent.add(operation.key);
+              next(operation);
+            }
           }
 
           failedQueue.length = 0;

--- a/exchanges/graphcache/src/offlineExchange.ts
+++ b/exchanges/graphcache/src/offlineExchange.ts
@@ -159,7 +159,7 @@ export const offlineExchange =
               if (operation.kind !== 'subscription')
                 next(makeOperation('teardown', operation));
               sent.add(operation.key);
-              next(operation);
+              next(toRequestPolicy(operation, 'cache-first'));
             }
           }
 


### PR DESCRIPTION
Follow-up to #3199
Resolves #3093

## Set of changes

- Add a crude teardown+seen routine to `failedQueue` in `offlineExchange`'s `flushQueue`
