### PR TITLE
fix(graphcache): Fix untranspiled class field initializer syntax in bundle

### DIFF
--- a/.changeset/healthy-chefs-learn.md
+++ b/.changeset/healthy-chefs-learn.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix untranspiled class property initializer syntax being leftover in build output. (Regression in #3053)

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -106,7 +106,9 @@ export class Store<
     }
   }
 
-  keyOfField = keyOfField;
+  keyOfField(fieldName: string, fieldArgs?: FieldArgs) {
+    return keyOfField(fieldName, fieldArgs);
+  }
 
   keyOfEntity(data: Entity) {
     // In resolvers and updaters we may have a specific parent
@@ -148,7 +150,9 @@ export class Store<
     return link || null;
   }
 
-  resolveFieldByKey = this.resolve;
+  resolveFieldByKey(entity: Entity, field: string, args?: FieldArgs) {
+    return this.resolve(entity, field, args);
+  }
 
   invalidate(entity: Entity, field?: string, args?: FieldArgs) {
     const entityKey = this.keyOfEntity(entity);

--- a/scripts/eslint/preset.js
+++ b/scripts/eslint/preset.js
@@ -76,6 +76,14 @@ module.exports = {
         '@typescript-eslint/array-type': 'off',
         'import/no-internal-modules': 'off',
 
+        'no-restricted-syntax': [
+          "error",
+          {
+            "selector": "PropertyDefinition[value]",
+            "message": "Property definitions with value initializers aren’t transpiled"
+          },
+        ],
+
         '@typescript-eslint/no-unused-vars': ['error', {
           argsIgnorePattern: '^_',
         }],


### PR DESCRIPTION
Resolves #3274

## Summary

Fixes untranspiled class property initializer syntax being leftover in build output due to syntax used in the `Store`.

This is a regression in #3053, and further regressions will be prevented by adding an ESLint rule.

## Set of changes

- Relace class property initializer in `Store`
