### PR TITLE
fix(persisted): Add missing teardown source

### DIFF
--- a/.changeset/five-penguins-unite.md
+++ b/.changeset/five-penguins-unite.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-persisted': patch
+---
+
+Fix `persistedExchange` ignoring teardowns in its initial operation mapping. Since the hash function is promisified, which defers any persisted operation, it needs to respect teardowns.


### PR DESCRIPTION
Resolves #3311

## Summary

Add missing `teardown` support to the `persistedExchange`. Since the hashing function is promisified and hence deferred, initial operation reads that are cancelled (i.e. particularly in React/Preact) need to cancel the ongoing operation correctly.

## Set of changes

- Add missing `takeUntil` teardown source to `persistedExchange`
