### PR TITLE
Fix/react usequery pause edgecase

### DIFF
--- a/.changeset/serious-balloons-cheat.md
+++ b/.changeset/serious-balloons-cheat.md
@@ -1,0 +1,5 @@
+---
+'urql': patch
+---
+
+Fix edge case that causes execute functions from `useQuery` and `useSubscription` to fail when they’re called in their state after a render that changes `pause`. This would previously cause internal dependencies to be outdated and the source to be discarded immediately in some cases.

--- a/packages/react-urql/src/hooks/useQuery.ts
+++ b/packages/react-urql/src/hooks/useQuery.ts
@@ -376,9 +376,9 @@ export function useQuery<
       cache,
       request,
       suspense,
-      getSnapshot,
       args.requestPolicy,
       args.context,
+      args.pause,
     ]
   );
 

--- a/packages/react-urql/src/hooks/useSubscription.ts
+++ b/packages/react-urql/src/hooks/useSubscription.ts
@@ -300,7 +300,7 @@ export function useSubscription<
 
       deferDispatch(setState, state => [source, state[1], deps]);
     },
-    [client, args.context, request]
+    [client, request, args.context, args.pause]
   );
 
   return [currentResult, executeSubscription];


### PR DESCRIPTION
Resolves #3289
Supersedes #3289

## Summary

This updates the outdated dependencies array in `react-urql`’s `useQuery` (which still contained `getSnapshot`) and adds `args.pause`. It does the same in `useSubscription`.

When `executeQuery`/`executeSubscription` are not re-created when all dependencies change, the first render when they're outdated would refresh the dependencies to an older version, causing the source to be immediately overridden again.

This specifically caused an edge case because the dependencies didn't include `args.pause`. This means that the execute functions are outdated the render after `args.pause` changes, and means that their state change is immediately overwritten.

## Set of changes

- Update `executeQuery` / `executeSubscription` dependencies to account for `args.pause` changes