### PR TITLE
fix(vue): Ensure that source is updated atomically

### DIFF
--- a/.changeset/hungry-cars-hide.md
+++ b/.changeset/hungry-cars-hide.md
@@ -1,0 +1,5 @@
+---
+'@urql/vue': patch
+---
+
+Prevent multiple operations being executed in a row when multiple inputs change simultaneously (e.g. `isPaused` and query inputs)

--- a/packages/vue-urql/src/utils.ts
+++ b/packages/vue-urql/src/utils.ts
@@ -1,7 +1,38 @@
-import { Ref, isRef } from 'vue';
+import { GraphQLRequest, AnyVariables } from '@urql/core';
+import { Ref, ShallowRef, isRef } from 'vue';
 
 export function unwrapPossibleProxy<V>(possibleProxy: V | Ref<V>): V {
   return possibleProxy && isRef(possibleProxy)
     ? possibleProxy.value
     : possibleProxy;
 }
+
+export interface RequestState<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+> {
+  request: GraphQLRequest<Data, Variables>;
+  isPaused: boolean;
+}
+
+export function createRequestState<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+>(
+  request: GraphQLRequest<Data, Variables>,
+  isPaused: boolean
+): RequestState<Data, Variables> {
+  return { request, isPaused };
+}
+
+export const updateShallowRef = <T extends Record<string, any>>(
+  ref: ShallowRef<T>,
+  next: T
+) => {
+  for (const key in next) {
+    if (ref.value[key] !== next[key]) {
+      ref.value = next;
+      return;
+    }
+  }
+};


### PR DESCRIPTION
Resolves #3215

## Summary

Prevent `useQuery` and `useSubscription`’s sources from updating multiple times when inputs change.

## Set of changes

- Combine input updates into a single effect and use a shallow ref
