### PR TITLE
fix(graphcache): Re-enable offlineExchange issuing non-cache request policies

### DIFF
--- a/.changeset/eleven-snakes-look.md
+++ b/.changeset/eleven-snakes-look.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Allow `offlineExchange` to once again issue all request policies, instead of mapping them to `cache-first`. When replaying operations after rehydrating it will now prioritise network policies, and before rehydrating receiving a network result will prevent a network request from being issued again.

--- a/.changeset/two-ants-relate.md
+++ b/.changeset/two-ants-relate.md
@@ -1,0 +1,6 @@
+---
+'@urql/exchange-graphcache': patch
+'@urql/core': patch
+---
+
+Add `OperationContext.optimistic` flag as an internal indication on whether a mutation triggered an optimistic update in `@urql/exchange-graphcache`'s `cacheExchange`.

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -4,6 +4,7 @@ import {
   makeOperation,
   Operation,
   OperationResult,
+  OperationContext,
   RequestPolicy,
   CacheOutcome,
 } from '@urql/core';
@@ -144,6 +145,7 @@ export const cacheExchange =
 
     // This registers queries with the data layer to ensure commutativity
     const prepareForwardedOperation = (operation: Operation) => {
+      let context: Partial<OperationContext> | undefined;
       if (operation.kind === 'query') {
         // Pre-reserve the position of the result layer
         reserveLayer(store.data, operation.key);
@@ -176,6 +178,9 @@ export const cacheExchange =
           const pendingOperations: Operations = new Set();
           collectPendingOperations(pendingOperations, dependencies);
           executePendingOperations(operation, pendingOperations, true);
+
+          // Mark operation as optimistic
+          context = { optimistic: true };
         }
       }
 
@@ -191,7 +196,7 @@ export const cacheExchange =
               )
             : operation.variables,
         },
-        operation.context
+        { ...operation.context, ...context }
       );
     };
 

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -155,6 +155,7 @@ export const cacheExchange =
         reexecutingOperations.delete(operation.key);
         // Mark operation layer as done
         noopDataState(store.data, operation.key);
+        return operation;
       } else if (
         operation.kind === 'mutation' &&
         operation.context.requestPolicy !== 'network-only'

--- a/exchanges/graphcache/src/offlineExchange.ts
+++ b/exchanges/graphcache/src/offlineExchange.ts
@@ -20,8 +20,8 @@ import { toRequestPolicy } from './helpers/operation';
 const policyLevel = {
   'cache-only': 0,
   'cache-first': 1,
-  'cache-and-network': 2,
-  'network-only': 3,
+  'network-only': 2,
+  'cache-and-network': 3,
 } as const;
 
 /** Input parameters for the {@link offlineExchange}.

--- a/exchanges/graphcache/src/test-utils/examples-1.test.ts
+++ b/exchanges/graphcache/src/test-utils/examples-1.test.ts
@@ -534,12 +534,41 @@ it('correctly resolves optimistic updates on Relay schemas', () => {
   `;
 
   write(store, { query: getRoot }, queryData);
-  writeOptimistic(store, { query: updateItem, variables: { id: '2' } }, 1);
+  const { dependencies } = writeOptimistic(
+    store,
+    { query: updateItem, variables: { id: '2' } },
+    1
+  );
+  expect(dependencies.size).not.toBe(0);
   InMemoryData.noopDataState(store.data, 1);
   const queryRes = query(store, { query: getRoot });
 
   expect(queryRes.partial).toBe(false);
   expect(queryRes.data).not.toBe(null);
+});
+
+it('skips non-optimistic mutation fields on writes', () => {
+  const store = new Store();
+
+  const updateItem = gql`
+    mutation UpdateItem($id: ID!) {
+      updateItem(id: $id) {
+        __typename
+        item {
+          __typename
+          id
+          name
+        }
+      }
+    }
+  `;
+
+  const { dependencies } = writeOptimistic(
+    store,
+    { query: updateItem, variables: { id: '2' } },
+    1
+  );
+  expect(dependencies.size).toBe(0);
 });
 
 it('allows cumulative optimistic updates', () => {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -528,6 +528,13 @@ export interface OperationContext {
    * @see {@link https://beta.reactjs.org/blog/2022/03/29/react-v18#new-suspense-features} for more information on React Suspense.
    */
   suspense?: boolean;
+  /** A metdata flag indicating whether this operation triggered optimistic updates.
+   *
+   * @remarks
+   * This configuration flag is reserved for `@urql/exchange-graphcache` and is flipped
+   * when an operation triggerd optimistic updates.
+   */
+  optimistic?: boolean;
   [key: string]: any;
 }
 


### PR DESCRIPTION
## Summary

This PR, when applied, makes two changes.

Primarily, requesdt policies other than `cache-first` are now allowed in the `offlineExchange` when re-running failed operations. After rehydration or when replaying failed queries, queries will now not be forced to `cache-first` policies, and instead use the highest policy that was issued, preferring network policies (`cache-only` < `cache-first` < `network-only` < `cache-and-network`).

Additionally, instead of checking manually which mutations have made optimistic changes, the `cacheExchange` will now mark optimistic mutations' contexts with `optimistic: true` instead.

## Set of changes

- Add `OperationContext.optimistic` indicating optimistic updates have been made
- Remove `cache-first` forcing in `offlineExchange`
- Pick highest policy that has been seen in `offlineExchange`
- Remove queries from `failedQueue` that have received a pre-hydration network result
