### PR TITLE
Vercel for Docs Deployment

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -70,13 +70,3 @@ jobs:
         working-directory: ./packages/site
         if: github.ref != 'refs/heads/main'
         run: pnpm run build --staging
-
-      #- name: Deploy Staging Site
-      #  working-directory: ./packages/site
-      #  if: github.ref != 'refs/heads/main'
-      #  run: pnpm run deploy --staging
-      #  env:
-      #    FORMIDEPLOY_GIT_SHA: ${{ github.event.pull_request.head.sha }}
-      #    GITHUB_DEPLOYMENT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #    SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
-      #    SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}

--- a/packages/site/static.config.js
+++ b/packages/site/static.config.js
@@ -3,7 +3,8 @@ import { resolve } from 'path';
 import constants from './src/constants';
 import Document from './src/html';
 
-const basePath = 'open-source/urql';
+const basePath =
+  process.env.VERCEL_ENV === 'preview' ? '.' : 'open-source/urql';
 const isStaging = process.env.REACT_STATIC_ENV === 'staging';
 const isProduction = process.env.REACT_STATIC_ENV === 'production';
 


### PR DESCRIPTION
This PR tweaks the react-static docs config _a tiny bit_ so that we can deploy the urql docs on Vercel. The end result:

- Vercel for staging previews on PRs. [See here](https://urql-docs-m6qsbtehz-formidable-labs.vercel.app/) for an example from this PR. For staging previews, the docs will be deployed at root of deployment site.
- We'll be using Vercel for production deploys here soon as well (instead of S3), so production Vercel deployment will still be nested at `/open-source/urql` so that it can be "stitched" into the upcoming formidable.com site.
- Removing all traces of Surge for deployments.
- Once formidable.com is migrated to new Next.js site, we'll follow up and remove formideploy logic as well.