### PR TITLE
fix(types): move `types` condition to the front

### DIFF
--- a/exchanges/auth/package.json
+++ b/exchanges/auth/package.json
@@ -25,9 +25,9 @@
   "source": "src/index.ts",
   "exports": {
     ".": {
+      "types": "./dist/urql-exchange-auth.d.ts",
       "import": "./dist/urql-exchange-auth.mjs",
       "require": "./dist/urql-exchange-auth.js",
-      "types": "./dist/urql-exchange-auth.d.ts",
       "source": "./src/index.ts"
     },
     "./package.json": "./package.json"

--- a/exchanges/context/package.json
+++ b/exchanges/context/package.json
@@ -24,9 +24,9 @@
   "source": "src/index.ts",
   "exports": {
     ".": {
+      "types": "./dist/urql-exchange-context.d.ts",
       "import": "./dist/urql-exchange-context.mjs",
       "require": "./dist/urql-exchange-context.js",
-      "types": "./dist/urql-exchange-context.d.ts",
       "source": "./src/index.ts"
     },
     "./package.json": "./package.json"

--- a/exchanges/execute/package.json
+++ b/exchanges/execute/package.json
@@ -25,9 +25,9 @@
   "source": "src/index.ts",
   "exports": {
     ".": {
+      "types": "./dist/urql-exchange-execute.d.ts",
       "import": "./dist/urql-exchange-execute.mjs",
       "require": "./dist/urql-exchange-execute.js",
-      "types": "./dist/urql-exchange-execute.d.ts",
       "source": "./src/index.ts"
     },
     "./package.json": "./package.json"

--- a/exchanges/graphcache/default-storage/package.json
+++ b/exchanges/graphcache/default-storage/package.json
@@ -8,9 +8,9 @@
   "source": "../src/default-storage/index.ts",
   "exports": {
     ".": {
+      "types": "../dist/urql-exchange-graphcache-default-storage.d.ts",
       "import": "../dist/urql-exchange-graphcache-default-storage.mjs",
       "require": "../dist/urql-exchange-graphcache-default-storage.js",
-      "types": "../dist/urql-exchange-graphcache-default-storage.d.ts",
       "source": "../src/default-storage/index.ts"
     },
     "./package.json": "./package.json"

--- a/exchanges/graphcache/package.json
+++ b/exchanges/graphcache/package.json
@@ -25,22 +25,22 @@
   "source": "src/index.ts",
   "exports": {
     ".": {
+      "types": "./dist/urql-exchange-graphcache.d.ts",
       "import": "./dist/urql-exchange-graphcache.mjs",
       "require": "./dist/urql-exchange-graphcache.js",
-      "types": "./dist/urql-exchange-graphcache.d.ts",
       "source": "./src/index.ts"
     },
     "./package.json": "./package.json",
     "./extras": {
+      "types": "./dist/urql-exchange-graphcache-extras.d.ts",
       "import": "./dist/urql-exchange-graphcache-extras.mjs",
       "require": "./dist/urql-exchange-graphcache-extras.js",
-      "types": "./dist/urql-exchange-graphcache-extras.d.ts",
       "source": "./src/extras/index.ts"
     },
     "./default-storage": {
+      "types": "./dist/urql-exchange-graphcache-default-storage.d.ts",
       "import": "./dist/urql-exchange-graphcache-default-storage.mjs",
       "require": "./dist/urql-exchange-graphcache-default-storage.js",
-      "types": "./dist/urql-exchange-graphcache-default-storage.d.ts",
       "source": "./src/default-storage/index.ts"
     }
   },

--- a/exchanges/persisted/package.json
+++ b/exchanges/persisted/package.json
@@ -23,9 +23,9 @@
   "source": "src/index.ts",
   "exports": {
     ".": {
+      "types": "./dist/urql-exchange-persisted.d.ts",
       "import": "./dist/urql-exchange-persisted.mjs",
       "require": "./dist/urql-exchange-persisted.js",
-      "types": "./dist/urql-exchange-persisted.d.ts",
       "source": "./src/index.ts"
     },
     "./package.json": "./package.json"

--- a/exchanges/populate/package.json
+++ b/exchanges/populate/package.json
@@ -22,9 +22,9 @@
   "source": "src/index.ts",
   "exports": {
     ".": {
+      "types": "./dist/urql-exchange-populate.d.ts",
       "import": "./dist/urql-exchange-populate.mjs",
       "require": "./dist/urql-exchange-populate.js",
-      "types": "./dist/urql-exchange-populate.d.ts",
       "source": "./src/index.ts"
     },
     "./package.json": "./package.json"

--- a/exchanges/refocus/package.json
+++ b/exchanges/refocus/package.json
@@ -25,9 +25,9 @@
   "source": "src/index.ts",
   "exports": {
     ".": {
+      "types": "./dist/urql-exchange-refocus.d.ts",
       "import": "./dist/urql-exchange-refocus.mjs",
       "require": "./dist/urql-exchange-refocus.js",
-      "types": "./dist/urql-exchange-refocus.d.ts",
       "source": "./src/index.ts"
     },
     "./package.json": "./package.json"

--- a/exchanges/request-policy/package.json
+++ b/exchanges/request-policy/package.json
@@ -24,9 +24,9 @@
   "source": "src/index.ts",
   "exports": {
     ".": {
+      "types": "./dist/urql-exchange-request-policy.d.ts",
       "import": "./dist/urql-exchange-request-policy.mjs",
       "require": "./dist/urql-exchange-request-policy.js",
-      "types": "./dist/urql-exchange-request-policy.d.ts",
       "source": "./src/index.ts"
     },
     "./package.json": "./package.json"

--- a/exchanges/retry/package.json
+++ b/exchanges/retry/package.json
@@ -24,9 +24,9 @@
   "source": "src/index.ts",
   "exports": {
     ".": {
+      "types": "./dist/urql-exchange-retry.d.ts",
       "import": "./dist/urql-exchange-retry.mjs",
       "require": "./dist/urql-exchange-retry.js",
-      "types": "./dist/urql-exchange-retry.d.ts",
       "source": "./src/index.ts"
     },
     "./package.json": "./package.json"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,16 +24,16 @@
   "source": "src/index.ts",
   "exports": {
     ".": {
+      "types": "./dist/urql-core.d.ts",
       "import": "./dist/urql-core.mjs",
       "require": "./dist/urql-core.js",
-      "types": "./dist/urql-core.d.ts",
       "source": "./src/index.ts"
     },
     "./package.json": "./package.json",
     "./internal": {
+      "types": "./dist/urql-core-internal.d.ts",
       "import": "./dist/urql-core-internal.mjs",
       "require": "./dist/urql-core-internal.js",
-      "types": "./dist/urql-core-internal.d.ts",
       "source": "./src/internal/index.ts"
     }
   },

--- a/packages/introspection/package.json
+++ b/packages/introspection/package.json
@@ -23,9 +23,9 @@
   "source": "src/index.ts",
   "exports": {
     ".": {
+      "types": "./dist/urql-introspection.d.ts",
       "import": "./dist/urql-introspection.mjs",
       "require": "./dist/urql-introspection.js",
-      "types": "./dist/urql-introspection.d.ts",
       "source": "./src/index.ts"
     },
     "./package.json": "./package.json"

--- a/packages/preact-urql/package.json
+++ b/packages/preact-urql/package.json
@@ -25,9 +25,9 @@
   "source": "src/index.ts",
   "exports": {
     ".": {
+      "types": "./dist/urql-preact.d.ts",
       "import": "./dist/urql-preact.mjs",
       "require": "./dist/urql-preact.js",
-      "types": "./dist/urql-preact.d.ts",
       "source": "./src/index.ts"
     },
     "./package.json": "./package.json"

--- a/packages/storage-rn/package.json
+++ b/packages/storage-rn/package.json
@@ -32,9 +32,9 @@
   ],
   "exports": {
     ".": {
+      "types": "./dist/urql-storage-rn.d.ts",
       "import": "./dist/urql-storage-rn.mjs",
       "require": "./dist/urql-storage-rn.js",
-      "types": "./dist/urql-storage-rn.d.ts",
       "source": "./src/index.ts"
     },
     "./package.json": "./package.json"

--- a/packages/svelte-urql/package.json
+++ b/packages/svelte-urql/package.json
@@ -25,9 +25,9 @@
   "source": "src/index.ts",
   "exports": {
     ".": {
+      "types": "./dist/urql-svelte.d.ts",
       "import": "./dist/urql-svelte.mjs",
       "require": "./dist/urql-svelte.js",
-      "types": "./dist/urql-svelte.d.ts",
       "source": "./src/index.ts"
     },
     "./package.json": "./package.json"

--- a/packages/vue-urql/package.json
+++ b/packages/vue-urql/package.json
@@ -25,9 +25,9 @@
   "source": "src/index.ts",
   "exports": {
     ".": {
+      "types": "./dist/urql-vue.d.ts",
       "import": "./dist/urql-vue.mjs",
       "require": "./dist/urql-vue.js",
-      "types": "./dist/urql-vue.d.ts",
       "source": "./src/index.ts"
     },
     "./package.json": "./package.json"


### PR DESCRIPTION
I moved `types` condition to the front. `package.json#exports` are **order-sensitive** - they are always matched from the top to the bottom. When a match is found then it should be used and no further matching should occur. 

Right now, the current setup works in TypeScript but it's considered a bug and it should not be relied upon, see the thread and the comment [here](https://github.com/microsoft/TypeScript/issues/50762#issuecomment-1528318260). For that reason, I would like to fix all popular packages that misconfigured their `exports` this way so the bug can be fixed in TypeScript.

⚠️ this PR focuses solely on fixing "🐛 Used fallback condition" problem but the "🎭 Masquerading as CJS" remains here. You can check the reported errors [here](https://arethetypeswrong.github.io/?p=%40urql%2Fcore%404.0.7)