### PR TITLE
fix(graphcache): Allow partial optimistic results

### DIFF
--- a/.changeset/five-icons-agree.md
+++ b/.changeset/five-icons-agree.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Make "Invalid undefined" warning heuristic smarter and allow for partial optimistic results. Previously, when a partial optimistic result would be passed, a warning would be issued, and in production, fields would be deleted from the cache. Instead, we now only issue a warning if these fields aren't cached already.

--- a/exchanges/graphcache/src/operations/query.test.ts
+++ b/exchanges/graphcache/src/operations/query.test.ts
@@ -164,8 +164,6 @@ describe('Query', () => {
       todos: [{ __typename: 'Todo', id: '0', text: 'Solve bug' }],
     });
 
-    // The warning should be called for `__typename`
-    expect(console.warn).toHaveBeenCalledTimes(1);
     expect(console.error).not.toHaveBeenCalled();
   });
 

--- a/exchanges/graphcache/src/operations/write.test.ts
+++ b/exchanges/graphcache/src/operations/write.test.ts
@@ -165,9 +165,9 @@ describe('Query', () => {
     // This should not overwrite the field
     write(store, { query }, { field: undefined } as any);
     // Because of us writing an undefined field
-    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(console.warn).toHaveBeenCalledTimes(2);
 
-    expect((console.warn as any).mock.calls[0][0]).toMatch(
+    expect((console.warn as any).mock.calls[1][0]).toMatch(
       /Invalid undefined: The field at `field`/
     );
 

--- a/exchanges/graphcache/src/operations/write.test.ts
+++ b/exchanges/graphcache/src/operations/write.test.ts
@@ -155,7 +155,7 @@ describe('Query', () => {
     );
   });
 
-  it.only('should skip undefined values that are expected', () => {
+  it('should skip undefined values that are expected', () => {
     const query = gql`
       {
         field
@@ -165,10 +165,10 @@ describe('Query', () => {
     // This should not overwrite the field
     write(store, { query }, { field: undefined } as any);
     // Because of us writing an undefined field
-    expect(console.warn).toHaveBeenCalledTimes(2);
+    expect(console.warn).toHaveBeenCalledTimes(1);
 
     expect((console.warn as any).mock.calls[0][0]).toMatch(
-      /The field `field` does not exist on `Query`/
+      /Invalid undefined: The field at `field`/
     );
 
     write(store, { query }, { field: 'test' } as any);

--- a/exchanges/graphcache/src/operations/write.test.ts
+++ b/exchanges/graphcache/src/operations/write.test.ts
@@ -155,22 +155,24 @@ describe('Query', () => {
     );
   });
 
-  it('should skip undefined values that are expected', () => {
+  it.only('should skip undefined values that are expected', () => {
     const query = gql`
       {
         field
       }
     `;
 
-    write(store, { query }, { field: 'test' } as any);
     // This should not overwrite the field
     write(store, { query }, { field: undefined } as any);
     // Because of us writing an undefined field
     expect(console.warn).toHaveBeenCalledTimes(2);
+
     expect((console.warn as any).mock.calls[0][0]).toMatch(
       /The field `field` does not exist on `Query`/
     );
 
+    write(store, { query }, { field: 'test' } as any);
+    write(store, { query }, { field: undefined } as any);
     InMemoryData.initDataState('read', store.data, null);
     // The field must still be `'test'`
     expect(InMemoryData.readRecord('Query', 'field')).toBe('test');

--- a/exchanges/graphcache/src/operations/write.ts
+++ b/exchanges/graphcache/src/operations/write.ts
@@ -248,26 +248,6 @@ const writeSelection = (
         (deferRef || (ctx.optimistic && rootField === 'query')))
     ) {
       continue;
-    } else if (rootField === 'query' && fieldValue === undefined && !deferRef) {
-      if (process.env.NODE_ENV !== 'production') {
-        if (!entityKey || !InMemoryData.hasField(entityKey, fieldKey)) {
-          const expected =
-            node.selectionSet === undefined
-              ? 'scalar (number, boolean, etc)'
-              : 'selection set';
-
-          warn(
-            'Invalid undefined: The field at `' +
-              fieldKey +
-              '` is `undefined`, but the GraphQL query expects a ' +
-              expected +
-              ' for this field.',
-            13
-          );
-        }
-      }
-
-      continue; // Skip this field
     }
 
     if (process.env.NODE_ENV !== 'production') {
@@ -294,6 +274,28 @@ const writeSelection = (
       // We have to update the context to reflect up-to-date ResolveInfo
       updateContext(ctx, data, typename, typename, fieldKey, fieldName);
       fieldValue = ensureData(resolver(fieldArgs || {}, ctx.store, ctx));
+    }
+
+    if (fieldValue === undefined) {
+      if (process.env.NODE_ENV !== 'production') {
+        if (!entityKey || !InMemoryData.hasField(entityKey, fieldKey)) {
+          const expected =
+            node.selectionSet === undefined
+              ? 'scalar (number, boolean, etc)'
+              : 'selection set';
+
+          warn(
+            'Invalid undefined: The field at `' +
+              fieldKey +
+              '` is `undefined`, but the GraphQL query expects a ' +
+              expected +
+              ' for this field.',
+            13
+          );
+        }
+      }
+
+      continue; // Skip this field
     }
 
     if (node.selectionSet) {

--- a/exchanges/graphcache/src/operations/write.ts
+++ b/exchanges/graphcache/src/operations/write.ts
@@ -240,34 +240,31 @@ const writeSelection = (
     let fieldValue = data[ctx.optimistic ? fieldName : fieldAlias];
 
     // Development check of undefined fields
-    if (process.env.NODE_ENV !== 'production') {
-      if (
-        rootField === 'query' &&
-        fieldValue === undefined &&
-        !deferRef &&
-        !ctx.optimistic
-      ) {
-        const expected =
-          node.selectionSet === undefined
-            ? 'scalar (number, boolean, etc)'
-            : 'selection set';
+    if (rootField === 'query' && fieldValue === undefined && !deferRef) {
+      if (process.env.NODE_ENV !== 'production') {
+        if (ctx.store.schema && typename && fieldName !== '__typename') {
+          isFieldAvailableOnType(ctx.store.schema, typename, fieldName);
+        }
 
-        warn(
-          'Invalid undefined: The field at `' +
-            fieldKey +
-            '` is `undefined`, but the GraphQL query expects a ' +
-            expected +
-            ' for this field.',
-          13
-        );
+        if (!entityKey || !InMemoryData.hasField(entityKey, fieldKey)) {
+          const expected =
+            node.selectionSet === undefined
+              ? 'scalar (number, boolean, etc)'
+              : 'selection set';
 
-        continue; // Skip this field
-      } else if (ctx.store.schema && typename && fieldName !== '__typename') {
-        isFieldAvailableOnType(ctx.store.schema, typename, fieldName);
+          warn(
+            'Invalid undefined: The field at `' +
+              fieldKey +
+              '` is `undefined`, but the GraphQL query expects a ' +
+              expected +
+              ' for this field.',
+            13
+          );
+        }
       }
-    }
 
-    if (
+      continue; // Skip this field
+    } else if (
       // Skip typename fields and assume they've already been written above
       fieldName === '__typename' ||
       // Fields marked as deferred that aren't defined must be skipped


### PR DESCRIPTION
## Summary

We basically had some logic that would allow writes to be incomplete, however, this didn't apply to optimistic results, which would always cause cached fields to be deleted. Furthermore, in production, partial results will always lead to cached values being deleted from the cache.

Instead, we can apply a better heuristic which only triggers the warning when a field is missing from the cache, but always allow writes to continue, no matter whether values are set or not.

This should in theory be safe, since we're moving potential errors over to reading from the cache.

This also adds a change which makes optimistic mutations read previous keys and `__typename` fields from the cache to complete mutation results from prior cache results. This should tremendously help the developer experience of having to create these functions.

## Set of changes

- Allow `continue` to be applied to `undefined` field values
- Include `ctx.optimistic` in the above check
- Update a test accordingly which checks for `console.warn`s
- Only trigger a warning if the field isn't cached
- Auto-fallback to `__typename` from cached values
- Auto-fallback to keys from cached links
