### PR TITLE
fix(core): Return fetch source cancellation to old behaviour

### DIFF
--- a/.changeset/famous-snakes-double.md
+++ b/.changeset/famous-snakes-double.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Return `AbortController` invocation to previous behaviour where it used to be more forceful. It will now properly abort outside of when our generator yields results, and hence now also cancels requests again that have already delivered headers but are currently awaiting a response body.


### PR DESCRIPTION
Related #3234

## Summary

This PR returns the `AbortController` invocation to its previous behaviour, when it used to be more forceful.

The `fetchSource` will now properly abort the request outside of when its async generator yields results. This means that it can now abort _after_ headers have been delivered but _before_ a response body becomes available. This will cause us to now cancel requests again that are stalled and hence not wait for a response body if it's not needed any longer.

## Set of changes

- Move `AbortController` logic outside of async generator
