### PR TITLE
fix(graphcache): Fix offlineExchange’s failed queue not being filtered for teardowns

### DIFF
--- a/.changeset/pretty-dodos-happen.md
+++ b/.changeset/pretty-dodos-happen.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix torn down queries not being removed from `offlineExchange`’s failed queue on rehydration.

--- a/exchanges/graphcache/src/offlineExchange.ts
+++ b/exchanges/graphcache/src/offlineExchange.ts
@@ -230,6 +230,10 @@ export const offlineExchange =
             onPush(operation => {
               if (operation.kind === 'query' && !hasRehydrated) {
                 failedQueue.push(operation);
+              } else if (operation.kind === 'teardown') {
+                for (let i = failedQueue.length - 1; i >= 0; i--)
+                  if (failedQueue[i].key === operation.key)
+                    failedQueue.splice(i, 1);
               }
             })
           ),


### PR DESCRIPTION
Related to #3235

## Summary

Remove queries from `offlineExchange`’s failed queue that are torn down during rehydration.
This may become important to prevent fetching queries that are no longer relevant.

## Set of changes

- Add filtering to `failedQueue` for teardowns
