### PR TITLE
fix(react): Avoid using stale deps from closure when executing query in useQuery

### DIFF
--- a/.changeset/mean-zebras-itch.md
+++ b/.changeset/mean-zebras-itch.md
@@ -1,0 +1,5 @@
+---
+'urql': patch
+---
+
+Fix re-executing operation with stale deps in useQuery

--- a/packages/react-urql/src/hooks/useQuery.ts
+++ b/packages/react-urql/src/hooks/useQuery.ts
@@ -368,7 +368,7 @@ export function useQuery<
               })
             )
           : client.executeQuery(request, context);
-        return [source, state[1], deps];
+        return [source, state[1], state[2]];
       });
     },
     [


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR, but please make sure to open an issue or discuss
  your changes first, if you’re looking to submit a larger PR.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary
Currently if you change `pause` it does not recreate `executeQuery` so it ends up using stale values from `deps`. In order to ensure that it uses the freshest values without adding another case that can trigger re-renders or break memoization, I made it use `state[2]` instead with resolves the issue. If this is undesirable I can change it to just add `args.pause` as a dependency of the `useCallback` which I think will also fix the issue.

## Set of changes
- useQuery now uses `state[2]` instead of `deps` within `executeQuery`
<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->
