### PR TITLE
docs(workspace): Add additional sandbox links and links to examples

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -22,7 +22,7 @@ body:
     id: reproduction
     attributes:
       label: Reproduction
-      description: Please provide a link via [codesandbox](https://codesandbox.io/s/urql-issue-template-client-iui0o) or a link to a repo that can reproduce the problem you ran into. A [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example) is required. If a report is vague (e.g. just a generic error message) and if no reproduction is provided the issue will be auto-closed.
+      description: Please provide a link to a reproduction. Templates can be found in the [examples folder](https://github.com/urql-graphql/urql/tree/main/examples). A [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example) is required. If a report is vague (e.g. just a generic error message) and if no reproduction is provided the issue will be auto-closed.
       placeholder: Reproduction
     validations:
       required: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,13 @@ standard and the rule of thumb is to try to explain **what you expected** and **
 instead.** Following this makes it very clear whether it's a known behavior, an unexpected issue,
 or an undocumented quirk.
 
+We do ask that issues _aren’t_ created for questions, or where a bug is likely to be either caused
+by misusage or misconfiguration. In short, if you can’t provide a reproduction of the issue, then
+it may be the case that you’ve got a question instead.
+
+If you need a template for creating a reproduction, all of our examples can be opened in isolated
+sandboxes or modified as you see fit: https://github.com/urql-graphql/urql/tree/main/examples
+
 ### How do I propose changes?
 
 We follow an **RFC proposal process**. This allows anyone to propose a new feature or a change, and

--- a/docs/advanced/authentication.md
+++ b/docs/advanced/authentication.md
@@ -10,6 +10,8 @@ Most APIs include some type of authentication, usually in the form of an auth to
 The purpose of the [`authExchange`](../api/auth-exchange.md) is to provide a flexible API that facilitates the typical
 JWT-based authentication flow.
 
+> **Note:** [You can find a code example for `@urql/exchange-auth` in an example in the `urql` repository.](https://github.com/urql-graphql/urql/tree/main/examples/with-refresh-auth)
+
 ## Typical Authentication Flow
 
 **Initial login** — the user opens the application and authenticates for the first time. They enter their credentials and receive an auth token.

--- a/docs/advanced/persistence-and-uploads.md
+++ b/docs/advanced/persistence-and-uploads.md
@@ -32,6 +32,8 @@ enable support for Automatic Persisted Queries. This exchange works alongside ot
 subscription exchanges by adding metadata for persisted queries to each GraphQL
 request by modifying the `extensions` object of operations.
 
+> **Note:** [You can find a code example for `@urql/exchange-persisted` in an example in the `urql` repository.](https://github.com/urql-graphql/urql/tree/main/examples/with-apq)
+
 ### Installation & Setup
 
 First install `@urql/exchange-persisted` alongside `urql`:
@@ -131,3 +133,5 @@ GraphQL Multipart Request specification, and sends it off to the API.
 
 > **Note:** Previously, this worked by installing the `@urql/multipart-fetch-exchange` package.
 > however, this package has been deprecated and file uploads are now built into `@urql/core@4`.
+
+[You can find a code example for file uploads in an example in the `urql` repository.](https://github.com/urql-graphql/urql/tree/main/examples/with-multipart)

--- a/docs/advanced/retry-operations.md
+++ b/docs/advanced/retry-operations.md
@@ -9,6 +9,8 @@ The `retryExchange` lets us retry specific operation, by default it will
 retry only network errors, but we can specify additional options to add
 functionality.
 
+> **Note:** [You can find a code example for `@urql/exchange-retry` in an example in the `urql` repository.](https://github.com/urql-graphql/urql/tree/main/examples/with-retry)
+
 ## Installation and Setup
 
 First install `@urql/exchange-retry` alongside `urql`:

--- a/docs/advanced/subscriptions.md
+++ b/docs/advanced/subscriptions.md
@@ -50,7 +50,7 @@ When we define this function it must return an "Observable-like" object, which n
 [Observable spec](https://github.com/tc39/proposal-observable), which comes down to having an
 object with a `.subscribe()` method accepting an observer.
 
-## Setting up `graphql-ws`
+### Setting up `graphql-ws`
 
 For backends supporting `graphql-ws`, we recommend using the [graphql-ws](https://github.com/enisdenjo/graphql-ws) client.
 
@@ -88,7 +88,7 @@ we return to the `subscriptionExchange` inside `forwardSubscription`.
 
 [Read more on the `graphql-ws` README.](https://github.com/enisdenjo/graphql-ws/blob/master/README.md)
 
-## Setting up `subscriptions-transport-ws`
+### Setting up `subscriptions-transport-ws`
 
 For backends supporting `subscriptions-transport-ws`, [Apollo's `subscriptions-transport-ws`
 package](https://github.com/apollographql/subscriptions-transport-ws) can be used.
@@ -118,6 +118,29 @@ and are using the `SubscriptionClient`'s `request` method to create a Subscripti
 we return to the `subscriptionExchange` inside `forwardSubscription`.
 
 [Read more about `subscription-transport-ws` on its README.](https://github.com/apollographql/subscriptions-transport-ws/blob/master/README.md)
+
+### Using `fetch` for subscriptions
+
+Some GraphQL backends (for example GraphQL Yoga) support built-in transport protocols that
+can execute subscriptions via a simple HTTP fetch call.
+In fact, this is how `@defer` and `@stream` directives are supported. These transports can
+also be used for subscriptions.
+
+```js
+import { Client, cacheExchange, fetchExchange, subscriptionExchange } from 'urql';
+
+const client = new Client({
+  url: '/graphql',
+  fetchSubscriptions: true,
+  exchanges: [cacheExchange, fetchExchange],
+});
+```
+
+In this example, we only need to enable `fetchSubscriptions: true` on the `Client`, and the
+`fetchExchange` will be used to send subscriptions to the API. If your API supports this transport,
+it will stream results back to the `fetchExchange`.
+
+[You can find a code example of subscriptions via `fetch` in an example in the `urql` repository.](https://github.com/urql-graphql/urql/tree/main/examples/with-subscriptions-via-fetch)
 
 ## React & Preact
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,17 +1,366 @@
-| Example                                                          | Description                                                                                                  |
-| ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| [`with-react`](./with-react)                                     | Shows a basic query in `urql` with React.                                                                    |
-| [`with-react-native`](./with-react-native)                       | Shows a basic query in `urql` with React Native.                                                             |
-| [`with-svelte`](./with-svelte)                                   | Shows a basic query in `@urql/svelte` with Svelte.                                                           |
-| [`with-vue3`](./with-vue3)                                       | Shows a basic query in `@urql/vue` with Vue 3.                                                               |
-| [`with-next`](./with-next)                                       | Shows some examples with `next-urql` in Next.js with the default, `getStaticProps` and `getServerSideProps`. |
-| [`with-pagination`](./with-pagination)                           | Shows how to generically set up pagination with `urql` in UI code.                                           |
-| [`with-infinite-pagination`](./with-infinite-pagination)         | Shows how to generically set up infinite scrolling pagination with `urql` in UI code.                        |
-| [`with-apq`](./with-apq)                                         | Shows Automatic Persisted Queries with `@urql/exchange-persisted-fetch`.                                     |
-| [`with-graphcache-updates`](./with-graphcache-updates)           | Shows manual cache updates with `@urql/exchange-graphcache`.                                                 |
-| [`with-graphcache-pagination`](./with-graphcache-pagination)     | Shows the automatic infinite pagination helpers from `@urql/exchange-graphcache`.                            |
-| [`with-multipart`](./with-multipart)                             | Shows file upload support with `@urql/exchange-multipart-fetch`.                                             |
-| [`with-refresh-auth`](./with-refresh-auth)                       | Shows an example of authentication with refresh tokens using `@urql/exchange-auth`.                          |
-| [`with-retry`](./with-retry)                                     | Shows how to set up `@urql/exchange-retry` for retrying failed operations.                                   |
-| [`with-defer-stream-directives`](./with-defer-stream-directives) | Demonstrates `urql` and `@urql/exchange-graphcache` with built-in support for `@defer` and `@stream`.        |
-| [`with-subscriptions-via-fetch`](./with-subscriptions-via-fetch) | Demonstrates `urql` executing subscriptions with a GraphQL Yoga API via the `fetchExchange`.                 |
+<table>
+<thead>
+  <tr>
+    <th>Example</th>
+    <th></th>
+    <th></th>
+  </tr>
+</thead>
+<tbody>
+
+<tr>
+  <td>
+    <a href="./with-react"><strong>with-react</strong></a><br />
+  </td>
+  <td>
+    Shows a basic query in <code>urql</code> with React.
+  </td>
+  <td>
+    <a href="https://stackblitz.com/github/urql-graphql/urql/tree/main/examples/with-react">
+      <img
+        alt="Open in StackBlitz"
+        src="https://img.shields.io/badge/open_in_stackblitz-1269D3?logo=stackblitz"
+      />
+    </a>
+    <a href="https://codesandbox.io/p/sandbox/github/urql-graphql/urql/tree/main/examples/with-react">
+      <img
+        alt="Open in CodeSandbox"
+        src="https://img.shields.io/badge/open_in_codesandbox-151515?logo=codesandbox"
+      />
+    </a>
+  </td>
+</tr>
+
+<tr>
+  <td>
+    <a href="./with-react-native"><strong>with-react-native</strong></a><br />
+  </td>
+  <td>
+    Shows a basic query in <code>urql</code> with React Native.
+  </td>
+  <td>
+    <a href="https://stackblitz.com/github/urql-graphql/urql/tree/main/examples/with-react-native">
+      <img
+        alt="Open in StackBlitz"
+        src="https://img.shields.io/badge/open_in_stackblitz-1269D3?logo=stackblitz"
+      />
+    </a>
+    <a href="https://codesandbox.io/p/sandbox/github/urql-graphql/urql/tree/main/examples/with-react-native">
+      <img
+        alt="Open in CodeSandbox"
+        src="https://img.shields.io/badge/open_in_codesandbox-151515?logo=codesandbox"
+      />
+    </a>
+  </td>
+</tr>
+
+<tr>
+  <td>
+    <a href="./with-svelte"><strong>with-svelte</strong></a><br />
+  </td>
+  <td>
+    Shows a basic query in <code>@urql/svelte</code> with Svelte.
+  </td>
+  <td>
+    <a href="https://stackblitz.com/github/urql-graphql/urql/tree/main/examples/with-svelte">
+      <img
+        alt="Open in StackBlitz"
+        src="https://img.shields.io/badge/open_in_stackblitz-1269D3?logo=stackblitz"
+      />
+    </a>
+    <a
+    href="https://codesandbox.io/p/sandbox/github/urql-graphql/urql/tree/main/examples/with-svelte">
+      <img
+        alt="Open in CodeSandbox"
+        src="https://img.shields.io/badge/open_in_codesandbox-151515?logo=codesandbox"
+      />
+    </a>
+  </td>
+</tr>
+
+<tr>
+  <td>
+    <a href="./with-vue3"><strong>with-vue3</strong></a><br />
+  </td>
+  <td>
+    Shows a basic query in <code>@urql/vue</code> with Vue 3.
+  </td>
+  <td>
+    <a href="https://stackblitz.com/github/urql-graphql/urql/tree/main/examples/with-vue3">
+      <img
+        alt="Open in StackBlitz"
+        src="https://img.shields.io/badge/open_in_stackblitz-1269D3?logo=stackblitz"
+      />
+    </a>
+    <a href="https://codesandbox.io/p/sandbox/github/urql-graphql/urql/tree/main/examples/with-vue3">
+      <img
+        alt="Open in CodeSandbox"
+        src="https://img.shields.io/badge/open_in_codesandbox-151515?logo=codesandbox"
+      />
+    </a>
+  </td>
+</tr>
+
+<tr>
+  <td>
+    <a href="./with-next"><strong>with-next</strong></a><br />
+  </td>
+  <td>
+    Shows a basic query in <code>next-urql</code> with Next.js.
+  </td>
+  <td>
+    <a href="https://stackblitz.com/github/urql-graphql/urql/tree/main/examples/with-next">
+      <img
+        alt="Open in StackBlitz"
+        src="https://img.shields.io/badge/open_in_stackblitz-1269D3?logo=stackblitz"
+      />
+    </a>
+    <a href="https://codesandbox.io/p/sandbox/github/urql-graphql/urql/tree/main/examples/with-next">
+      <img
+        alt="Open in CodeSandbox"
+        src="https://img.shields.io/badge/open_in_codesandbox-151515?logo=codesandbox"
+      />
+    </a>
+  </td>
+</tr>
+
+<tr>
+  <td>
+    <a href="./with-pagination"><strong>with-pagination</strong></a><br />
+  </td>
+  <td>
+    Shows how to generically set up pagination with <code>urql</code> in UI code.
+  </td>
+  <td>
+    <a href="https://stackblitz.com/github/urql-graphql/urql/tree/main/examples/with-pagination">
+      <img
+        alt="Open in StackBlitz"
+        src="https://img.shields.io/badge/open_in_stackblitz-1269D3?logo=stackblitz"
+      />
+    </a>
+    <a
+    href="https://codesandbox.io/p/sandbox/github/urql-graphql/urql/tree/main/examples/with-pagination">
+      <img
+        alt="Open in CodeSandbox"
+        src="https://img.shields.io/badge/open_in_codesandbox-151515?logo=codesandbox"
+      />
+    </a>
+  </td>
+</tr>
+
+<tr>
+  <td>
+    <a href="./with-infinite-pagination"><strong>with-infinite-pagination</strong></a><br />
+  </td>
+  <td>
+    Shows how to generically set up infinite scrolling pagination with <code>urql</code> in UI code.
+  </td>
+  <td>
+    <a href="https://stackblitz.com/github/urql-graphql/urql/tree/main/examples/with-infinite-pagination">
+      <img
+        alt="Open in StackBlitz"
+        src="https://img.shields.io/badge/open_in_stackblitz-1269D3?logo=stackblitz"
+      />
+    </a>
+    <a
+    href="https://codesandbox.io/p/sandbox/github/urql-graphql/urql/tree/main/examples/with-infinite-pagination">
+      <img
+        alt="Open in CodeSandbox"
+        src="https://img.shields.io/badge/open_in_codesandbox-151515?logo=codesandbox"
+      />
+    </a>
+  </td>
+</tr>
+
+<tr>
+  <td>
+    <a href="./with-apq"><strong>with-apq</strong></a><br />
+  </td>
+  <td>
+    Shows Automatic Persisted Queries with <code>@urql/exchange-persisted</code>.
+  </td>
+  <td>
+    <a href="https://stackblitz.com/github/urql-graphql/urql/tree/main/examples/with-apq">
+      <img
+        alt="Open in StackBlitz"
+        src="https://img.shields.io/badge/open_in_stackblitz-1269D3?logo=stackblitz"
+      />
+    </a>
+    <a
+    href="https://codesandbox.io/p/sandbox/github/urql-graphql/urql/tree/main/examples/with-apq">
+      <img
+        alt="Open in CodeSandbox"
+        src="https://img.shields.io/badge/open_in_codesandbox-151515?logo=codesandbox"
+      />
+    </a>
+  </td>
+</tr>
+
+<tr>
+  <td>
+    <a href="./with-graphcache-updates"><strong>with-graphcache-updates</strong></a><br />
+  </td>
+  <td>
+    Shows manual cache updates with <code>@urql/exchange-graphcache</code>.
+  </td>
+  <td>
+    <a href="https://stackblitz.com/github/urql-graphql/urql/tree/main/examples/with-graphcache-updates">
+      <img
+        alt="Open in StackBlitz"
+        src="https://img.shields.io/badge/open_in_stackblitz-1269D3?logo=stackblitz"
+      />
+    </a>
+    <a href="https://codesandbox.io/p/sandbox/github/urql-graphql/urql/tree/main/examples/with-graphcache-updates">
+      <img
+        alt="Open in CodeSandbox"
+        src="https://img.shields.io/badge/open_in_codesandbox-151515?logo=codesandbox"
+      />
+    </a>
+  </td>
+</tr>
+
+<tr>
+  <td>
+    <a href="./with-graphcache-pagination"><strong>with-graphcache-pagination</strong></a><br />
+  </td>
+  <td>
+    Shows the automatic infinite pagination helpers from <code>@urql/exchange-graphcache</code>.
+  </td>
+  <td>
+    <a
+    href="https://stackblitz.com/github/urql-graphql/urql/tree/main/examples/with-graphcache-pagination">
+      <img
+        alt="Open in StackBlitz"
+        src="https://img.shields.io/badge/open_in_stackblitz-1269D3?logo=stackblitz"
+      />
+    </a>
+    <a href="https://codesandbox.io/p/sandbox/github/urql-graphql/urql/tree/main/examples/with-graphcache-pagination">
+      <img
+        alt="Open in CodeSandbox"
+        src="https://img.shields.io/badge/open_in_codesandbox-151515?logo=codesandbox"
+      />
+    </a>
+  </td>
+</tr>
+
+<tr>
+  <td>
+    <a href="./with-multipart"><strong>with-multipart</strong></a><br />
+  </td>
+  <td>
+    Shows file upload support integrated in <code>@urql/core</code>.
+  </td>
+  <td>
+    <a href="https://stackblitz.com/github/urql-graphql/urql/tree/main/examples/with-multipart">
+      <img
+        alt="Open in StackBlitz"
+        src="https://img.shields.io/badge/open_in_stackblitz-1269D3?logo=stackblitz"
+      />
+    </a>
+    <a href="https://codesandbox.io/p/sandbox/github/urql-graphql/urql/tree/main/examples/with-multipart">
+      <img
+        alt="Open in CodeSandbox"
+        src="https://img.shields.io/badge/open_in_codesandbox-151515?logo=codesandbox"
+      />
+    </a>
+  </td>
+</tr>
+
+<tr>
+  <td>
+    <a href="./with-refresh-auth"><strong>with-refresh-auth</strong></a><br />
+  </td>
+  <td>
+    Shows authentication with refresh tokens using <code>@urql/exchange-auth</code>.
+  </td>
+  <td>
+    <a href="https://stackblitz.com/github/urql-graphql/urql/tree/main/examples/with-refresh-auth">
+      <img
+        alt="Open in StackBlitz"
+        src="https://img.shields.io/badge/open_in_stackblitz-1269D3?logo=stackblitz"
+      />
+    </a>
+    <a href="https://codesandbox.io/p/sandbox/github/urql-graphql/urql/tree/main/examples/with-refresh-auth">
+      <img
+        alt="Open in CodeSandbox"
+        src="https://img.shields.io/badge/open_in_codesandbox-151515?logo=codesandbox"
+      />
+    </a>
+  </td>
+</tr>
+
+<tr>
+  <td>
+    <a href="./with-retry"><strong>with-retry</strong></a><br />
+  </td>
+  <td>
+    Shows retrying of failed operations with <code>@urql/exchange-retry</code>.
+  </td>
+  <td>
+    <a href="https://stackblitz.com/github/urql-graphql/urql/tree/main/examples/with-retry">
+      <img
+        alt="Open in StackBlitz"
+        src="https://img.shields.io/badge/open_in_stackblitz-1269D3?logo=stackblitz"
+      />
+    </a>
+    <a href="https://codesandbox.io/p/sandbox/github/urql-graphql/urql/tree/main/examples/with-retry">
+      <img
+        alt="Open in CodeSandbox"
+        src="https://img.shields.io/badge/open_in_codesandbox-151515?logo=codesandbox"
+      />
+    </a>
+  </td>
+</tr>
+
+<tr>
+  <td>
+    <a href="./with-defer-stream-directives"><strong>with-defer-stream-directives</strong></a><br />
+  </td>
+  <td>
+    Demonstrates <code>urql</code> and <code>@urql/exchange-graphcache</code> with built-in support for <code>@defer</code> and <code>@stream</code>.
+  </td>
+  <td>
+    <a
+    href="https://stackblitz.com/github/urql-graphql/urql/tree/main/examples/with-defer-stream-directives">
+      <img
+        alt="Open in StackBlitz"
+        src="https://img.shields.io/badge/open_in_stackblitz-1269D3?logo=stackblitz"
+      />
+    </a>
+    <a
+    href="https://codesandbox.io/p/sandbox/github/urql-graphql/urql/tree/main/examples/with-defer-stream-directives">
+      <img
+        alt="Open in CodeSandbox"
+        src="https://img.shields.io/badge/open_in_codesandbox-151515?logo=codesandbox"
+      />
+    </a>
+  </td>
+</tr>
+
+<tr>
+  <td>
+    <a href="./with-subscriptions-via-fetch"><strong>with-subscriptions-via-fetch</strong></a><br />
+  </td>
+  <td>
+    Demonstrates <code>@urql/core</code>'s built-in support for executing subscriptions with a GraphQL Yoga API via the <code>fetchExchange</code>.
+  </td>
+  <td>
+    <a
+    href="https://stackblitz.com/github/urql-graphql/urql/tree/main/examples/with-subscriptions-via-fetch">
+      <img
+        alt="Open in StackBlitz"
+        src="https://img.shields.io/badge/open_in_stackblitz-1269D3?logo=stackblitz"
+      />
+    </a>
+    <a
+    href="https://codesandbox.io/p/sandbox/github/urql-graphql/urql/tree/main/examples/with-subscriptions-via-fetch">
+      <img
+        alt="Open in CodeSandbox"
+        src="https://img.shields.io/badge/open_in_codesandbox-151515?logo=codesandbox"
+      />
+    </a>
+  </td>
+</tr>
+
+</tbody>
+</table>

--- a/examples/with-apq/README.md
+++ b/examples/with-apq/README.md
@@ -1,5 +1,20 @@
 # With Automatic Persisted Queries
 
+<p>
+  <a href="https://stackblitz.com/github/urql-graphql/urql/tree/main/examples/with-apq">
+    <img
+      alt="Open in StackBlitz"
+      src="https://img.shields.io/badge/open_in_stackblitz-1269D3?logo=stackblitz&style=for-the-badge"
+    />
+  </a>
+  <a href="https://codesandbox.io/p/sandbox/github/urql-graphql/urql/tree/main/examples/with-apq">
+    <img
+      alt="Open in CodeSandbox"
+      src="https://img.shields.io/badge/open_in_codesandbox-151515?logo=codesandbox&style=for-the-badge"
+    />
+  </a>
+</p>
+
 This example shows `urql` in use with `@urql/exchange-persisted-fetch`'s `persistedFetchExchange`
 to support [Automatic Persisted
 Queries](https://www.apollographql.com/docs/apollo-server/performance/apq/). This largely follows

--- a/examples/with-apq/package.json
+++ b/examples/with-apq/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@urql/core": "^4.0.11",
-    "@urql/exchange-persisted-fetch": "^1.3.0",
+    "@urql/exchange-persisted": "^4.0.1",
     "graphql": "^16.6.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/examples/with-defer-stream-directives/README.md
+++ b/examples/with-defer-stream-directives/README.md
@@ -1,5 +1,21 @@
 # With `@defer` / `@stream` Directives
 
+<p>
+  <a href="https://stackblitz.com/github/urql-graphql/urql/tree/main/examples/with-defer-stream-directives">
+    <img
+      alt="Open in StackBlitz"
+      src="https://img.shields.io/badge/open_in_stackblitz-1269D3?logo=stackblitz&style=for-the-badge"
+    />
+  </a>
+  <a
+  href="https://codesandbox.io/p/sandbox/github/urql-graphql/urql/tree/main/examples/with-defer-stream-directives">
+    <img
+      alt="Open in CodeSandbox"
+      src="https://img.shields.io/badge/open_in_codesandbox-151515?logo=codesandbox&style=for-the-badge"
+    />
+  </a>
+</p>
+
 This example shows `urql` in use [with `@defer` and `@stream`
 directives](https://graphql.org/blog/2020-12-08-improving-latency-with-defer-and-stream-directives)
 in GraphQL.

--- a/examples/with-graphcache-pagination/README.md
+++ b/examples/with-graphcache-pagination/README.md
@@ -1,5 +1,22 @@
 # With Graphcache's Pagination
 
+<p>
+  <a
+  href="https://stackblitz.com/github/urql-graphql/urql/tree/main/examples/with-graphcache-pagination">
+    <img
+      alt="Open in StackBlitz"
+      src="https://img.shields.io/badge/open_in_stackblitz-1269D3?logo=stackblitz&style=for-the-badge"
+    />
+  </a>
+  <a
+  href="https://codesandbox.io/p/sandbox/github/urql-graphql/urql/tree/main/examples/with-graphcache-pagination">
+    <img
+      alt="Open in CodeSandbox"
+      src="https://img.shields.io/badge/open_in_codesandbox-151515?logo=codesandbox&style=for-the-badge"
+    />
+  </a>
+</p>
+
 This example shows `urql` in use with `@urql/exchange-graphcache`'s infinite pagination helpers to
 merge several pages of a Relay-compliant schema into an infinite list.
 This largely follows the ["Pagination" section on the "Local Resolvers" docs

--- a/examples/with-graphcache-updates/README.md
+++ b/examples/with-graphcache-updates/README.md
@@ -1,5 +1,22 @@
 # With Graphcache's Pagination
 
+<p>
+  <a
+  href="https://stackblitz.com/github/urql-graphql/urql/tree/main/examples/with-graphcache-updates">
+    <img
+      alt="Open in StackBlitz"
+      src="https://img.shields.io/badge/open_in_stackblitz-1269D3?logo=stackblitz&style=for-the-badge"
+    />
+  </a>
+  <a
+  href="https://codesandbox.io/p/sandbox/github/urql-graphql/urql/tree/main/examples/with-graphcache-updates">
+    <img
+      alt="Open in CodeSandbox"
+      src="https://img.shields.io/badge/open_in_codesandbox-151515?logo=codesandbox&style=for-the-badge"
+    />
+  </a>
+</p>
+
 This example shows `urql` in use with `@urql/exchange-graphcache` and demonstrates a manual cache
 update, as explained in [the "Cache Updates" docs page](https://formidable.com/open-source/urql/docs/graphcache/cache-updates/).
 This example uses the [`trygql.formidable.dev/graphql/web-collections`

--- a/examples/with-infinite-pagination/README.md
+++ b/examples/with-infinite-pagination/README.md
@@ -1,5 +1,22 @@
 # With Infinite Pagination (in React)
 
+<p>
+  <a
+  href="https://stackblitz.com/github/urql-graphql/urql/tree/main/examples/with-infinite-pagination">
+    <img
+      alt="Open in StackBlitz"
+      src="https://img.shields.io/badge/open_in_stackblitz-1269D3?logo=stackblitz&style=for-the-badge"
+    />
+  </a>
+  <a
+  href="https://codesandbox.io/p/sandbox/github/urql-graphql/urql/tree/main/examples/with-infinite-pagination">
+    <img
+      alt="Open in CodeSandbox"
+      src="https://img.shields.io/badge/open_in_codesandbox-151515?logo=codesandbox&style=for-the-badge"
+    />
+  </a>
+</p>
+
 This example shows how to implement **infinite scroll** pagination with `urql`
 in your React UI code.
 

--- a/examples/with-multipart/README.md
+++ b/examples/with-multipart/README.md
@@ -1,5 +1,21 @@
 # With Multipart File Upload
 
+<p>
+  <a href="https://stackblitz.com/github/urql-graphql/urql/tree/main/examples/with-multipart">
+    <img
+      alt="Open in StackBlitz"
+      src="https://img.shields.io/badge/open_in_stackblitz-1269D3?logo=stackblitz&style=for-the-badge"
+    />
+  </a>
+  <a
+  href="https://codesandbox.io/p/sandbox/github/urql-graphql/urql/tree/main/examples/with-multipart">
+    <img
+      alt="Open in CodeSandbox"
+      src="https://img.shields.io/badge/open_in_codesandbox-151515?logo=codesandbox&style=for-the-badge"
+    />
+  </a>
+</p>
+
 This example shows `urql` in use with `@urql/exchange-multipart-fetch`'s `multipartFetchExchange`
 to support file uploads in GraphQL. This largely follows the ["File Uploads" docs
 page](https://formidable.com/open-source/urql/docs/advanced/persistence-and-uploads/)

--- a/examples/with-next/README.md
+++ b/examples/with-next/README.md
@@ -1,5 +1,20 @@
 # With Next.js
 
+<p>
+  <a href="https://stackblitz.com/github/urql-graphql/urql/tree/main/examples/with-next">
+    <img
+      alt="Open in StackBlitz"
+      src="https://img.shields.io/badge/open_in_stackblitz-1269D3?logo=stackblitz&style=for-the-badge"
+    />
+  </a>
+  <a href="https://codesandbox.io/p/sandbox/github/urql-graphql/urql/tree/main/examples/with-next">
+    <img
+      alt="Open in CodeSandbox"
+      src="https://img.shields.io/badge/open_in_codesandbox-151515?logo=codesandbox&style=for-the-badge"
+    />
+  </a>
+</p>
+
 This example shows `next-urql` and `urql` in use with Next.js as explained [in the "Next.js" section
 on the "Server-side Rendering" docs
 page](https://formidable.com/open-source/urql/docs/advanced/server-side-rendering/#nextjs).

--- a/examples/with-pagination/README.md
+++ b/examples/with-pagination/README.md
@@ -1,5 +1,21 @@
 # With Pagination (in React)
 
+<p>
+  <a href="https://stackblitz.com/github/urql-graphql/urql/tree/main/examples/with-pagination">
+    <img
+      alt="Open in StackBlitz"
+      src="https://img.shields.io/badge/open_in_stackblitz-1269D3?logo=stackblitz&style=for-the-badge"
+    />
+  </a>
+  <a
+  href="https://codesandbox.io/p/sandbox/github/urql-graphql/urql/tree/main/examples/with-pagination">
+    <img
+      alt="Open in CodeSandbox"
+      src="https://img.shields.io/badge/open_in_codesandbox-151515?logo=codesandbox&style=for-the-badge"
+    />
+  </a>
+</p>
+
 This example shows how to implement pagination with `urql` in your React UI code.
 
 It renders several pages as fragments with one component managing the variables

--- a/examples/with-react-native/README.md
+++ b/examples/with-react-native/README.md
@@ -1,5 +1,21 @@
 # With React Native
 
+<p>
+  <a href="https://stackblitz.com/github/urql-graphql/urql/tree/main/examples/with-react-native">
+    <img
+      alt="Open in StackBlitz"
+      src="https://img.shields.io/badge/open_in_stackblitz-1269D3?logo=stackblitz&style=for-the-badge"
+    />
+  </a>
+  <a
+  href="https://codesandbox.io/p/sandbox/github/urql-graphql/urql/tree/main/examples/with-react-native">
+    <img
+      alt="Open in CodeSandbox"
+      src="https://img.shields.io/badge/open_in_codesandbox-151515?logo=codesandbox&style=for-the-badge"
+    />
+  </a>
+</p>
+
 This example shows `urql` in use with React Native.
 
 To run this example install dependencies and run the `start` script:

--- a/examples/with-react/README.md
+++ b/examples/with-react/README.md
@@ -1,5 +1,20 @@
 # With React
 
+<p>
+  <a href="https://stackblitz.com/github/urql-graphql/urql/tree/main/examples/with-react">
+    <img
+      alt="Open in StackBlitz"
+      src="https://img.shields.io/badge/open_in_stackblitz-1269D3?logo=stackblitz&style=for-the-badge"
+    />
+  </a>
+  <a href="https://codesandbox.io/p/sandbox/github/urql-graphql/urql/tree/main/examples/with-react">
+    <img
+      alt="Open in CodeSandbox"
+      src="https://img.shields.io/badge/open_in_codesandbox-151515?logo=codesandbox&style=for-the-badge"
+    />
+  </a>
+</p>
+
 This example shows `urql` in use with React, as explained on the ["React/Preact" page of the "Basics"
 documentation.](https://formidable.com/open-source/urql/docs/basics/react-preact/)
 

--- a/examples/with-refresh-auth/README.md
+++ b/examples/with-refresh-auth/README.md
@@ -1,5 +1,21 @@
 # With Refresh Authentication
 
+<p>
+  <a href="https://stackblitz.com/github/urql-graphql/urql/tree/main/examples/with-refresh-auth">
+    <img
+      alt="Open in StackBlitz"
+      src="https://img.shields.io/badge/open_in_stackblitz-1269D3?logo=stackblitz&style=for-the-badge"
+    />
+  </a>
+  <a
+  href="https://codesandbox.io/p/sandbox/github/urql-graphql/urql/tree/main/examples/with-refresh-auth">
+    <img
+      alt="Open in CodeSandbox"
+      src="https://img.shields.io/badge/open_in_codesandbox-151515?logo=codesandbox&style=for-the-badge"
+    />
+  </a>
+</p>
+
 This example shows `urql` in use with `@urql/exchange-auth`'s `authExchange`
 to support authentication token and refresh token logic. This largely follows the ["Authentication" docs
 page](https://formidable.com/open-source/urql/docs/advanced/authentication/)

--- a/examples/with-retry/README.md
+++ b/examples/with-retry/README.md
@@ -1,5 +1,20 @@
 # Integrating `@urql/exchange-retry`’s retryExchange
 
+<p>
+  <a href="https://stackblitz.com/github/urql-graphql/urql/tree/main/examples/with-retry">
+    <img
+      alt="Open in StackBlitz"
+      src="https://img.shields.io/badge/open_in_stackblitz-1269D3?logo=stackblitz&style=for-the-badge"
+    />
+  </a>
+  <a href="https://codesandbox.io/p/sandbox/github/urql-graphql/urql/tree/main/examples/with-retry">
+    <img
+      alt="Open in CodeSandbox"
+      src="https://img.shields.io/badge/open_in_codesandbox-151515?logo=codesandbox&style=for-the-badge"
+    />
+  </a>
+</p>
+
 Integrating urql is as simple as:
 
 1.  Install packages

--- a/examples/with-subscriptions-via-fetch/README.md
+++ b/examples/with-subscriptions-via-fetch/README.md
@@ -1,5 +1,22 @@
 # With Subscriptions via Fetch
 
+<p>
+  <a
+  href="https://stackblitz.com/github/urql-graphql/urql/tree/main/examples/with-subscriptions-via-fetch">
+    <img
+      alt="Open in StackBlitz"
+      src="https://img.shields.io/badge/open_in_stackblitz-1269D3?logo=stackblitz&style=for-the-badge"
+    />
+  </a>
+  <a
+  href="https://codesandbox.io/p/sandbox/github/urql-graphql/urql/tree/main/examples/with-subscriptions-via-fetch">
+    <img
+      alt="Open in CodeSandbox"
+      src="https://img.shields.io/badge/open_in_codesandbox-151515?logo=codesandbox&style=for-the-badge"
+    />
+  </a>
+</p>
+
 This example shows `urql` in use with subscriptions running via a plain `fetch`
 HTTP request to GraphQL Yoga. This uses the [GraphQL Server-Sent
 Events](https://the-guild.dev/blog/graphql-over-sse) protocol, which means that

--- a/examples/with-svelte/README.md
+++ b/examples/with-svelte/README.md
@@ -1,5 +1,20 @@
 # With Svelte
 
+<p>
+  <a href="https://stackblitz.com/github/urql-graphql/urql/tree/main/examples/with-svelte">
+    <img
+      alt="Open in StackBlitz"
+      src="https://img.shields.io/badge/open_in_stackblitz-1269D3?logo=stackblitz&style=for-the-badge"
+    />
+  </a>
+  <a href="https://codesandbox.io/p/sandbox/github/urql-graphql/urql/tree/main/examples/with-svelte">
+    <img
+      alt="Open in CodeSandbox"
+      src="https://img.shields.io/badge/open_in_codesandbox-151515?logo=codesandbox&style=for-the-badge"
+    />
+  </a>
+</p>
+
 This example shows `@urql/svelte` in use with Svelte, as explained on the ["Svelte" page of the "Basics"
 documentation.](https://formidable.com/open-source/urql/docs/basics/svelte/)
 

--- a/examples/with-vue3/README.md
+++ b/examples/with-vue3/README.md
@@ -1,5 +1,20 @@
 # With Vue 3
 
+<p>
+  <a href="https://stackblitz.com/github/urql-graphql/urql/tree/main/examples/with-vue3">
+    <img
+      alt="Open in StackBlitz"
+      src="https://img.shields.io/badge/open_in_stackblitz-1269D3?logo=stackblitz&style=for-the-badge"
+    />
+  </a>
+  <a href="https://codesandbox.io/p/sandbox/github/urql-graphql/urql/tree/main/examples/with-vue3">
+    <img
+      alt="Open in CodeSandbox"
+      src="https://img.shields.io/badge/open_in_codesandbox-151515?logo=codesandbox&style=for-the-badge"
+    />
+  </a>
+</p>
+
 This example shows `@urql/vue` in use with Vue 3, as explained on the ["Vue" page of the "Basics"
 documentation.](https://formidable.com/open-source/urql/docs/basics/vue/)
 


### PR DESCRIPTION
- Refactor `examples/README` to contain a table with more links
- Add Stackblitz & CodeSandbox links to each example's `README`
- Add links to examples to various docs pages
- Add subscriptions via `fetch` instructions to docs