### PR TITLE
fix(core): Respect additionalTypenames option on subscriptions

### DIFF
--- a/.changeset/breezy-melons-deny.md
+++ b/.changeset/breezy-melons-deny.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Respect `additionalTypenames` on subscriptions and re-execute queries for them as well, as one would intuitively expect.


### PR DESCRIPTION
Resolves #3223

## Summary

Allow subscriptions to also be annotated with `additionalTypenames` and use them to re-execute queries.

## Set of changes

- Include subscriptions in response handling in document cache
