### PR TITLE
feat(graphcache): Add globalIDs option

### DIFF
--- a/.changeset/dull-fishes-push.md
+++ b/.changeset/dull-fishes-push.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': minor
+---
+
+Add `globalIDs` configuration option to omit typenames in cache keys.

--- a/exchanges/graphcache/src/store/store.test.ts
+++ b/exchanges/graphcache/src/store/store.test.ts
@@ -237,6 +237,20 @@ describe('Store with KeyingConfig', () => {
   });
 });
 
+describe('Store with Global IDs', () => {
+  it('generates keys without typenames when set to true', () => {
+    const store = new Store({ globalIDs: true });
+    expect(store.keyOfEntity({ __typename: 'Any', id: '123' })).toBe('123');
+    expect(store.keyOfEntity({ __typename: 'None', id: '123' })).toBe('123');
+  });
+
+  it('generates keys without typenames when matching an input set', () => {
+    const store = new Store({ globalIDs: ['User'] });
+    expect(store.keyOfEntity({ __typename: 'Any', id: '123' })).toBe('Any:123');
+    expect(store.keyOfEntity({ __typename: 'User', id: '123' })).toBe('123');
+  });
+});
+
 describe('Store with ResolverConfig', () => {
   it("sets the store's resolvers field to the given argument", () => {
     const resolversOption = {

--- a/exchanges/graphcache/src/types.ts
+++ b/exchanges/graphcache/src/types.ts
@@ -581,6 +581,17 @@ export type CacheExchangeOpts = {
    * the full keys docs.
    */
   keys?: KeyingConfig;
+  /** Enables global IDs for keying GraphQL types.
+   *
+   * @rematks
+   * When `globalIDs` are enabled, GraphQL object type names will not contribute
+   * to the keys of entities and instead only their ID fields (or `keys` return
+   * values will be used.
+   *
+   * This is useful to overlap types of differing typenames. While this isn’t recommended
+   * it can be necessary to represent more complex interface relationships.
+   */
+  globalIDs?: boolean;
   /** Configures Graphcache with Schema Introspection data.
    *
    * @remarks

--- a/exchanges/graphcache/src/types.ts
+++ b/exchanges/graphcache/src/types.ts
@@ -590,8 +590,11 @@ export type CacheExchangeOpts = {
    *
    * This is useful to overlap types of differing typenames. While this isn’t recommended
    * it can be necessary to represent more complex interface relationships.
+   *
+   * If this should only be applied to a limited set of type names, a list of
+   * type names may be passed instead.
    */
-  globalIDs?: boolean;
+  globalIDs?: string[] | boolean;
   /** Configures Graphcache with Schema Introspection data.
    *
    * @remarks

--- a/exchanges/graphcache/src/types.ts
+++ b/exchanges/graphcache/src/types.ts
@@ -583,7 +583,7 @@ export type CacheExchangeOpts = {
   keys?: KeyingConfig;
   /** Enables global IDs for keying GraphQL types.
    *
-   * @rematks
+   * @remarks
    * When `globalIDs` are enabled, GraphQL object type names will not contribute
    * to the keys of entities and instead only their ID fields (or `keys` return
    * values will be used.


### PR DESCRIPTION
Resolves #3176

## Summary

Add `globalIDs` option to omit typenames from entity cache keys.

This allows schemas with global ID guarantees and no ID overlap to combine entities in the cache. While this isn't recommended per se, since it's often a schema design problem, rather than a cache problem, it can be used to create strategic overlaps in the cache, when a type of an object implementing an interface “changes”

## Set of changes

- Add `globalIDs` option and update `keyOfEntity` function
