### PR TITLE
fix(retry): Reset delay/count state if an operation succeeds

### DIFF
--- a/.changeset/curvy-poems-compare.md
+++ b/.changeset/curvy-poems-compare.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-retry': minor
+---
+
+Reset `retryExchange`’s previous attempts and delay if an operation succeeds. This prevents the exchange from keeping its old retry count and delay if the operation delivered a result in the meantime. This is important for it to help recover from failing subscriptions.


### PR DESCRIPTION
Resolves #3220

## Summary

This resets operations’ `delay` and `count` states if they succeed. This may be important to recover from failing subscriptions, since a new result should be able to restore the retry state to where it was before the subscription failed.

## Set of changes

- Add resetting object state to `retryExchange`
- Add test case
