### PR TITLE
fix(graphcache): Fix info.parentKey for updaters and optimistic updaters

### DIFF
--- a/.changeset/wild-hotels-kick.md
+++ b/.changeset/wild-hotels-kick.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix `info.parentKey` not being correctly set for updaters or optimistic updaters.

--- a/exchanges/graphcache/src/operations/write.ts
+++ b/exchanges/graphcache/src/operations/write.ts
@@ -278,7 +278,14 @@ const writeSelection = (
     // Execute the field-level resolver to retrieve its data
     if (resolver) {
       // We have to update the context to reflect up-to-date ResolveInfo
-      updateContext(ctx, data, typename, typename, fieldKey, fieldName);
+      updateContext(
+        ctx,
+        data,
+        typename,
+        entityKey || typename,
+        fieldKey,
+        fieldName
+      );
       fieldValue = ensureData(resolver(fieldArgs || {}, ctx.store, ctx));
     }
 
@@ -345,7 +352,7 @@ const writeSelection = (
         ctx,
         data,
         typename,
-        typename,
+        entityKey || typename,
         joinKeys(typename, fieldKey),
         fieldName
       );


### PR DESCRIPTION
## Summary

Fixes a typo in `updateContext` that caused `info.parentKey` to be incorrectly set for updaters and optimistic updaters

## Set of changes

- Update `typename` in `updateContext` calls in `write` to `entityKey || typename`
