### PR TITLE
fix(graphcache): Prevent marking operations as reexecuting after optimistic mutation

### DIFF
--- a/.changeset/serious-dots-sit.md
+++ b/.changeset/serious-dots-sit.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Optimistic mutation results should never result in dependent operations being blocked.


### PR DESCRIPTION
## Summary

Prevent marking operations as reexecuting when an optimistic mutation executes and instead delay rotating them

## Set of changes

- Prevent `reexecutingOperations` rotation after optimistic mutation
