### PR TITLE
feat(persisted): Allow nullish hashes for skipping persisted logic

### DIFF
--- a/.changeset/seven-adults-fix.md
+++ b/.changeset/seven-adults-fix.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-persisted': minor
+---
+
+Allow persisted query logic to be skipped by the `persistedExchange` if the passed `generateHash` function resolves to a nullish value. This allows (A)PQ to be selectively disabled for individual operations.

--- a/exchanges/persisted/src/persistedExchange.ts
+++ b/exchanges/persisted/src/persistedExchange.ts
@@ -68,6 +68,10 @@ export interface PersistedExchangeOptions {
    * hashes at compile-time, or need to use a custom SHA-256 function,
    * you may pass one here.
    *
+   * If `generateHash` returns either `null` or `undefined`, the
+   * operation will not be treated as a persisted operation, which
+   * essentially skips this exchange’s logic for a given operation.
+   *
    * Hint: The default SHA-256 function uses the WebCrypto API. This
    * API is unavailable on React Native, which may require you to
    * pass a custom function here.
@@ -75,7 +79,7 @@ export interface PersistedExchangeOptions {
   generateHash?(
     query: string,
     document: TypedDocumentNode<any, any>
-  ): Promise<string>;
+  ): Promise<string | undefined | null>;
   /** Enables persisted queries to be used for mutations.
    *
    * @remarks


### PR DESCRIPTION
## Summary

This allows `generateHash` to resolve to `null | undefined`, effectively allowing the persisted logic to be skipped selectively for individual operations.

## Set of changes

- Allow `null | undefined` to be returned by `generateHash`
- Add test for new case
