### PR TITLE
feat(auth): Handle refreshAuth rejections gracefully

### DIFF
--- a/.changeset/light-kangaroos-smash.md
+++ b/.changeset/light-kangaroos-smash.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-auth': patch
+---
+
+Handle `refreshAuth` rejections and pass the resulting error on to `OperationResult`s on the authentication queue.


### PR DESCRIPTION
## Summary

This adds a `catch(errorQueue)` case to `refreshAuth` and replaces `finally(flushQueue)` with `then(flushQueue)`. The rejection case will issue `OperationResult`s for all `Operation`s in the queue and will pass the authentication error that `refreshAuth` rejected with on as the network error.

## Set of changes

- Add error handling to `refreshAuth` rejections
