### PR TITLE
fix(core): Always exclude teardowns from subscriptionExchange

### DIFF
--- a/.changeset/green-geese-switch.md
+++ b/.changeset/green-geese-switch.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Don't allow `isSubscriptionOperation` option in `subscriptionExchange` to include `teardown` operations, to avoid confusion.

--- a/packages/core/src/exchanges/subscription.ts
+++ b/packages/core/src/exchanges/subscription.ts
@@ -186,20 +186,22 @@ export const subscriptionExchange =
         };
       });
     };
+
     const isSubscriptionOperationFn =
       isSubscriptionOperation ||
-      (operation => {
-        const { kind } = operation;
-        return (
-          kind === 'subscription' ||
-          (!!enableAllOperations && (kind === 'query' || kind === 'mutation'))
-        );
-      });
+      (operation =>
+        operation.kind === 'subscription' ||
+        (!!enableAllOperations &&
+          (operation.kind === 'query' || operation.kind === 'mutation')));
 
     return ops$ => {
       const subscriptionResults$ = pipe(
         ops$,
-        filter(isSubscriptionOperationFn),
+        filter(
+          operation =>
+            operation.kind !== 'teardown' &&
+            isSubscriptionOperationFn(operation)
+        ),
         mergeMap(operation => {
           const { key } = operation;
           const teardown$ = pipe(
@@ -216,7 +218,11 @@ export const subscriptionExchange =
 
       const forward$ = pipe(
         ops$,
-        filter(op => !isSubscriptionOperationFn(op)),
+        filter(
+          operation =>
+            operation.kind === 'teardown' ||
+            !isSubscriptionOperationFn(operation)
+        ),
         forward
       );
 


### PR DESCRIPTION
Resolves #3205

## Summary

Always exclude `teardown` from the accepted operations in `subscriptionExchange` to avoid confusion, since it's nonsensical to let it handle them as a normal operation.

## Set of changes

- Add `teardown` check to `subscriptionExchange`'s filters
