### PR TITLE
fix(auth): Fix authExchange’s retry queue ignoring teardowns

### DIFF
--- a/.changeset/weak-eagles-walk.md
+++ b/.changeset/weak-eagles-walk.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-auth': patch
+---
+
+Fix regression that caused teardowns to be ignored by an `authExchange`’s retry queue.


### PR DESCRIPTION
## Summary

A regression caused the `authExchange` to disregard teardowns and still issue retries for operations that were cancelled.

## Set of changes

- Add `retryQueue.delete` call for teardowns
