### PR TITLE
chore(core): Deprecate maskTypename option

### DIFF
--- a/.changeset/swift-camels-draw.md
+++ b/.changeset/swift-camels-draw.md
@@ -1,0 +1,8 @@
+---
+'@urql/core': patch
+---
+
+Add deprecation notice for `maskTypename` option.
+Masking typenames in a result is no longer recommended. It’s only
+useful when multiple pre-conditions are applied and inferior to
+mapping to an input object manually.

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -171,6 +171,8 @@ export interface ClientOptions {
   preferGetMethod?: boolean | 'force' | 'within-url-limit';
   /** Instructs the `Client` to remove `__typename` properties on all results.
    *
+   * @deprecated Not recommended over modelling inputs manually (See #3299)
+   *
    * @remarks
    * By default, cache exchanges will alter your GraphQL documents to request `__typename` fields
    * for all selections. However, this means that your GraphQL data will now contain `__typename` fields you

--- a/packages/core/src/utils/maskTypename.ts
+++ b/packages/core/src/utils/maskTypename.ts
@@ -1,5 +1,7 @@
 /** Used to recursively mark `__typename` fields in data as non-enumerable.
  *
+ * @deprecated Not recommended over modelling inputs manually (See #3299)
+ *
  * @remarks
  * This utility can be used to recursively copy GraphQl response data and hide
  * all `__typename` fields present on it.


### PR DESCRIPTION
See: https://github.com/urql-graphql/urql/issues/3297#issuecomment-1612987757

## Summary

This PR, when applied, deprecates `maskTypename` (both the option and the utility).
The option may be removed sooner than the utility function.

In short, applying `maskTypename` was not recommended and applying it in an exchange yourself is still supported in the future.
This is because it's often only used (and requested) by users given that they want to pass GraphQL objects back into their mutations as GraphQL input objects, which requires the following pre-conditions to apply:

- the API mimicks inputs that mirror outputs
- the user doesn't actually provide the inputs
- the selection sets of both match precisely

However, compared to Graphcache's output for example, it leads to non-faithful data shapes, and is only used to “save” time and not map to input objects, which is a short task.

## Set of changes

- Deprecate `maskTypename` option and function
