### PR TITLE
Add solid

### DIFF
--- a/packages/solid-urql/package.json
+++ b/packages/solid-urql/package.json
@@ -1,0 +1,73 @@
+{
+  "name": "@urql/solid",
+  "version": "4.0.4",
+  "description": "A highly customizable and versatile GraphQL client for Solid",
+  "sideEffects": false,
+  "homepage": "https://formidable.com/open-source/urql/docs/",
+  "bugs": "https://github.com/urql-graphql/urql/issues",
+  "license": "MIT",
+  "author": "urql GraphQL Contributors",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/urql-graphql/urql.git",
+    "directory": "packages/solid-urql"
+  },
+  "keywords": [
+    "graphql client",
+    "state management",
+    "cache",
+    "graphql",
+    "exchanges",
+    "solid"
+  ],
+  "main": "dist/urql-solid",
+  "module": "dist/urql-solid.mjs",
+  "types": "dist/urql-solid.d.ts",
+  "source": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/urql-solid.d.ts",
+      "import": "./dist/urql-solid.mjs",
+      "require": "./dist/urql-solid.js",
+      "source": "./src/index.ts"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "LICENSE",
+    "CHANGELOG.md",
+    "README.md",
+    "dist/"
+  ],
+  "scripts": {
+    "test": "vitest",
+    "clean": "rimraf dist",
+    "check": "tsc --noEmit",
+    "lint": "eslint --ext=js,jsx,ts,tsx .",
+    "build": "rollup -c ../../scripts/rollup/config.mjs",
+    "prepare": "node ../../scripts/prepare/index.js",
+    "prepublishOnly": "run-s clean build"
+  },
+  "devDependencies": {
+    "@solidjs/testing-library": "^0.8.2",
+    "@testing-library/jest-dom": "^5.16.5",
+    "@urql/core": "workspace:*",
+    "graphql": "^16.0.0",
+    "jsdom": "^22.1.0",
+    "vite-plugin-solid": "^2.7.0",
+    "vite-tsconfig-paths": "^4.2.0",
+    "vitest": "^0.32.2"
+  },
+  "peerDependencies": {
+    "solid-js": "^1.7.7"
+  },
+  "dependencies": {
+    "@solid-primitives/utils": "^6.2.0",
+    "@urql/core": "^4.0.0",
+    "wonka": "^6.3.2"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  }
+}

--- a/packages/solid-urql/package.json
+++ b/packages/solid-urql/package.json
@@ -62,7 +62,6 @@
     "solid-js": "^1.7.7"
   },
   "dependencies": {
-    "@solid-primitives/utils": "^6.2.0",
     "@urql/core": "^4.0.0",
     "wonka": "^6.3.2"
   },

--- a/packages/solid-urql/src/context.ts
+++ b/packages/solid-urql/src/context.ts
@@ -1,4 +1,4 @@
-import { Client } from '@urql/core';
+import { type Client } from '@urql/core';
 import { createContext, useContext } from 'solid-js';
 
 export const Context = createContext<Client>();

--- a/packages/solid-urql/src/context.ts
+++ b/packages/solid-urql/src/context.ts
@@ -4,7 +4,7 @@ import { createContext, useContext } from 'solid-js';
 export const Context = createContext<Client>();
 export const Provider = Context.Provider;
 
-type UseClient = () => Client;
+export type UseClient = () => Client;
 export const useClient: UseClient = () => {
   const client = useContext(Context);
 

--- a/packages/solid-urql/src/context.ts
+++ b/packages/solid-urql/src/context.ts
@@ -1,0 +1,20 @@
+import { Client } from '@urql/core';
+import { createContext, useContext } from 'solid-js';
+
+export const Context = createContext<Client>();
+export const Provider = Context.Provider;
+
+type UseClient = () => Client;
+export const useClient: UseClient = () => {
+  const client = useContext(Context);
+
+  if (process.env.NODE_ENV !== 'production' && client === undefined) {
+    const error =
+      "No client has been specified using urql's Provider. please create a client and add a Provider.";
+
+    console.error(error);
+    throw new Error(error);
+  }
+
+  return client!;
+};

--- a/packages/solid-urql/src/context.ts
+++ b/packages/solid-urql/src/context.ts
@@ -1,4 +1,4 @@
-import { type Client } from '@urql/core';
+import type { Client } from '@urql/core';
 import { createContext, useContext } from 'solid-js';
 
 export const Context = createContext<Client>();

--- a/packages/solid-urql/src/createMutation.test.ts
+++ b/packages/solid-urql/src/createMutation.test.ts
@@ -1,0 +1,78 @@
+import { renderHook } from '@solidjs/testing-library';
+import { expect, it, describe, vi } from 'vitest';
+import { createMutation } from './createMutation';
+import {
+  OperationResult,
+  OperationResultSource,
+  createClient,
+  gql,
+} from '@urql/core';
+import { makeSubject } from 'wonka';
+
+const QUERY = gql`
+  mutation {
+    test
+  }
+`;
+
+const client = createClient({
+  url: '/graphql',
+  exchanges: [],
+  suspense: false,
+});
+vi.mock('./context', () => {
+  const useClient = () => {
+    return client!;
+  };
+
+  return { useClient };
+});
+
+describe('createMutation', () => {
+  it.only('should have expected state before and after finish', async () => {
+    const subject = makeSubject<any>();
+    const clientMutation = vi
+      .spyOn(client, 'executeMutation')
+      .mockImplementation(
+        () => subject.source as OperationResultSource<OperationResult>
+      );
+
+    const { result } = renderHook(() =>
+      createMutation<{ test: boolean }, { variable: number }>(QUERY)
+    );
+
+    expect(result[0]).toMatchObject({
+      data: undefined,
+      stale: false,
+      fetching: false,
+      error: undefined,
+      extensions: undefined,
+      operation: undefined,
+    });
+
+    const promise = result[1]({ variable: 1 });
+
+    expect(result[0]).toMatchObject({
+      data: undefined,
+      stale: false,
+      fetching: true,
+      error: undefined,
+      extensions: undefined,
+      operation: undefined,
+    });
+
+    expect(clientMutation).toHaveBeenCalledTimes(1);
+
+    subject.next({ data: { test: true }, stale: false });
+    await promise.then(got => {
+      expect(got.stale).toBe(false);
+      expect(got.error).toBe(undefined);
+      expect(got.data).toEqual({ test: true });
+    });
+
+    expect(result[0].fetching).toBe(false);
+    expect(result[0].stale).toBe(false);
+    expect(result[0].error).toBe(undefined);
+    expect(result[0].data).toEqual({ test: true });
+  });
+});

--- a/packages/solid-urql/src/createMutation.test.ts
+++ b/packages/solid-urql/src/createMutation.test.ts
@@ -29,7 +29,7 @@ vi.mock('./context', () => {
 });
 
 describe('createMutation', () => {
-  it.only('should have expected state before and after finish', async () => {
+  it('should have expected state before and after finish', async () => {
     const subject = makeSubject<any>();
     const clientMutation = vi
       .spyOn(client, 'executeMutation')

--- a/packages/solid-urql/src/createMutation.ts
+++ b/packages/solid-urql/src/createMutation.ts
@@ -1,0 +1,70 @@
+import { createStore } from 'solid-js/store';
+import {
+  createRequest,
+  type AnyVariables,
+  type DocumentInput,
+  OperationContext,
+  CombinedError,
+  Operation,
+} from '@urql/core';
+import { useClient } from './context';
+import { pipe, onPush, filter, take, toPromise } from 'wonka';
+
+export type CreateMutationState<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+> = {
+  fetching: boolean;
+  stale: boolean;
+  data?: Data;
+  error?: CombinedError;
+  extensions?: Record<string, any>;
+  operation?: Operation<Data, Variables>;
+};
+
+export const createMutation = <
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+>(
+  query: DocumentInput<Data, Variables>
+) => {
+  const client = useClient();
+  const initialResult: CreateMutationState<Data, Variables> = {
+    operation: undefined,
+    fetching: false,
+    stale: false,
+    data: undefined,
+    error: undefined,
+    extensions: undefined,
+  };
+
+  const [state, setState] =
+    createStore<CreateMutationState<Data, Variables>>(initialResult);
+
+  const execute = (
+    variables: Variables,
+    context?: Partial<OperationContext>
+  ) => {
+    setState({ ...initialResult, fetching: true });
+
+    const request = createRequest(query, variables);
+    return pipe(
+      client.executeMutation(request, context ?? {}),
+      onPush(result => {
+        setState({
+          fetching: false,
+          stale: result.stale,
+          data: result.data,
+          error: result.error,
+          extensions: result.extensions,
+          operation: result.operation,
+        });
+      }),
+      filter(result => !result.hasNext),
+      take(1),
+      toPromise
+    );
+  };
+
+  return [state, execute] as const;
+};

--- a/packages/solid-urql/src/createMutation.ts
+++ b/packages/solid-urql/src/createMutation.ts
@@ -5,7 +5,7 @@ import {
   type OperationContext,
   type Operation,
   type OperationResult,
-  CombinedError,
+  type CombinedError,
   createRequest,
 } from '@urql/core';
 import { useClient } from './context';
@@ -13,7 +13,7 @@ import { pipe, onPush, filter, take, toPromise } from 'wonka';
 
 export type CreateMutationState<
   Data = any,
-  Variables extends AnyVariables = AnyVariables
+  Variables extends AnyVariables = AnyVariables,
 > = {
   /** Indicates whether `createMutation` is currently executing a mutation. */
   fetching: boolean;
@@ -69,7 +69,7 @@ export type CreateMutationState<
  */
 export type CreateMutationExecute<
   Data = any,
-  Variables extends AnyVariables = AnyVariables
+  Variables extends AnyVariables = AnyVariables,
 > = (
   variables: Variables,
   context?: Partial<OperationContext>
@@ -86,10 +86,10 @@ export type CreateMutationExecute<
  */
 export type CreateMutationResult<
   Data = any,
-  Variables extends AnyVariables = AnyVariables
+  Variables extends AnyVariables = AnyVariables,
 > = [
   CreateMutationState<Data, Variables>,
-  CreateMutationExecute<Data, Variables>
+  CreateMutationExecute<Data, Variables>,
 ];
 
 /** Hook to create a GraphQL mutation, run by passing variables to the returned execute function.
@@ -131,7 +131,7 @@ export type CreateMutationResult<
  */
 export const createMutation = <
   Data = any,
-  Variables extends AnyVariables = AnyVariables
+  Variables extends AnyVariables = AnyVariables,
 >(
   query: DocumentInput<Data, Variables>
 ): CreateMutationResult<Data, Variables> => {
@@ -156,7 +156,7 @@ export const createMutation = <
 
     const request = createRequest(query, variables);
     return pipe(
-      client.executeMutation(request, context ?? {}),
+      client.executeMutation(request, context),
       onPush(result => {
         setState({
           fetching: false,

--- a/packages/solid-urql/src/createMutation.ts
+++ b/packages/solid-urql/src/createMutation.ts
@@ -4,6 +4,7 @@ import {
   type DocumentInput,
   type OperationContext,
   type Operation,
+  type OperationResult,
   CombinedError,
   createRequest,
 } from '@urql/core';
@@ -14,20 +15,126 @@ export type CreateMutationState<
   Data = any,
   Variables extends AnyVariables = AnyVariables
 > = {
+  /** Indicates whether `createMutation` is currently executing a mutation. */
   fetching: boolean;
+
+  /** Indicates that the mutation result is not fresh.
+   *
+   * @remarks
+   * The `stale` flag is set to `true` when a new result for the mutation
+   * is expected.
+   * This is mostly unused for mutations and will rarely affect you, and
+   * is more relevant for queries.
+   *
+   * @see {@link OperationResult.stale} for the source of this value.
+   */
   stale: boolean;
+  /** The {@link OperationResult.data} for the executed mutation. */
   data?: Data;
+  /** The {@link OperationResult.error} for the executed mutation. */
   error?: CombinedError;
+  /** The {@link OperationResult.extensions} for the executed mutation. */
   extensions?: Record<string, any>;
+  /** The {@link Operation} that the current state is for.
+   *
+   * @remarks
+   * This is the mutation {@link Operation} that has last been executed.
+   * When {@link CreateMutationState.fetching} is `true`, this is the
+   * last `Operation` that the current state was for.
+   */
   operation?: Operation<Data, Variables>;
 };
 
+/** Triggers {@link createMutation} to execute its GraphQL mutation operation.
+ *
+ * @param variables - variables using which the mutation will be executed.
+ * @param context - optionally, context options that will be merged with the hook's
+ * context options and the `Client`’s options.
+ * @returns the {@link OperationResult} of the mutation.
+ *
+ * @remarks
+ * When called, {@link createMutation} will start the GraphQL mutation
+ * it currently holds and use the `variables` passed to it.
+ *
+ * Once the mutation response comes back from the API, its
+ * returned promise will resolve to the mutation’s {@link OperationResult}
+ * and the {@link CreateMutationState} will be updated with the result.
+ *
+ * @example
+ * ```ts
+ * const [result, executeMutation] = createMutation(UpdateTodo);
+ * const start = async ({ id, title }) => {
+ *   const result = await executeMutation({ id, title });
+ * };
+ */
+export type CreateMutationExecute<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+> = (
+  variables: Variables,
+  context?: Partial<OperationContext>
+) => Promise<OperationResult<Data, Variables>>;
+
+/** Result tuple returned by the {@link createMutation} hook.
+ *
+ * @remarks
+ * Similarly to a `createSignal` hook’s return value,
+ * the first element is the {@link createMutation}’s state, updated
+ * as mutations are executed with the second value, which is
+ * used to start mutations and is a {@link CreateMutationExecute}
+ * function.
+ */
+export type CreateMutationResult<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+> = [
+  CreateMutationState<Data, Variables>,
+  CreateMutationExecute<Data, Variables>
+];
+
+/** Hook to create a GraphQL mutation, run by passing variables to the returned execute function.
+ *
+ * @param query - a GraphQL mutation document which `createMutation` will execute.
+ * @returns a {@link CreateMutationResult} tuple of a {@link CreateMutationState} result,
+ * and an execute function to start the mutation.
+ *
+ * @remarks
+ * `createMutation` allows GraphQL mutations to be defined and keeps its state
+ * after the mutation is started with the returned execute function.
+ *
+ * Given a GraphQL mutation document it returns state to keep track of the
+ * mutation state and a {@link CreateMutationExecute} function, which accepts
+ * variables for the mutation to be executed.
+ * Once called, the mutation executes and the state will be updated with
+ * the mutation’s result.
+ *
+ * @example
+ * ```ts
+ * import { gql, createMutation } from '@urql/solid';
+ *
+ * const UpdateTodo = gql`
+ *   mutation ($id: ID!, $title: String!) {
+ *     updateTodo(id: $id, title: $title) {
+ *       id, title
+ *     }
+ *   }
+ * `;
+ *
+ * const UpdateTodo = () => {
+ *   const [result, executeMutation] = createMutation(UpdateTodo);
+ *   const start = async ({ id, title }) => {
+ *     const result = await executeMutation({ id, title });
+ *   };
+ *   // ...
+ * };
+ * ```
+ */
 export const createMutation = <
   Data = any,
   Variables extends AnyVariables = AnyVariables
 >(
   query: DocumentInput<Data, Variables>
-) => {
+): CreateMutationResult<Data, Variables> => {
   const client = useClient();
   const initialResult: CreateMutationState<Data, Variables> = {
     operation: undefined,
@@ -66,5 +173,5 @@ export const createMutation = <
     );
   };
 
-  return [state, execute] as const;
+  return [state, execute];
 };

--- a/packages/solid-urql/src/createMutation.ts
+++ b/packages/solid-urql/src/createMutation.ts
@@ -1,11 +1,11 @@
 import { createStore } from 'solid-js/store';
 import {
-  createRequest,
   type AnyVariables,
   type DocumentInput,
-  OperationContext,
+  type OperationContext,
+  type Operation,
   CombinedError,
-  Operation,
+  createRequest,
 } from '@urql/core';
 import { useClient } from './context';
 import { pipe, onPush, filter, take, toPromise } from 'wonka';

--- a/packages/solid-urql/src/createQuery.test.tsx
+++ b/packages/solid-urql/src/createQuery.test.tsx
@@ -37,7 +37,7 @@ const App = (props: AppProps) => {
   return (
     <Suspense fallback={<span data-testid="loading">loading</span>}>
       <Show when={resource.data}>
-        <span data-testid="value">{resource.data?.test}</span>
+        {data => <span data-testid="value">{data().test}</span>}
       </Show>
       <button
         data-testid="refetch"
@@ -116,22 +116,22 @@ describe('createQuery', () => {
       })
     );
 
-    expect(result[0].fetching).toStrictEqual(true);
+    expect(result[0].fetching).toEqual(true);
     subject.next({ data: { test: true } });
-    await waitFor(() => result[0].fetching === false);
+    expect(result[0].fetching).toEqual(false);
 
     setVariable(2);
 
-    expect(result[0].fetching).toStrictEqual(true);
+    expect(result[0].fetching).toEqual(true);
     subject.next({ data: { test: true } });
-    await waitFor(() => result[0].fetching === false);
+    expect(result[0].fetching).toEqual(false);
 
     expect(executeQuery).toHaveBeenCalledTimes(2);
 
     setPause(true);
     setVariable(3);
 
-    expect(result[0].fetching).toStrictEqual(false);
+    expect(result[0].fetching).toEqual(false);
     expect(executeQuery).toHaveBeenCalledTimes(2);
   });
 
@@ -155,18 +155,18 @@ describe('createQuery', () => {
       })
     );
 
-    await waitFor(() => expect(result[0].fetching).toStrictEqual(true));
+    expect(result[0].fetching).toEqual(true);
     subject.next({ data: { test: true } });
-    await waitFor(() => expect(result[0].fetching).toStrictEqual(false));
-    await waitFor(() => expect(result[0].data?.test).toStrictEqual(true));
+    expect(result[0].fetching).toEqual(false);
+    expect(result[0].data?.test).toEqual(true);
     setVariables({ variable: 2 });
 
-    await waitFor(() => expect(result[0].fetching).toStrictEqual(true));
+    expect(result[0].fetching).toEqual(true);
     expect(executeQuery).toHaveBeenCalledTimes(2);
 
     subject.next({ data: { test: false } });
-    await waitFor(() => expect(result[0].fetching).toStrictEqual(false));
-    await waitFor(() => expect(result[0].data?.test).toStrictEqual(false));
+    expect(result[0].fetching).toEqual(false);
+    expect(result[0].data?.test).toEqual(false);
   });
 
   it('should receive data', async () => {
@@ -184,12 +184,12 @@ describe('createQuery', () => {
       })
     );
 
-    await waitFor(() => expect(result[0].fetching).toStrictEqual(true));
+    expect(result[0].fetching).toEqual(true);
     expect(result[0].data).toBeUndefined();
 
     subject.next({ data: { test: true } });
 
-    await waitFor(() => expect(result[0].fetching).toStrictEqual(false));
+    expect(result[0].fetching).toEqual(false);
     expect(result[0].data).toStrictEqual({ test: true });
     expect(executeQuery).toHaveBeenCalledTimes(1);
   });

--- a/packages/solid-urql/src/createQuery.test.tsx
+++ b/packages/solid-urql/src/createQuery.test.tsx
@@ -94,7 +94,7 @@ describe('createQuery', () => {
     expect(await findByTestId('value')).not.toBeFalsy();
   });
 
-  it.only('should persist pause after refetch when variable changes', async () => {
+  it('should persist pause after refetch when variable changes', async () => {
     const subject =
       makeSubject<Pick<OperationResult<{ test: boolean }, any>, 'data'>>();
     const executeQuery = vi

--- a/packages/solid-urql/src/createQuery.test.tsx
+++ b/packages/solid-urql/src/createQuery.test.tsx
@@ -1,0 +1,196 @@
+import { expect, it, describe, vi } from 'vitest';
+import { createQuery } from './createQuery';
+import { render, renderHook, waitFor } from '@solidjs/testing-library';
+import { createClient } from '@urql/core';
+import { Show, Suspense, createSignal } from 'solid-js';
+import { makeSubject } from 'wonka';
+import { OperationResult, OperationResultSource } from '@urql/core';
+import '@testing-library/jest-dom';
+
+const client = createClient({
+  url: '/graphql',
+  exchanges: [],
+  suspense: false,
+});
+vi.mock('./context', () => {
+  const useClient = () => {
+    return client!;
+  };
+
+  return { useClient };
+});
+
+type AppProps = {
+  suspense?: boolean;
+};
+const App = (props: AppProps) => {
+  const [resource, refetch] = createQuery<
+    { test: boolean },
+    { variable: number }
+  >({
+    query: '{ test }',
+    context: {
+      suspense: props.suspense,
+    },
+  });
+
+  return (
+    <Suspense fallback={<span data-testid="loading">loading</span>}>
+      <Show when={resource.data}>
+        <span data-testid="value">{resource.data?.test}</span>
+      </Show>
+      <button
+        data-testid="refetch"
+        onClick={() => refetch({ variables: { variable: 1 } })}
+      >
+        refetch
+      </button>
+    </Suspense>
+  );
+};
+
+describe('createQuery', () => {
+  it('should not suspend', async () => {
+    const subject =
+      makeSubject<Pick<OperationResult<{ test: boolean }, any>, 'data'>>();
+    vi.spyOn(client, 'executeQuery').mockImplementation(
+      () => subject.source as OperationResultSource<OperationResult>
+    );
+
+    const { findByTestId } = render(() => <App suspense={false} />);
+
+    subject.next({ data: { test: true } });
+    waitFor(async () =>
+      expect((await findByTestId('value')).innerText).toStrictEqual('true')
+    );
+
+    const refetch = await findByTestId('refetch');
+    refetch.click();
+
+    subject.next({ data: { test: true } });
+    waitFor(async () =>
+      expect((await findByTestId('value')).innerText).toStrictEqual('true')
+    );
+  });
+
+  it('should suspend', async () => {
+    const subject =
+      makeSubject<Pick<OperationResult<{ test: boolean }, any>, 'data'>>();
+    vi.spyOn(client, 'executeQuery').mockImplementation(
+      () => subject.source as OperationResultSource<OperationResult>
+    );
+
+    const { findByTestId } = render(() => <App suspense={true} />);
+
+    expect(await findByTestId('loading')).not.toBeFalsy();
+    subject.next({ data: { test: true } });
+    expect(await findByTestId('value')).not.toBeFalsy();
+
+    const refetch = await findByTestId('refetch');
+    refetch.click();
+
+    expect(await findByTestId('loading')).not.toBeFalsy();
+    subject.next({ data: { test: true } });
+    expect(await findByTestId('value')).not.toBeFalsy();
+  });
+
+  it('should not refetch when paused on variable change', async () => {
+    const subject =
+      makeSubject<Pick<OperationResult<{ test: boolean }, any>, 'data'>>();
+    const executeQuery = vi
+      .spyOn(client, 'executeQuery')
+      .mockImplementation(
+        () => subject.source as OperationResultSource<OperationResult>
+      );
+
+    const [variable, setVariable] = createSignal(1);
+    const [pause, setPause] = createSignal(false);
+
+    const { result } = renderHook(() =>
+      createQuery<{ variable: number }>({
+        query: '{ test }',
+        pause: pause,
+        variables: () => ({
+          variable: variable(),
+        }),
+      })
+    );
+
+    expect(result[0].fetching).toStrictEqual(true);
+    subject.next({ data: { test: true } });
+    await waitFor(() => result[0].fetching === false);
+
+    setVariable(2);
+
+    expect(result[0].fetching).toStrictEqual(true);
+    subject.next({ data: { test: true } });
+    await waitFor(() => result[0].fetching === false);
+
+    expect(executeQuery).toHaveBeenCalledTimes(2);
+
+    setPause(true);
+    setVariable(3);
+
+    expect(result[0].fetching).toStrictEqual(false);
+    expect(executeQuery).toHaveBeenCalledTimes(2);
+  });
+
+  it('should trigger refetch on variables change', async () => {
+    const subject =
+      makeSubject<Pick<OperationResult<{ test: boolean }, any>, 'data'>>();
+    const executeQuery = vi
+      .spyOn(client, 'executeQuery')
+      .mockImplementation(
+        () => subject.source as OperationResultSource<OperationResult>
+      );
+
+    const [variables, setVariables] = createSignal<{ variable: number }>({
+      variable: 1,
+    });
+
+    const { result } = renderHook(() =>
+      createQuery<{ test: boolean }, { variable: number }>({
+        query: '{ test }',
+        variables: variables,
+      })
+    );
+
+    await waitFor(() => expect(result[0].fetching).toStrictEqual(true));
+    subject.next({ data: { test: true } });
+    await waitFor(() => expect(result[0].fetching).toStrictEqual(false));
+    await waitFor(() => expect(result[0].data?.test).toStrictEqual(true));
+    setVariables({ variable: 2 });
+
+    await waitFor(() => expect(result[0].fetching).toStrictEqual(true));
+    expect(executeQuery).toHaveBeenCalledTimes(2);
+
+    subject.next({ data: { test: false } });
+    await waitFor(() => expect(result[0].fetching).toStrictEqual(false));
+    await waitFor(() => expect(result[0].data?.test).toStrictEqual(false));
+  });
+
+  it('should receive data', async () => {
+    const subject =
+      makeSubject<Pick<OperationResult<{ test: boolean }, any>, 'data'>>();
+    const executeQuery = vi
+      .spyOn(client, 'executeQuery')
+      .mockImplementation(
+        () => subject.source as OperationResultSource<OperationResult>
+      );
+
+    const { result } = renderHook(() =>
+      createQuery<{ variable: number }, { test: boolean }>({
+        query: '{ test }',
+      })
+    );
+
+    await waitFor(() => expect(result[0].fetching).toStrictEqual(true));
+    expect(result[0].data).toBeUndefined();
+
+    subject.next({ data: { test: true } });
+
+    await waitFor(() => expect(result[0].fetching).toStrictEqual(false));
+    expect(result[0].data).toStrictEqual({ test: true });
+    expect(executeQuery).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/solid-urql/src/createQuery.ts
+++ b/packages/solid-urql/src/createQuery.ts
@@ -1,0 +1,230 @@
+import {
+  type AnyVariables,
+  type OperationContext,
+  createRequest,
+  type DocumentInput,
+  type OperationResult,
+  type RequestPolicy,
+} from '@urql/core';
+import {
+  batch,
+  createComputed,
+  createMemo,
+  createResource,
+  onCleanup,
+} from 'solid-js';
+import { createStore, unwrap } from 'solid-js/store';
+import { useClient } from './context';
+import { asAccessor } from '@solid-primitives/utils';
+import {
+  concat,
+  fromValue,
+  makeSubject,
+  map,
+  never,
+  pipe,
+  scan,
+  subscribe,
+  switchMap,
+} from 'wonka';
+import { type MaybeAccessor } from '@solid-primitives/utils';
+
+export type QueryExecuteArgs<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+> = {
+  query: DocumentInput<Data, Variables>;
+  requestPolicy?: RequestPolicy;
+  context?: Partial<OperationContext>;
+  pause?: boolean;
+  variables?: Variables;
+};
+
+/** State of the current query, your {@link createQuery} hook is executing.
+ *
+ * @remarks
+ * `UseQueryState` is returned (in a tuple) by {@link createQuery} and
+ * gives you the updating {@link OperationResult} of GraphQL queries.
+ *
+ * Even when the query and variables passed to {@link createQuery} change,
+ * this state preserves the prior state and sets the `fetching` flag to
+ * `true`.
+ * This allows you to display the previous state, while implementing
+ * a separate loading indicator separately.
+ */
+export type CreateQueryState<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+> = OperationResult<Data, Variables> & {
+  /** Indicates whether `createQuery` is waiting for a new result.
+   *
+   * @remarks
+   * When `createQuery` is passed a new query and/or variables, it will
+   * start executing the new query operation and `fetching` is set to
+   * `true` until a result arrives.
+   *
+   * Hint: This is subtly different than whether the query is actually
+   * fetching, and doesn’t indicate whether a query is being re-executed
+   * in the background. For this, see {@link CreateQueryState.stale}.
+   */
+  fetching: boolean;
+};
+
+export type CreateQueryArgs<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+> = {
+  query: DocumentInput<Data, Variables>;
+  requestPolicy?: MaybeAccessor<RequestPolicy>;
+  context?: MaybeAccessor<Partial<OperationContext>>;
+  pause?: MaybeAccessor<boolean>;
+  variables?: MaybeAccessor<Variables>;
+};
+
+export const createQuery = <
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+>(
+  args: CreateQueryArgs<Data, Variables>
+) => {
+  const client = useClient();
+  const optionsSubject = makeSubject<QueryExecuteArgs<Data, Variables>>();
+  const getContext = asAccessor(args.context),
+    getPause = asAccessor(args.pause),
+    getRequestPolicy = asAccessor(args.requestPolicy),
+    getVariables = asAccessor(args.variables);
+
+  const isSuspense = createMemo(() => {
+    const ctx = getContext();
+    if (ctx !== undefined && ctx.suspense !== undefined) {
+      return ctx.suspense;
+    }
+
+    return client.suspense;
+  });
+
+  const request = createRequest(args.query, getVariables() as any);
+  const context: Partial<OperationContext> = {
+    requestPolicy: getRequestPolicy(),
+    ...getContext(),
+  };
+  const operation = client.createRequestOperation('query', request, context);
+  const initialResult: CreateQueryState<Data, Variables> = {
+    operation: operation,
+    fetching: false,
+    data: undefined,
+    error: undefined,
+    extensions: undefined,
+    hasNext: false,
+    stale: false,
+  };
+
+  const [result, setResult] =
+    createStore<CreateQueryState<Data, Variables>>(initialResult);
+
+  const [dataResource, { refetch, mutate }] = createResource<
+    CreateQueryState<Data, Variables>
+  >(() => {
+    return new Promise(resolve => {
+      const got = unwrap(result);
+      if (got.fetching) {
+        return;
+      }
+
+      resolve(got);
+    });
+  });
+
+  const sub = pipe(
+    optionsSubject.source,
+    switchMap(options$ => {
+      if (options$.pause) return never;
+
+      const request = createRequest<Data, AnyVariables>(
+        options$.query,
+        options$.variables
+      );
+
+      return concat<Partial<CreateQueryState<Data, Variables>>>([
+        fromValue({ fetching: true, stale: false }),
+        pipe(
+          client.executeQuery(request, {
+            requestPolicy: options$.requestPolicy,
+            ...options$.context,
+          }),
+          map(({ stale, data, error, extensions, operation }) => ({
+            fetching: false,
+            stale: !!stale,
+            data,
+            error,
+            operation,
+            extensions,
+          }))
+        ),
+        fromValue({ fetching: false }),
+      ]);
+    }),
+    scan(
+      (result: CreateQueryState<Data, Variables>, partial) => ({
+        ...result,
+        ...partial,
+      }),
+      initialResult
+    ),
+    subscribe(result => {
+      batch(() => {
+        setResult(result);
+        mutate(result);
+        refetch();
+      });
+    })
+  );
+
+  createComputed(() => {
+    const pause = getPause();
+    if (pause === true) {
+      return;
+    }
+
+    optionsSubject.next({
+      query: args.query,
+      context: getContext(),
+      pause: pause,
+      requestPolicy: getRequestPolicy(),
+      variables: getVariables(),
+    });
+  });
+
+  onCleanup(() => sub.unsubscribe());
+
+  batch(() => {
+    mutate(() => unwrap(result));
+    refetch();
+  });
+
+  const refetchFn = (refetchArgs: Partial<OperationContext>) => {
+    optionsSubject.next({
+      query: args.query,
+      requestPolicy: refetchArgs.requestPolicy ?? getRequestPolicy(),
+      context: refetchArgs ?? getContext(),
+      pause: false,
+      variables: getVariables(),
+    });
+  };
+
+  const handler = {
+    get(
+      target: CreateQueryState<Data, Variables>,
+      prop: keyof CreateQueryState<Data, Variables>
+    ): any {
+      if (isSuspense() && prop === 'data') {
+        return dataResource()?.data;
+      }
+
+      return Reflect.get(target, prop);
+    },
+  };
+
+  const proxy = new Proxy(result, handler);
+  return [proxy, refetchFn] as const;
+};

--- a/packages/solid-urql/src/createQuery.ts
+++ b/packages/solid-urql/src/createQuery.ts
@@ -1,11 +1,11 @@
 import {
   type AnyVariables,
   type OperationContext,
-  createRequest,
   type DocumentInput,
   type OperationResult,
   type RequestPolicy,
-  OperationResultSource,
+  type OperationResultSource,
+  createRequest,
 } from '@urql/core';
 import {
   batch,
@@ -16,7 +16,7 @@ import {
 } from 'solid-js';
 import { createStore, unwrap } from 'solid-js/store';
 import { useClient } from './context';
-import { asAccessor } from '@solid-primitives/utils';
+import { type MaybeAccessor, asAccessor } from '@solid-primitives/utils';
 import {
   concat,
   fromValue,
@@ -27,7 +27,6 @@ import {
   subscribe,
   switchMap,
 } from 'wonka';
-import { type MaybeAccessor } from '@solid-primitives/utils';
 
 export type QueryExecuteArgs<
   Data = any,

--- a/packages/solid-urql/src/createQuery.ts
+++ b/packages/solid-urql/src/createQuery.ts
@@ -28,6 +28,27 @@ import {
   switchMap,
 } from 'wonka';
 
+/** Triggers {@link createQuery} to execute a new GraphQL query operation.
+ *
+ * @remarks
+ * When called, {@link createQuery} will re-execute the GraphQL query operation
+ * it currently holds, even if {@link CreateQueryArgs.pause} is set to `true`.
+ *
+ * This is useful for executing a paused query or re-executing a query
+ * and get a new network result, by passing a new request policy.
+ *
+ * ```ts
+ * const [result, reExecuteQuery] = createQuery({ query });
+ *
+ * const refresh = () => {
+ *   // Re-execute the query with a network-only policy, skipping the cache
+ *   reExecuteQuery({ requestPolicy: 'network-only' });
+ * };
+ * ```
+ *
+ */
+export type CreateQueryExecute = (opts?: Partial<OperationContext>) => void;
+
 /** State of the current query, your {@link createQuery} hook is executing.
  *
  * @remarks
@@ -58,23 +79,108 @@ export type CreateQueryState<
   fetching: boolean;
 };
 
+/**
+ * Input arguments for the {@link createQuery} hook.
+ */
 export type CreateQueryArgs<
   Data = any,
   Variables extends AnyVariables = AnyVariables
 > = {
+  /** The GraphQL query that `createQuery` executes. */
   query: DocumentInput<Data, Variables>;
-  requestPolicy?: MaybeAccessor<RequestPolicy>;
-  context?: MaybeAccessor<Partial<OperationContext>>;
-  pause?: MaybeAccessor<boolean>;
+
+  /** The variables for the GraphQL {@link CreateQueryArgs.query} that `createQuery` executes. */
   variables?: MaybeAccessor<Variables>;
+
+  /** Updates the {@link RequestPolicy} for the executed GraphQL query operation.
+   *
+   * @remarks
+   * `requestPolicy` modifies the {@link RequestPolicy} of the GraphQL query operation
+   * that `useQuery` executes, and indicates a caching strategy for cache exchanges.
+   *
+   * For example, when set to `'cache-and-network'`, {@link createQuery} will
+   * receive a cached result with `stale: true` and an API request will be
+   * sent in the background.
+   *
+   * @see {@link OperationContext.requestPolicy} for where this value is set.
+   */
+  requestPolicy?: MaybeAccessor<RequestPolicy>;
+
+  /** Updates the {@link OperationContext} for the executed GraphQL query operation.
+   *
+   * @remarks
+   * `context` may be passed to {@link createQuery}, to update the {@link OperationContext}
+   * of a query operation. This may be used to update the `context` that exchanges
+   * will receive for a single hook.
+   *
+   * In order to re-execute query on context change pass {@link Accessor} instead
+   * of raw value.
+   */
+  context?: MaybeAccessor<Partial<OperationContext>>;
+
+  /** Prevents {@link useQuery} from automatically executing GraphQL query operations.
+   *
+   * @remarks
+   * `pause` may be set to `true` to stop {@link createQuery} from executing
+   * automatically. The hook will stop receiving updates from the {@link Client}
+   * and won’t execute the query operation, until either it’s set to `false`
+   * or the {@link CreateQueryExecute} function is called.
+   */
+  pause?: MaybeAccessor<boolean>;
 };
 
+/** Result tuple returned by the {@link createQuery} hook.
+ *
+ * @remarks
+ * the first element is the {@link createQuery}’s result and state,
+ * a {@link CreateQueryState} object,
+ * and the second is used to imperatively re-execute the query
+ * via a {@link CreateQueryExecute} function.
+ */
+export type CreateQueryResult<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+> = [CreateQueryState<Data, Variables>, CreateQueryExecute];
+
+/** Hook to run a GraphQL query and get updated GraphQL results.
+ *
+ * @param args - a {@link CreateQueryArgs} object, to pass a `query`, `variables`, and options.
+ * @returns a {@link CreateQueryResult} tuple of a {@link CreateQueryState} result, and re-execute function.
+ *
+ * @remarks
+ * `createQuery` allows GraphQL queries to be defined and executed.
+ * Given {@link CreateQueryArgs.query}, it executes the GraphQL query with the
+ * context’s {@link Client}.
+ *
+ * The returned result updates when the `Client` has new results
+ * for the query, and changes when your input `args` change.
+ *
+ * Additionally, if the `suspense` option is enabled on the `Client`,
+ * the `createQuery` hook will suspend instead of indicating that it’s
+ * waiting for a result via {@link UseQueryState.fetching}.
+ *
+ * @example
+ * ```tsx
+ * import { gql, createQuery } from '@urql/solid';
+ *
+ * const TodosQuery = gql`
+ *   query { todos { id, title } }
+ * `;
+ *
+ * const Todos = () => {
+ *   const [result, reExecuteQuery] = createQuery({
+ *     query: TodosQuery,
+ *   });
+ *   // ...
+ * };
+ * ```
+ */
 export const createQuery = <
   Data = any,
   Variables extends AnyVariables = AnyVariables
 >(
   args: CreateQueryArgs<Data, Variables>
-) => {
+): CreateQueryResult => {
   const client = useClient();
   const getContext = asAccessor(args.context),
     getPause = asAccessor(args.pause),
@@ -85,6 +191,7 @@ export const createQuery = <
     OperationResultSource<OperationResult<Data, Variables>> | undefined
   >();
 
+  // Combine suspense param coming from context and client with context being priority
   const isSuspense = createMemo(() => {
     const ctx = getContext();
     if (ctx !== undefined && ctx.suspense !== undefined) {
@@ -113,6 +220,12 @@ export const createQuery = <
   const [result, setResult] =
     createStore<CreateQueryState<Data, Variables>>(initialResult);
 
+  // `createResource` is only way to trigger suspense, suspense handling works as follows:
+  // 1. Calling `dataResource` mounts resource to closes suspense. Thus depending on where it is called
+  // it could mount in same component or parent. For usage convince we call it by proxy when using `data`
+  // 2. After any changes we call `refetch` which results in creation of new promise and depending on `fetching`
+  // value we either discard promise without resolving or resolve it. Discard doesn't result in anything while
+  // resolve finishes suspense
   const [dataResource, { refetch, mutate }] = createResource<
     CreateQueryState<Data, Variables>
   >(() => {
@@ -129,11 +242,13 @@ export const createQuery = <
   const sub = pipe(
     resultSourceSubject.source,
     switchMap(subscription$ => {
+      // On pause source is set to undefined
       if (subscription$ === undefined) {
         return fromValue({ fetching: false });
       }
 
       return concat([
+        // Fetch start state
         fromValue({ fetching: true, stale: false }),
         pipe(
           subscription$,
@@ -146,9 +261,11 @@ export const createQuery = <
             extensions,
           }))
         ),
-        fromValue({ fetching: false }),
+        // Fetch finish state
+        fromValue({ fetching: false, stale: false }),
       ]);
     }),
+    // Merging partial results into previous
     scan(
       (result: CreateQueryState<Data, Variables>, partial: any) => ({
         ...result,
@@ -188,7 +305,7 @@ export const createQuery = <
     refetch();
   });
 
-  const executeQuery = (opts?: Partial<OperationContext>) => {
+  const executeQuery: CreateQueryExecute = opts => {
     const request = createRequest(args.query, getVariables() as any);
     const context: Partial<OperationContext> = {
       requestPolicy: opts?.requestPolicy ?? getRequestPolicy(),
@@ -213,5 +330,5 @@ export const createQuery = <
   };
 
   const proxy = new Proxy(result, handler);
-  return [proxy, executeQuery] as const;
+  return [proxy, executeQuery];
 };

--- a/packages/solid-urql/src/createQuery.ts
+++ b/packages/solid-urql/src/createQuery.ts
@@ -28,17 +28,6 @@ import {
   switchMap,
 } from 'wonka';
 
-export type QueryExecuteArgs<
-  Data = any,
-  Variables extends AnyVariables = AnyVariables
-> = {
-  query: DocumentInput<Data, Variables>;
-  requestPolicy?: RequestPolicy;
-  context?: Partial<OperationContext>;
-  pause?: boolean;
-  variables?: Variables;
-};
-
 /** State of the current query, your {@link createQuery} hook is executing.
  *
  * @remarks

--- a/packages/solid-urql/src/createQuery.ts
+++ b/packages/solid-urql/src/createQuery.ts
@@ -171,7 +171,7 @@ export const createQuery = <
   Variables extends AnyVariables = AnyVariables,
 >(
   args: CreateQueryArgs<Data, Variables>
-): CreateQueryResult => {
+): CreateQueryResult<Data, Variables> => {
   const client = useClient();
   const getContext = asAccessor(args.context);
   const getPause = asAccessor(args.pause);

--- a/packages/solid-urql/src/createQuery.ts
+++ b/packages/solid-urql/src/createQuery.ts
@@ -200,12 +200,12 @@ export const createQuery = <
     refetch();
   });
 
-  const refetchFn = (refetchArgs: Partial<OperationContext>) => {
+  const executeQuery = (opts?: Partial<OperationContext>) => {
     const request = createRequest(args.query, getVariables() as any);
     const context: Partial<OperationContext> = {
-      requestPolicy: refetchArgs.requestPolicy ?? getRequestPolicy(),
+      requestPolicy: opts?.requestPolicy ?? getRequestPolicy(),
       ...getContext(),
-      ...refetchArgs,
+      ...opts,
     };
 
     resultSourceSubject.next(client.executeQuery(request, context));
@@ -225,5 +225,5 @@ export const createQuery = <
   };
 
   const proxy = new Proxy(result, handler);
-  return [proxy, refetchFn] as const;
+  return [proxy, executeQuery] as const;
 };

--- a/packages/solid-urql/src/createQuery.ts
+++ b/packages/solid-urql/src/createQuery.ts
@@ -15,7 +15,7 @@ import {
 } from 'solid-js';
 import { createStore, produce } from 'solid-js/store';
 import { useClient } from './context';
-import { type MaybeAccessor, asAccessor } from '@solid-primitives/utils';
+import { type MaybeAccessor, asAccessor } from './utils';
 import type { Source, Subscription } from 'wonka';
 import { onEnd, pipe, subscribe } from 'wonka';
 

--- a/packages/solid-urql/src/createQuery.ts
+++ b/packages/solid-urql/src/createQuery.ts
@@ -52,7 +52,7 @@ export type CreateQueryExecute = (opts?: Partial<OperationContext>) => void;
 /** State of the current query, your {@link createQuery} hook is executing.
  *
  * @remarks
- * `UseQueryState` is returned (in a tuple) by {@link createQuery} and
+ * `CreateQueryState` is returned (in a tuple) by {@link createQuery} and
  * gives you the updating {@link OperationResult} of GraphQL queries.
  *
  * Even when the query and variables passed to {@link createQuery} change,
@@ -96,7 +96,7 @@ export type CreateQueryArgs<
    *
    * @remarks
    * `requestPolicy` modifies the {@link RequestPolicy} of the GraphQL query operation
-   * that `useQuery` executes, and indicates a caching strategy for cache exchanges.
+   * that `createQuery` executes, and indicates a caching strategy for cache exchanges.
    *
    * For example, when set to `'cache-and-network'`, {@link createQuery} will
    * receive a cached result with `stale: true` and an API request will be
@@ -118,7 +118,7 @@ export type CreateQueryArgs<
    */
   context?: MaybeAccessor<Partial<OperationContext>>;
 
-  /** Prevents {@link useQuery} from automatically executing GraphQL query operations.
+  /** Prevents {@link createQuery} from automatically executing GraphQL query operations.
    *
    * @remarks
    * `pause` may be set to `true` to stop {@link createQuery} from executing
@@ -157,7 +157,7 @@ export type CreateQueryResult<
  *
  * Additionally, if the `suspense` option is enabled on the `Client`,
  * the `createQuery` hook will suspend instead of indicating that it’s
- * waiting for a result via {@link UseQueryState.fetching}.
+ * waiting for a result via {@link CreateQueryState.fetching}.
  *
  * @example
  * ```tsx

--- a/packages/solid-urql/src/createSubscription.test.ts
+++ b/packages/solid-urql/src/createSubscription.test.ts
@@ -145,4 +145,32 @@ describe('createSubscription', () => {
     expect(executeQuery).toHaveBeenCalledOnce();
     expect(result[0].data).toStrictEqual({ value: 1 });
   });
+
+  it('should override pause when execute executeSubscription', async () => {
+    const subject =
+      makeSubject<Pick<OperationResult<{ value: number }, any>, 'data'>>();
+    const executeQuery = vi
+      .spyOn(client, 'executeSubscription')
+      .mockImplementation(
+        () => subject.source as OperationResultSource<OperationResult>
+      );
+
+    const { result } = renderHook(() =>
+      createSubscription<{ value: number }, { variable: number }>({
+        query: QUERY,
+        pause: true,
+      })
+    );
+
+    expect(result[0].fetching).toEqual(false);
+    expect(executeQuery).not.toBeCalled();
+
+    result[1]();
+
+    expect(result[0].fetching).toEqual(true);
+    expect(executeQuery).toHaveBeenCalledOnce();
+    subject.next({ data: { value: 1 } });
+
+    expect(result[0].data).toStrictEqual({ value: 1 });
+  });
 });

--- a/packages/solid-urql/src/createSubscription.test.ts
+++ b/packages/solid-urql/src/createSubscription.test.ts
@@ -158,7 +158,7 @@ describe('createSubscription', () => {
     });
   });
 
-  it('should unsubscribe on teardown', async () => {
+  it('should unsubscribe on teardown', () => {
     const subject =
       makeSubject<Pick<OperationResult<{ value: number }, any>, 'data'>>();
     vi.spyOn(client, 'executeSubscription').mockImplementation(
@@ -191,7 +191,7 @@ describe('createSubscription', () => {
     );
   });
 
-  it('should skip executing query when paused', async () => {
+  it('should skip executing query when paused', () => {
     const subject =
       makeSubject<Pick<OperationResult<{ value: number }, any>, 'data'>>();
     vi.spyOn(client, 'executeSubscription').mockImplementation(
@@ -282,7 +282,7 @@ describe('createSubscription', () => {
     });
   });
 
-  it.only('should aggregate results', () => {
+  it('should aggregate results', () => {
     const subject =
       makeSubject<Pick<OperationResult<{ value: number }, any>, 'data'>>();
     vi.spyOn(client, 'executeSubscription').mockImplementation(

--- a/packages/solid-urql/src/createSubscription.test.ts
+++ b/packages/solid-urql/src/createSubscription.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@solidjs/testing-library';
+import { renderHook, waitFor } from '@solidjs/testing-library';
 import {
   OperationResult,
   OperationResultSource,
@@ -9,6 +9,7 @@ import {
 import { expect, it, describe, vi } from 'vitest';
 import { makeSubject } from 'wonka';
 import { createSubscription } from './createSubscription';
+import { createSignal } from 'solid-js';
 
 const QUERY = gql`
   subscription {
@@ -30,7 +31,7 @@ vi.mock('./context', () => {
 });
 
 describe('createSubscription', () => {
-  it.only('should receive data', async () => {
+  it('should receive data', async () => {
     const subject =
       makeSubject<Pick<OperationResult<{ value: number }, any>, 'data'>>();
     const executeQuery = vi
@@ -77,5 +78,71 @@ describe('createSubscription', () => {
     subject.complete();
     expect(result[0].fetching).toBe(false);
     expect(result[0].data).toEqual({ value: 1 });
+  });
+
+  it('should call handler', async () => {
+    const handler = vi.fn();
+    const subject =
+      makeSubject<Pick<OperationResult<{ value: number }, any>, 'data'>>();
+    vi.spyOn(client, 'executeSubscription').mockImplementation(
+      () => subject.source as OperationResultSource<OperationResult>
+    );
+
+    renderHook(() =>
+      createSubscription<{ value: number }, { variable: number }>(
+        {
+          query: QUERY,
+        },
+        handler
+      )
+    );
+
+    waitFor(() => expect(handler).toHaveBeenCalledOnce());
+    subject.next({ data: { value: 0 } });
+    waitFor(() => expect(handler).toHaveBeenCalledTimes(2));
+  });
+
+  it('should unsubscribe on teardown', async () => {
+    const subject =
+      makeSubject<Pick<OperationResult<{ value: number }, any>, 'data'>>();
+    vi.spyOn(client, 'executeSubscription').mockImplementation(
+      () => subject.source as OperationResultSource<OperationResult>
+    );
+
+    const { result, cleanup } = renderHook(() =>
+      createSubscription<{ value: number }, { variable: number }>({
+        query: QUERY,
+      })
+    );
+
+    expect(result[0].fetching).toEqual(true);
+    cleanup();
+    waitFor(() => expect(result[0].fetching).toEqual(false));
+  });
+
+  it('should skip executing query when paused', async () => {
+    const subject =
+      makeSubject<Pick<OperationResult<{ value: number }, any>, 'data'>>();
+    const executeQuery = vi
+      .spyOn(client, 'executeSubscription')
+      .mockImplementation(
+        () => subject.source as OperationResultSource<OperationResult>
+      );
+
+    const [pause, setPause] = createSignal<boolean>(true);
+    const { result } = renderHook(() =>
+      createSubscription<{ value: number }, { variable: number }>({
+        query: QUERY,
+        pause: pause,
+      })
+    );
+
+    expect(executeQuery).not.toBeCalled();
+    subject.next({ data: { value: 0 } });
+    expect(result[0].data).toBeUndefined();
+    setPause(false);
+    subject.next({ data: { value: 1 } });
+    expect(executeQuery).toHaveBeenCalledOnce();
+    expect(result[0].data).toStrictEqual({ value: 1 });
   });
 });

--- a/packages/solid-urql/src/createSubscription.test.ts
+++ b/packages/solid-urql/src/createSubscription.test.ts
@@ -1,0 +1,81 @@
+import { renderHook } from '@solidjs/testing-library';
+import {
+  OperationResult,
+  OperationResultSource,
+  createClient,
+  createRequest,
+  gql,
+} from '@urql/core';
+import { expect, it, describe, vi } from 'vitest';
+import { makeSubject } from 'wonka';
+import { createSubscription } from './createSubscription';
+
+const QUERY = gql`
+  subscription {
+    value
+  }
+`;
+
+const client = createClient({
+  url: '/graphql',
+  exchanges: [],
+  suspense: false,
+});
+vi.mock('./context', () => {
+  const useClient = () => {
+    return client!;
+  };
+
+  return { useClient };
+});
+
+describe('createSubscription', () => {
+  it.only('should receive data', async () => {
+    const subject =
+      makeSubject<Pick<OperationResult<{ value: number }, any>, 'data'>>();
+    const executeQuery = vi
+      .spyOn(client, 'executeSubscription')
+      .mockImplementation(
+        () => subject.source as OperationResultSource<OperationResult>
+      );
+
+    const request = createRequest(QUERY, undefined);
+    const operation = client.createRequestOperation('subscription', request);
+
+    const { result } = renderHook(() =>
+      createSubscription<{ value: number }, { variable: number }>({
+        query: QUERY,
+      })
+    );
+
+    expect(result[0]).toMatchObject({
+      data: undefined,
+      stale: false,
+      fetching: true,
+      operation: operation,
+      error: undefined,
+      extensions: undefined,
+    });
+    expect(result[1]).toEqual(expect.any(Function));
+
+    expect(executeQuery).toHaveBeenCalledOnce();
+    expect(client.executeSubscription).toBeCalledWith(
+      {
+        key: expect.any(Number),
+        query: expect.any(Object),
+        variables: {},
+      },
+      undefined
+    );
+
+    subject.next({ data: { value: 0 } });
+    expect(result[0].data).toEqual({ value: 0 });
+
+    subject.next({ data: { value: 1 } });
+    expect(result[0].data).toEqual({ value: 1 });
+
+    subject.complete();
+    expect(result[0].fetching).toBe(false);
+    expect(result[0].data).toEqual({ value: 1 });
+  });
+});

--- a/packages/solid-urql/src/createSubscription.test.ts
+++ b/packages/solid-urql/src/createSubscription.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from '@solidjs/testing-library';
+import { renderHook, testEffect } from '@solidjs/testing-library';
 import {
   OperationResult,
   OperationResultSource,
@@ -8,8 +8,11 @@ import {
 } from '@urql/core';
 import { expect, it, describe, vi } from 'vitest';
 import { makeSubject } from 'wonka';
-import { createSubscription } from './createSubscription';
-import { createSignal } from 'solid-js';
+import {
+  CreateSubscriptionState,
+  createSubscription,
+} from './createSubscription';
+import { createEffect, createSignal } from 'solid-js';
 
 const QUERY = gql`
   subscription {
@@ -22,6 +25,7 @@ const client = createClient({
   exchanges: [],
   suspense: false,
 });
+
 vi.mock('./context', () => {
   const useClient = () => {
     return client!;
@@ -30,57 +34,89 @@ vi.mock('./context', () => {
   return { useClient };
 });
 
+// Given that it is not possible to directly listen to all store changes it is necessary
+// to access all relevant parts on which `createEffect` should listen on
+const markStateDependencies = (state: CreateSubscriptionState<any, any>) => {
+  state.data;
+  state.error;
+  state.extensions;
+  state.fetching;
+  state.operation;
+  state.stale;
+};
+
 describe('createSubscription', () => {
-  it('should receive data', async () => {
-    const subject =
-      makeSubject<Pick<OperationResult<{ value: number }, any>, 'data'>>();
-    const executeQuery = vi
-      .spyOn(client, 'executeSubscription')
-      .mockImplementation(
-        () => subject.source as OperationResultSource<OperationResult>
-      );
+  it('should receive data', () => {
+    return testEffect(done => {
+      const subject =
+        makeSubject<Pick<OperationResult<{ value: number }, any>, 'data'>>();
+      const executeQuery = vi
+        .spyOn(client, 'executeSubscription')
+        .mockImplementation(
+          () => subject.source as OperationResultSource<OperationResult>
+        );
 
-    const request = createRequest(QUERY, undefined);
-    const operation = client.createRequestOperation('subscription', request);
+      const request = createRequest(QUERY, undefined);
+      const operation = client.createRequestOperation('subscription', request);
 
-    const { result } = renderHook(() =>
-      createSubscription<{ value: number }, { variable: number }>({
+      const [state] = createSubscription<
+        { value: number },
+        { value: number },
+        { variable: number }
+      >({
         query: QUERY,
-      })
-    );
+      });
 
-    expect(result[0]).toMatchObject({
-      data: undefined,
-      stale: false,
-      fetching: true,
-      operation: operation,
-      error: undefined,
-      extensions: undefined,
+      createEffect((run: number = 0) => {
+        markStateDependencies(state);
+
+        switch (run) {
+          case 0: {
+            expect(state).toMatchObject({
+              data: undefined,
+              stale: false,
+              operation: operation,
+              error: undefined,
+              extensions: undefined,
+              fetching: true,
+            });
+            expect(executeQuery).toEqual(expect.any(Function));
+            expect(executeQuery).toHaveBeenCalledOnce();
+            expect(client.executeSubscription).toBeCalledWith(
+              {
+                key: expect.any(Number),
+                query: expect.any(Object),
+                variables: {},
+              },
+              undefined
+            );
+            subject.next({ data: { value: 0 } });
+            break;
+          }
+          case 1: {
+            expect(state.data).toEqual({ value: 0 });
+            subject.next({ data: { value: 1 } });
+            break;
+          }
+          case 2: {
+            expect(state.data).toEqual({ value: 1 });
+            // expect(state.fetching).toEqual(true);
+            subject.complete();
+            break;
+          }
+          case 3: {
+            expect(state.fetching).toEqual(false);
+            expect(state.data).toEqual({ value: 1 });
+            done();
+          }
+        }
+
+        return run + 1;
+      });
     });
-    expect(result[1]).toEqual(expect.any(Function));
-
-    expect(executeQuery).toHaveBeenCalledOnce();
-    expect(client.executeSubscription).toBeCalledWith(
-      {
-        key: expect.any(Number),
-        query: expect.any(Object),
-        variables: {},
-      },
-      undefined
-    );
-
-    subject.next({ data: { value: 0 } });
-    expect(result[0].data).toEqual({ value: 0 });
-
-    subject.next({ data: { value: 1 } });
-    expect(result[0].data).toEqual({ value: 1 });
-
-    subject.complete();
-    expect(result[0].fetching).toBe(false);
-    expect(result[0].data).toEqual({ value: 1 });
   });
 
-  it('should call handler', async () => {
+  it('should call handler', () => {
     const handler = vi.fn();
     const subject =
       makeSubject<Pick<OperationResult<{ value: number }, any>, 'data'>>();
@@ -88,18 +124,38 @@ describe('createSubscription', () => {
       () => subject.source as OperationResultSource<OperationResult>
     );
 
-    renderHook(() =>
-      createSubscription<{ value: number }, { variable: number }>(
+    return testEffect(done => {
+      const [state] = createSubscription<
+        { value: number },
+        { value: number },
+        { variable: number }
+      >(
         {
           query: QUERY,
         },
         handler
-      )
-    );
+      );
 
-    waitFor(() => expect(handler).toHaveBeenCalledOnce());
-    subject.next({ data: { value: 0 } });
-    waitFor(() => expect(handler).toHaveBeenCalledTimes(2));
+      createEffect((run: number = 0) => {
+        markStateDependencies(state);
+        switch (run) {
+          case 0: {
+            expect(state.fetching).toEqual(true);
+            subject.next({ data: { value: 0 } });
+
+            break;
+          }
+          case 1: {
+            expect(handler).toHaveBeenCalledOnce();
+            expect(handler).toBeCalledWith(undefined, { value: 0 });
+            done();
+            break;
+          }
+        }
+
+        return run + 1;
+      });
+    });
   });
 
   it('should unsubscribe on teardown', async () => {
@@ -109,44 +165,75 @@ describe('createSubscription', () => {
       () => subject.source as OperationResultSource<OperationResult>
     );
 
-    const { result, cleanup } = renderHook(() =>
+    const {
+      result: [state],
+      cleanup,
+    } = renderHook(() =>
       createSubscription<{ value: number }, { variable: number }>({
         query: QUERY,
       })
     );
 
-    expect(result[0].fetching).toEqual(true);
-    cleanup();
-    waitFor(() => expect(result[0].fetching).toEqual(false));
+    return testEffect(done =>
+      createEffect((run: number = 0) => {
+        if (run === 0) {
+          expect(state.fetching).toEqual(true);
+          cleanup();
+        }
+
+        if (run === 1) {
+          expect(state.fetching).toEqual(false);
+          done();
+        }
+
+        return run + 1;
+      })
+    );
   });
 
   it('should skip executing query when paused', async () => {
     const subject =
       makeSubject<Pick<OperationResult<{ value: number }, any>, 'data'>>();
-    const executeQuery = vi
-      .spyOn(client, 'executeSubscription')
-      .mockImplementation(
-        () => subject.source as OperationResultSource<OperationResult>
-      );
-
-    const [pause, setPause] = createSignal<boolean>(true);
-    const { result } = renderHook(() =>
-      createSubscription<{ value: number }, { variable: number }>({
-        query: QUERY,
-        pause: pause,
-      })
+    vi.spyOn(client, 'executeSubscription').mockImplementation(
+      () => subject.source as OperationResultSource<OperationResult>
     );
 
-    expect(executeQuery).not.toBeCalled();
-    subject.next({ data: { value: 0 } });
-    expect(result[0].data).toBeUndefined();
-    setPause(false);
-    subject.next({ data: { value: 1 } });
-    expect(executeQuery).toHaveBeenCalledOnce();
-    expect(result[0].data).toStrictEqual({ value: 1 });
+    return testEffect(done => {
+      const [pause, setPause] = createSignal<boolean>(true);
+
+      const [state] = createSubscription<
+        { value: number },
+        { value: number },
+        { variable: number }
+      >({ query: QUERY, pause: pause });
+
+      createEffect((run: number = 0) => {
+        switch (run) {
+          case 0: {
+            expect(state.fetching).toBe(false);
+            setPause(false);
+            break;
+          }
+          case 1: {
+            expect(state.fetching).toBe(true);
+            expect(state.data).toBeUndefined();
+            subject.next({ data: { value: 1 } });
+
+            break;
+          }
+          case 2: {
+            expect(state.data).toStrictEqual({ value: 1 });
+            done();
+            break;
+          }
+        }
+
+        return run + 1;
+      });
+    });
   });
 
-  it('should override pause when execute executeSubscription', async () => {
+  it('should override pause when execute executeSubscription', () => {
     const subject =
       makeSubject<Pick<OperationResult<{ value: number }, any>, 'data'>>();
     const executeQuery = vi
@@ -155,22 +242,98 @@ describe('createSubscription', () => {
         () => subject.source as OperationResultSource<OperationResult>
       );
 
-    const { result } = renderHook(() =>
-      createSubscription<{ value: number }, { variable: number }>({
+    return testEffect(done => {
+      const [state, executeSubscription] = createSubscription<
+        { value: number },
+        { value: number },
+        { variable: number }
+      >({
         query: QUERY,
         pause: true,
-      })
+      });
+
+      createEffect((run: number = 0) => {
+        markStateDependencies(state);
+
+        switch (run) {
+          case 0: {
+            expect(state.fetching).toEqual(false);
+            expect(executeQuery).not.toBeCalled();
+
+            executeSubscription();
+
+            break;
+          }
+          case 1: {
+            expect(state.fetching).toEqual(true);
+            expect(executeQuery).toHaveBeenCalledOnce();
+            subject.next({ data: { value: 1 } });
+            break;
+          }
+          case 2: {
+            expect(state.data).toStrictEqual({ value: 1 });
+            done();
+            break;
+          }
+        }
+
+        return run + 1;
+      });
+    });
+  });
+
+  it.only('should aggregate results', () => {
+    const subject =
+      makeSubject<Pick<OperationResult<{ value: number }, any>, 'data'>>();
+    vi.spyOn(client, 'executeSubscription').mockImplementation(
+      () => subject.source as OperationResultSource<OperationResult>
     );
 
-    expect(result[0].fetching).toEqual(false);
-    expect(executeQuery).not.toBeCalled();
+    return testEffect(done => {
+      const [state] = createSubscription<
+        { value: number },
+        { merged: number },
+        { variable: number }
+      >(
+        {
+          query: QUERY,
+        },
+        (prev, next) => {
+          if (prev === undefined) {
+            return {
+              merged: 0 + next.value,
+            };
+          }
 
-    result[1]();
+          return { merged: prev.merged + next.value };
+        }
+      );
 
-    expect(result[0].fetching).toEqual(true);
-    expect(executeQuery).toHaveBeenCalledOnce();
-    subject.next({ data: { value: 1 } });
+      createEffect((run: number = 0) => {
+        markStateDependencies(state);
+        switch (run) {
+          case 0: {
+            expect(state.fetching).toEqual(true);
+            subject.next({ data: { value: 1 } });
 
-    expect(result[0].data).toStrictEqual({ value: 1 });
+            break;
+          }
+          case 1: {
+            expect(state.data).toEqual({ merged: 1 });
+            subject.next({ data: { value: 2 } });
+
+            break;
+          }
+          case 2: {
+            expect(state.data).toEqual({ merged: 3 });
+
+            done();
+            break;
+          }
+        }
+
+        return run + 1;
+      });
+    });
   });
 });

--- a/packages/solid-urql/src/createSubscription.ts
+++ b/packages/solid-urql/src/createSubscription.ts
@@ -6,7 +6,7 @@ import {
   type OperationContext,
   type OperationResult,
   type OperationResultSource,
-  CombinedError,
+  type CombinedError,
   createRequest,
 } from '@urql/core';
 import { useClient } from './context';
@@ -51,7 +51,7 @@ export type CreateSubscriptionExecute = (
 /** Input arguments for the {@link createSubscription} hook. */
 export type CreateSubscriptionArgs<
   Data,
-  Variables extends AnyVariables = AnyVariables
+  Variables extends AnyVariables = AnyVariables,
 > = {
   /** The GraphQL subscription document that `createSubscription` executes. */
   query: DocumentInput<Data, Variables>;
@@ -81,7 +81,7 @@ export type CreateSubscriptionArgs<
 
 export type CreateSubscriptionState<
   Data = any,
-  Variables extends AnyVariables = AnyVariables
+  Variables extends AnyVariables = AnyVariables,
 > = {
   /** Indicates whether `createSubscription`’s subscription is active.
    *
@@ -169,7 +169,7 @@ export type SubscriptionHandler<T, R> = (prev: R | undefined, data: T) => R;
  */
 export type CreateSubscriptionResult<
   Data,
-  Variables extends AnyVariables = AnyVariables
+  Variables extends AnyVariables = AnyVariables,
 > = [CreateSubscriptionState<Data, Variables>, CreateSubscriptionExecute];
 
 /** Hook to run a GraphQL subscription and get updated GraphQL results.
@@ -212,14 +212,14 @@ export type CreateSubscriptionResult<
 export const createSubscription = <
   Data,
   Result = Data,
-  Variables extends AnyVariables = AnyVariables
+  Variables extends AnyVariables = AnyVariables,
 >(
   args: CreateSubscriptionArgs<Data, Variables>,
   handler?: SubscriptionHandler<Data, Result>
 ): CreateSubscriptionResult<Result, Variables> => {
-  const getContext = asAccessor(args.context),
-    getPause = asAccessor(args.pause),
-    getVariables = asAccessor(args.variables);
+  const getContext = asAccessor(args.context);
+  const getPause = asAccessor(args.pause);
+  const getVariables = asAccessor(args.variables);
 
   const client = useClient();
 

--- a/packages/solid-urql/src/createSubscription.ts
+++ b/packages/solid-urql/src/createSubscription.ts
@@ -1,13 +1,13 @@
-import { MaybeAccessor, asAccessor } from '@solid-primitives/utils';
+import { type MaybeAccessor, asAccessor } from '@solid-primitives/utils';
 import {
   type AnyVariables,
   type DocumentInput,
   type Operation,
   type OperationContext,
+  type OperationResult,
+  type OperationResultSource,
   CombinedError,
   createRequest,
-  OperationResult,
-  OperationResultSource,
 } from '@urql/core';
 import { useClient } from './context';
 import { createStore } from 'solid-js/store';

--- a/packages/solid-urql/src/createSubscription.ts
+++ b/packages/solid-urql/src/createSubscription.ts
@@ -23,13 +23,59 @@ import {
   switchMap,
 } from 'wonka';
 
+/** Triggers {@link createSubscription} to re-execute a GraphQL subscription operation.
+ *
+ * @param opts - optionally, context options that will be merged with the hook's
+ * {@link CreateSubscriptionArgs.context} options and the `Client`’s options.
+ *
+ * @remarks
+ * When called, {@link createSubscription} will restart the GraphQL subscription
+ * operation it currently holds. If {@link CreateSubscriptionArgs.pause} is set
+ * to `true`, it will start executing the subscription.
+ *
+ * ```ts
+ * const [result, executeSubscription] = createSubscription({
+ *   query,
+ *   pause: true,
+ * });
+ *
+ * const start = () => {
+ *   executeSubscription();
+ * };
+ * ```
+ */
+export type CreateSubscriptionExecute = (
+  opts?: Partial<OperationContext>
+) => void;
+
+/** Input arguments for the {@link createSubscription} hook. */
 export type CreateSubscriptionArgs<
   Data,
   Variables extends AnyVariables = AnyVariables
 > = {
+  /** The GraphQL subscription document that `createSubscription` executes. */
   query: DocumentInput<Data, Variables>;
+
+  /** The variables for the GraphQL subscription that `createSubscription` executes. */
   variables?: MaybeAccessor<Variables>;
+
+  /** Updates the {@link OperationContext} for the executed GraphQL subscription operation.
+   *
+   * @remarks
+   * `context` may be passed to {@link createSubscription}, to update the {@link OperationContext}
+   * of a subscription operation. This may be used to update the `context` that exchanges
+   * will receive for a single hook.
+   */
   context?: MaybeAccessor<Partial<OperationContext>>;
+
+  /** Prevents {@link createSubscription} from automatically starting GraphQL subscriptions.
+   *
+   * @remarks
+   * `pause` may be set to `true` to stop {@link createSubscription} from starting its subscription
+   * automatically. The hook will stop receiving updates from the {@link Client}
+   * and won’t start the subscription operation, until either it’s set to `false`
+   * or the {@link CreateSubscriptionExecute} function is called.
+   */
   pause?: MaybeAccessor<boolean>;
 };
 
@@ -37,16 +83,132 @@ export type CreateSubscriptionState<
   Data = any,
   Variables extends AnyVariables = AnyVariables
 > = {
+  /** Indicates whether `createSubscription`’s subscription is active.
+   *
+   * @remarks
+   * When `createSubscription` starts a subscription, the `fetching` flag
+   * is set to `true` and will remain `true` until the subscription
+   * completes on the API, or the {@link CreateSubscriptionArgs.pause}
+   * flag is set to `true`.
+   */
   fetching: boolean;
+
+  /** Indicates that the subscription result is not fresh.
+   *
+   * @remarks
+   * This is mostly unused for subscriptions and will rarely affect you, and
+   * is more relevant for queries.
+   *
+   * @see {@link OperationResult.stale} for the source of this value.
+   */
   stale: boolean;
+
+  /** The {@link OperationResult.data} for the executed subscription, or data returned by a handler.
+   *
+   * @remarks
+   * `data` will be set to the last {@link OperationResult.data} value
+   * received for the subscription.
+   *
+   * It will instead be set to the values that {@link SubscriptionHandler}
+   * returned, if a handler has been passed to {@link CreateSubscription}.
+   */
   data?: Data;
+
+  /** The {@link OperationResult.error} for the executed subscription. */
   error?: CombinedError;
+
+  /** The {@link OperationResult.extensions} for the executed mutation. */
   extensions?: Record<string, any>;
+
+  /** The {@link Operation} that the current state is for.
+   *
+   * @remarks
+   * This is the subscription {@link Operation} that is currently active.
+   * When {@link CreateSubscriptionState.fetching} is `true`, this is the
+   * last `Operation` that the current state was for.
+   */
   operation?: Operation<Data, Variables>;
 };
 
+/** Combines previous data with an incoming subscription result’s data.
+ *
+ * @remarks
+ * A `SubscriptionHandler` may be passed to {@link createSubscription} to
+ * aggregate subscription results into a combined {@link CreateSubscriptionState.data}
+ * value.
+ *
+ * This is useful when a subscription event delivers a single item, while
+ * you’d like to display a list of events.
+ *
+ * @example
+ * ```ts
+ * const NotificationsSubscription = gql`
+ *   subscription { newNotification { id, text } }
+ * `;
+ *
+ * const combineNotifications = (notifications = [], data) => {
+ *   return [...notifications, data.newNotification];
+ * };
+ *
+ * const [result, executeSubscription] = createSubscription(
+ *   { query: NotificationsSubscription },
+ *   combineNotifications,
+ * );
+ * ```
+ */
 export type SubscriptionHandler<T, R> = (prev: R | undefined, data: T) => R;
 
+/** Result tuple returned by the {@link createSubscription} hook.
+ *
+ * @remarks
+ * Similarly to a `createSignal` hook’s return value,
+ * the first element is the {@link createSubscription}’s state,
+ * a {@link CreateSubscriptionState} object,
+ * and the second is used to imperatively re-execute or start the subscription
+ * via a {@link CreateMutationExecute} function.
+ */
+export type CreateSubscriptionResult<
+  Data,
+  Variables extends AnyVariables = AnyVariables
+> = [CreateSubscriptionState<Data, Variables>, CreateSubscriptionExecute];
+
+/** Hook to run a GraphQL subscription and get updated GraphQL results.
+ *
+ * @param args - a {@link CreateSubscriptionArgs} object, to pass a `query`, `variables`, and options.
+ * @param handler - optionally, a {@link SubscriptionHandler} function to combine multiple subscription results.
+ * @returns a {@link CreateSubscriptionResponse} tuple of a {@link CreateSubscriptionState} result,
+ * and an execute function.
+ *
+ * @remarks
+ * `createSubscription` allows GraphQL subscriptions to be defined and executed.
+ * Given {@link CreateSubscriptionArgs.query}, it executes the GraphQL subscription with the
+ * context’s {@link Client}.
+ *
+ * The returned result updates when the `Client` has new results
+ * for the subscription, and `data` is updated with the result’s data
+ * or with the `data` that a `handler` returns.
+ *
+ * @example
+ * ```ts
+ * import { gql, createSubscription } from '@urql/solid';
+ *
+ * const NotificationsSubscription = gql`
+ *   subscription { newNotification { id, text } }
+ * `;
+ *
+ * const combineNotifications = (notifications = [], data) => {
+ *   return [...notifications, data.newNotification];
+ * };
+ *
+ * const Notifications = () => {
+ *   const [result, executeSubscription] = createSubscription(
+ *     { query: NotificationsSubscription },
+ *     combineNotifications,
+ *   );
+ *   // ...
+ * };
+ * ```
+ */
 export const createSubscription = <
   Data,
   Result = Data,
@@ -54,7 +216,7 @@ export const createSubscription = <
 >(
   args: CreateSubscriptionArgs<Data, Variables>,
   handler?: SubscriptionHandler<Data, Result>
-) => {
+): CreateSubscriptionResult<Result, Variables> => {
   const getContext = asAccessor(args.context),
     getPause = asAccessor(args.pause),
     getVariables = asAccessor(args.variables);
@@ -152,5 +314,5 @@ export const createSubscription = <
     );
   };
 
-  return [state, executeSubscription] as const;
+  return [state, executeSubscription];
 };

--- a/packages/solid-urql/src/createSubscription.ts
+++ b/packages/solid-urql/src/createSubscription.ts
@@ -1,0 +1,156 @@
+import { MaybeAccessor, asAccessor } from '@solid-primitives/utils';
+import {
+  type AnyVariables,
+  type DocumentInput,
+  type Operation,
+  type OperationContext,
+  CombinedError,
+  createRequest,
+  OperationResult,
+  OperationResultSource,
+} from '@urql/core';
+import { useClient } from './context';
+import { createStore } from 'solid-js/store';
+import { createComputed, onCleanup } from 'solid-js';
+import {
+  concat,
+  fromValue,
+  makeSubject,
+  map,
+  pipe,
+  scan,
+  subscribe,
+  switchMap,
+} from 'wonka';
+
+type CreateSubscriptionArgs<
+  Data,
+  Variables extends AnyVariables = AnyVariables
+> = {
+  query: DocumentInput<Data, Variables>;
+  variables?: MaybeAccessor<Variables>;
+  context?: MaybeAccessor<Partial<OperationContext>>;
+  pause?: MaybeAccessor<boolean>;
+};
+
+type CreateSubscriptionState<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+> = {
+  fetching: boolean;
+  stale: boolean;
+  data?: Data;
+  error?: CombinedError;
+  extensions?: Record<string, any>;
+  operation?: Operation<Data, Variables>;
+};
+
+export type SubscriptionHandler<T, R> = (prev: R | undefined, data: T) => R;
+
+export const createSubscription = <
+  Data,
+  Result = Data,
+  Variables extends AnyVariables = AnyVariables
+>(
+  args: CreateSubscriptionArgs<Data, Variables>,
+  handler?: SubscriptionHandler<Data, Result>
+) => {
+  const getContext = asAccessor(args.context),
+    getPause = asAccessor(args.pause),
+    getVariables = asAccessor(args.variables);
+
+  const client = useClient();
+
+  const request = createRequest(args.query, getVariables() as Variables);
+  const operation = client.createRequestOperation(
+    'subscription',
+    request,
+    getContext()
+  );
+  const initialState: CreateSubscriptionState<Result, Variables> = {
+    operation,
+    fetching: false,
+    data: undefined,
+    error: undefined,
+    extensions: undefined,
+    stale: false,
+  };
+
+  const operationSubject = makeSubject<
+    OperationResultSource<OperationResult<Data, Variables>> | undefined
+  >();
+  const [state, setState] =
+    createStore<CreateSubscriptionState<Result, Variables>>(initialState);
+
+  const sub = pipe(
+    operationSubject.source,
+    switchMap(subscription$ => {
+      if (subscription$ === undefined) {
+        return fromValue({ fetching: false });
+      }
+
+      return concat([
+        fromValue({ fetching: true, stale: false }),
+        pipe(
+          subscription$,
+          map(it => ({
+            fetching: true,
+            stale: !!it.stale,
+            data: it.data,
+            error: it.error,
+            extensions: it.extensions,
+            operation: it.operation,
+          }))
+        ),
+        fromValue({ fetching: false, stale: false }),
+      ]);
+    }),
+    scan((result: CreateSubscriptionState<Result, Variables>, partial: any) => {
+      const data =
+        partial.data !== undefined
+          ? typeof handler === 'function'
+            ? handler(result.data, partial.data)
+            : partial.data
+          : result.data;
+
+      return {
+        ...result,
+        ...partial,
+        data: data,
+      };
+    }, initialState),
+    subscribe(result => {
+      setState(result);
+    })
+  );
+
+  onCleanup(() => {
+    sub.unsubscribe();
+  });
+
+  createComputed(() => {
+    if (getPause() === true) {
+      operationSubject.next(undefined);
+      return;
+    }
+
+    const ctx = getContext();
+    const req = createRequest(args.query, getVariables() as Variables);
+    operationSubject.next(
+      client.executeSubscription<Data, Variables>(req, ctx)
+    );
+  });
+
+  const execute = (opts?: Partial<OperationContext>) => {
+    const ctx = getContext();
+    const req = createRequest(args.query, getVariables() as Variables);
+    operationSubject.next(
+      client.executeSubscription<Data, Variables>(req, {
+        ...ctx,
+        ...opts,
+      })
+    );
+  };
+
+  return [state, execute] as const;
+};

--- a/packages/solid-urql/src/createSubscription.ts
+++ b/packages/solid-urql/src/createSubscription.ts
@@ -141,7 +141,7 @@ export const createSubscription = <
     );
   });
 
-  const execute = (opts?: Partial<OperationContext>) => {
+  const executeSubscription = (opts?: Partial<OperationContext>) => {
     const ctx = getContext();
     const req = createRequest(args.query, getVariables() as Variables);
     resultSourceSubject.next(
@@ -152,5 +152,5 @@ export const createSubscription = <
     );
   };
 
-  return [state, execute] as const;
+  return [state, executeSubscription] as const;
 };

--- a/packages/solid-urql/src/createSubscription.ts
+++ b/packages/solid-urql/src/createSubscription.ts
@@ -76,14 +76,14 @@ export const createSubscription = <
     stale: false,
   };
 
-  const operationSubject = makeSubject<
+  const resultSourceSubject = makeSubject<
     OperationResultSource<OperationResult<Data, Variables>> | undefined
   >();
   const [state, setState] =
     createStore<CreateSubscriptionState<Result, Variables>>(initialState);
 
   const sub = pipe(
-    operationSubject.source,
+    resultSourceSubject.source,
     switchMap(subscription$ => {
       if (subscription$ === undefined) {
         return fromValue({ fetching: false });
@@ -130,13 +130,13 @@ export const createSubscription = <
 
   createComputed(() => {
     if (getPause() === true) {
-      operationSubject.next(undefined);
+      resultSourceSubject.next(undefined);
       return;
     }
 
     const ctx = getContext();
     const req = createRequest(args.query, getVariables() as Variables);
-    operationSubject.next(
+    resultSourceSubject.next(
       client.executeSubscription<Data, Variables>(req, ctx)
     );
   });
@@ -144,7 +144,7 @@ export const createSubscription = <
   const execute = (opts?: Partial<OperationContext>) => {
     const ctx = getContext();
     const req = createRequest(args.query, getVariables() as Variables);
-    operationSubject.next(
+    resultSourceSubject.next(
       client.executeSubscription<Data, Variables>(req, {
         ...ctx,
         ...opts,

--- a/packages/solid-urql/src/createSubscription.ts
+++ b/packages/solid-urql/src/createSubscription.ts
@@ -1,4 +1,4 @@
-import { type MaybeAccessor, asAccessor } from '@solid-primitives/utils';
+import { type MaybeAccessor, asAccessor } from './utils';
 import {
   type AnyVariables,
   type DocumentInput,

--- a/packages/solid-urql/src/createSubscription.ts
+++ b/packages/solid-urql/src/createSubscription.ts
@@ -23,7 +23,7 @@ import {
   switchMap,
 } from 'wonka';
 
-type CreateSubscriptionArgs<
+export type CreateSubscriptionArgs<
   Data,
   Variables extends AnyVariables = AnyVariables
 > = {
@@ -33,7 +33,7 @@ type CreateSubscriptionArgs<
   pause?: MaybeAccessor<boolean>;
 };
 
-type CreateSubscriptionState<
+export type CreateSubscriptionState<
   Data = any,
   Variables extends AnyVariables = AnyVariables
 > = {

--- a/packages/solid-urql/src/index.ts
+++ b/packages/solid-urql/src/index.ts
@@ -1,0 +1,1 @@
+export * from './context';

--- a/packages/solid-urql/src/index.ts
+++ b/packages/solid-urql/src/index.ts
@@ -6,7 +6,12 @@ export { useClient } from './context';
 export { type CreateMutationState } from './createMutation';
 export { createMutation } from './createMutation';
 
-export { type CreateQueryArgs, type CreateQueryState } from './createQuery';
+export {
+  type CreateQueryArgs,
+  type CreateQueryState,
+  type CreateQueryExecute,
+  type CreateQueryResult,
+} from './createQuery';
 export { createQuery } from './createQuery';
 
 export {

--- a/packages/solid-urql/src/index.ts
+++ b/packages/solid-urql/src/index.ts
@@ -3,7 +3,11 @@ export * from '@urql/core';
 export { type UseClient } from './context';
 export { useClient } from './context';
 
-export { type CreateMutationState } from './createMutation';
+export {
+  type CreateMutationState,
+  type CreateMutationExecute,
+  type CreateMutationResult,
+} from './createMutation';
 export { createMutation } from './createMutation';
 
 export {

--- a/packages/solid-urql/src/index.ts
+++ b/packages/solid-urql/src/index.ts
@@ -1,1 +1,18 @@
-export * from './context';
+export * from '@urql/core';
+
+export { type UseClient } from './context';
+export { useClient } from './context';
+
+export { type CreateMutationState } from './createMutation';
+export { createMutation } from './createMutation';
+
+export { type CreateQueryArgs, type CreateQueryState } from './createQuery';
+export { createQuery } from './createQuery';
+
+export {
+  type CreateSubscriptionArgs,
+  type CreateSubscriptionState,
+  type SubscriptionHandler,
+} from './createSubscription';
+
+export { createSubscription } from './createSubscription';

--- a/packages/solid-urql/src/index.ts
+++ b/packages/solid-urql/src/index.ts
@@ -21,6 +21,8 @@ export { createQuery } from './createQuery';
 export {
   type CreateSubscriptionArgs,
   type CreateSubscriptionState,
+  type CreateSubscriptionExecute,
+  type CreateSubscriptionResult,
   type SubscriptionHandler,
 } from './createSubscription';
 

--- a/packages/solid-urql/src/suspense.test.tsx
+++ b/packages/solid-urql/src/suspense.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, vi } from 'vitest';
+import {
+  OperationResult,
+  OperationResultSource,
+  createClient,
+} from '@urql/core';
+import { createQuery } from './createQuery';
+import { fireEvent, render, screen, waitFor } from '@solidjs/testing-library';
+import { Provider } from './context';
+import { Suspense } from 'solid-js';
+import { makeSubject } from 'wonka';
+
+describe('createQuery suspense', () => {
+  it('should not suspend', async () => {
+    const client = createClient({
+      url: '/graphql',
+      exchanges: [],
+      suspense: false,
+    });
+
+    const subject =
+      makeSubject<Pick<OperationResult<{ test: boolean }, any>, 'data'>>();
+    vi.spyOn(client, 'executeQuery').mockImplementation(
+      () => subject.source as OperationResultSource<OperationResult>
+    );
+
+    const Page = () => {
+      const [state, refetch] = createQuery<
+        { test: boolean },
+        { variable: number }
+      >({
+        query: '{ test }',
+      });
+
+      return (
+        <div>
+          <button data-testid="refetch" onClick={refetch} />
+          data: {String(state.data?.test)}
+        </div>
+      );
+    };
+
+    render(() => (
+      <Provider value={client}>
+        <Suspense fallback="loading">
+          <Page />
+        </Suspense>
+      </Provider>
+    ));
+
+    subject.next({ data: { test: true } });
+    await waitFor(() => screen.getByText('data: true'));
+
+    fireEvent.click(screen.getByTestId('refetch'));
+
+    subject.next({ data: { test: false } });
+    await waitFor(() => screen.getByText('data: false'));
+  });
+
+  it('should suspend', async () => {
+    const client = createClient({
+      url: '/graphql',
+      exchanges: [],
+      suspense: true,
+    });
+
+    const subject =
+      makeSubject<Pick<OperationResult<{ test: boolean }, any>, 'data'>>();
+    vi.spyOn(client, 'executeQuery').mockImplementation(
+      () => subject.source as OperationResultSource<OperationResult>
+    );
+
+    const Page = () => {
+      const [state] = createQuery<{ test: boolean }, { variable: number }>({
+        query: '{ test }',
+      });
+
+      return <div>data: {String(state.data?.test)}</div>;
+    };
+
+    render(() => (
+      <Provider value={client}>
+        <Suspense fallback="loading">
+          <Page />
+        </Suspense>
+      </Provider>
+    ));
+
+    await waitFor(() => screen.getByText('loading'));
+
+    subject.next({ data: { test: true } });
+    await waitFor(() => screen.getByText('data: true'));
+  });
+
+  it('context suspend should override client suspend', async () => {
+    const client = createClient({
+      url: '/graphql',
+      exchanges: [],
+      suspense: false,
+    });
+
+    const subject =
+      makeSubject<Pick<OperationResult<{ test: boolean }, any>, 'data'>>();
+    vi.spyOn(client, 'executeQuery').mockImplementation(
+      () => subject.source as OperationResultSource<OperationResult>
+    );
+
+    const Page = () => {
+      const [state] = createQuery<{ test: boolean }, { variable: number }>({
+        query: '{ test }',
+        context: {
+          suspense: true,
+        },
+      });
+
+      return <div>data: {String(state.data?.test)}</div>;
+    };
+
+    render(() => (
+      <Provider value={client}>
+        <Suspense fallback="loading">
+          <Page />
+        </Suspense>
+      </Provider>
+    ));
+
+    await waitFor(() => screen.getByText('loading'));
+
+    subject.next({ data: { test: true } });
+    await waitFor(() => screen.getByText('data: true'));
+  });
+});

--- a/packages/solid-urql/src/utils.ts
+++ b/packages/solid-urql/src/utils.ts
@@ -1,0 +1,11 @@
+import type { Accessor } from 'solid-js';
+
+export type MaybeAccessor<T> = T | Accessor<T>;
+
+export type MaybeAccessorValue<T extends MaybeAccessor<any>> =
+  T extends () => any ? ReturnType<T> : T;
+
+export const asAccessor = <A extends MaybeAccessor<unknown>>(
+  v: A
+): Accessor<MaybeAccessorValue<A>> =>
+  typeof v === 'function' ? (v as any) : () => v;

--- a/packages/solid-urql/tsconfig.json
+++ b/packages/solid-urql/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "jsx": "preserve",
+    "jsxImportSource": "solid-js"
+  }
+}

--- a/packages/solid-urql/vitest.config.ts
+++ b/packages/solid-urql/vitest.config.ts
@@ -1,0 +1,32 @@
+/// <reference types="vitest" />
+/// <reference types="vite/client" />
+// 👆 do not forget to add the references above
+import { resolve } from 'path';
+import { defineConfig } from 'vite';
+import solidPlugin from 'vite-plugin-solid';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+export default defineConfig({
+  plugins: [solidPlugin(), tsconfigPaths()],
+  server: {
+    port: 3000,
+  },
+  build: {
+    target: 'esnext',
+  },
+  test: {
+    environment: 'jsdom',
+    transformMode: { web: [/\.[jt]sx?$/] },
+    globals: true,
+    setupFiles: [resolve(__dirname, '../../scripts/vitest/setup.js')],
+    clearMocks: true,
+    exclude: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/cypress/**',
+      '**/e2e-tests/**',
+      '**/.{idea,git,cache,output,temp}/**',
+      '**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress}.config.*',
+    ],
+  },
+});

--- a/packages/solid-urql/vitest.config.ts
+++ b/packages/solid-urql/vitest.config.ts
@@ -1,11 +1,10 @@
-import { mergeConfig } from 'vite';
+import { defineConfig, mergeConfig } from 'vite';
 import solidPlugin from 'vite-plugin-solid';
 import rootConfig from '../../vitest.config';
-import { defineProject } from 'vitest/config';
 
 export default mergeConfig(
   rootConfig,
-  defineProject({
+  defineConfig({
     plugins: [solidPlugin()],
     test: {
       globals: true,

--- a/packages/solid-urql/vitest.config.ts
+++ b/packages/solid-urql/vitest.config.ts
@@ -1,32 +1,14 @@
-/// <reference types="vitest" />
-/// <reference types="vite/client" />
-// 👆 do not forget to add the references above
-import { resolve } from 'path';
-import { defineConfig } from 'vite';
+import { mergeConfig } from 'vite';
 import solidPlugin from 'vite-plugin-solid';
-import tsconfigPaths from 'vite-tsconfig-paths';
+import rootConfig from '../../vitest.config';
+import { defineProject } from 'vitest/config';
 
-export default defineConfig({
-  plugins: [solidPlugin(), tsconfigPaths()],
-  server: {
-    port: 3000,
-  },
-  build: {
-    target: 'esnext',
-  },
-  test: {
-    environment: 'jsdom',
-    transformMode: { web: [/\.[jt]sx?$/] },
-    globals: true,
-    setupFiles: [resolve(__dirname, '../../scripts/vitest/setup.js')],
-    clearMocks: true,
-    exclude: [
-      '**/node_modules/**',
-      '**/dist/**',
-      '**/cypress/**',
-      '**/e2e-tests/**',
-      '**/.{idea,git,cache,output,temp}/**',
-      '**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress}.config.*',
-    ],
-  },
-});
+export default mergeConfig(
+  rootConfig,
+  defineProject({
+    plugins: [solidPlugin()],
+    test: {
+      globals: true,
+    },
+  })
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -539,6 +539,43 @@ importers:
         specifier: '>=4.4.6'
         version: 4.46.0
 
+  packages/solid-urql:
+    dependencies:
+      '@solid-primitives/utils':
+        specifier: ^6.2.0
+        version: 6.2.0(solid-js@1.7.7)
+      '@urql/core':
+        specifier: ^4.0.0
+        version: link:../core
+      solid-js:
+        specifier: ^1.7.7
+        version: 1.7.7
+      wonka:
+        specifier: ^6.3.2
+        version: 6.3.2
+    devDependencies:
+      '@solidjs/testing-library':
+        specifier: ^0.8.2
+        version: 0.8.2(@solidjs/router@0.8.2)(solid-js@1.7.7)
+      '@testing-library/jest-dom':
+        specifier: ^5.16.5
+        version: 5.16.5
+      graphql:
+        specifier: ^16.6.0
+        version: 16.6.0
+      jsdom:
+        specifier: ^22.1.0
+        version: 22.1.0
+      vite-plugin-solid:
+        specifier: ^2.7.0
+        version: 2.7.0(solid-js@1.7.7)(vite@3.2.5)
+      vite-tsconfig-paths:
+        specifier: ^4.2.0
+        version: 4.2.0(typescript@5.1.6)(vite@3.2.5)
+      vitest:
+        specifier: ^0.32.2
+        version: 0.32.2(jsdom@22.1.0)(terser@5.17.1)
+
   packages/storage-rn:
     devDependencies:
       '@react-native-async-storage/async-storage':
@@ -638,6 +675,10 @@ packages:
     dependencies:
       tunnel: 0.0.6
 
+  /@adobe/css-tools@4.2.0:
+    resolution: {integrity: sha512-E09FiIft46CmH5Qnjb0wsW54/YQd69LsxeKUOWawmws1XWvyFGURnAChH0mlr7YPFR1ofwvUQfcL0J3lMxXqPA==}
+    dev: true
+
   /@ampproject/remapping@2.2.0:
     resolution: {integrity: sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==}
     engines: {node: '>=6.0.0'}
@@ -665,6 +706,12 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@babel/code-frame@7.21.4:
+    resolution: {integrity: sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/highlight': 7.18.6
+
   /@babel/code-frame@7.22.5:
     resolution: {integrity: sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==}
     engines: {node: '>=6.9.0'}
@@ -681,19 +728,19 @@ packages:
     dependencies:
       '@babel/code-frame': 7.22.5
       '@babel/generator': 7.21.5
-      '@babel/helper-module-transforms': 7.21.5
+      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.12.9)
       '@babel/helpers': 7.21.5
-      '@babel/parser': 7.22.4
-      '@babel/template': 7.20.7
+      '@babel/parser': 7.22.7
+      '@babel/template': 7.22.5
       '@babel/traverse': 7.21.5(supports-color@5.5.0)
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.5
       convert-source-map: 1.9.0
       debug: 4.3.4(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       lodash: 4.17.21
       resolve: 1.22.2
-      semver: 5.7.2
+      semver: 5.7.1
       source-map: 0.5.7
     transitivePeerDependencies:
       - supports-color
@@ -703,20 +750,20 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@ampproject/remapping': 2.2.0
-      '@babel/code-frame': 7.22.5
+      '@babel/code-frame': 7.21.4
       '@babel/generator': 7.21.5
       '@babel/helper-compilation-targets': 7.21.5(@babel/core@7.21.5)
       '@babel/helper-module-transforms': 7.21.5
       '@babel/helpers': 7.21.5
-      '@babel/parser': 7.22.4
+      '@babel/parser': 7.21.5
       '@babel/template': 7.20.7
       '@babel/traverse': 7.21.5(supports-color@5.5.0)
-      '@babel/types': 7.22.4
+      '@babel/types': 7.21.5
       convert-source-map: 1.9.0
       debug: 4.3.4(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
-      semver: 6.3.1
+      semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
 
@@ -724,7 +771,7 @@ packages:
     resolution: {integrity: sha512-SrKK/sRv8GesIW1bDagf9cCG38IOMYZusoe1dfg0D8aiUe3Amvoj1QtjTPAWcfrZFvIwlleLb0gxzQidL9w14w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.4
+      '@babel/types': 7.21.5
       '@jridgewell/gen-mapping': 0.3.2
       '@jridgewell/trace-mapping': 0.3.17
       jsesc: 2.5.2
@@ -733,13 +780,19 @@ packages:
     resolution: {integrity: sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.4
+      '@babel/types': 7.21.5
+
+  /@babel/helper-annotate-as-pure@7.22.5:
+    resolution: {integrity: sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.22.5
 
   /@babel/helper-builder-binary-assignment-operator-visitor@7.12.13:
     resolution: {integrity: sha512-CZOv9tGphhDRlVjVkAgm8Nhklm9RzSmWpX2my+t7Ua/KT616pEzXsQCjinzvkRvHWJ9itO4f296efroX23XCMA==}
     dependencies:
       '@babel/helper-explode-assignable-expression': 7.13.0
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.5
 
   /@babel/helper-compilation-targets@7.21.5(@babel/core@7.21.5):
     resolution: {integrity: sha512-1RkbFGUKex4lvsB9yhIfWltJM5cZKUftB2eNajaDv3dCMEp49iBG0K14uH8NnX9IPux2+mK7JGEOB0jn48/J6w==}
@@ -772,6 +825,24 @@ packages:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@babel/helper-create-class-features-plugin@7.22.9(@babel/core@7.21.5):
+    resolution: {integrity: sha512-Pwyi89uO4YrGKxL/eNJ8lfEH55DnRloGPOseaA8NFNL6jAUnn+KccaISiFazCj5IolPPDjGSdzQzXVzODVRqUQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.21.5
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-function-name': 7.22.5
+      '@babel/helper-member-expression-to-functions': 7.22.5
+      '@babel/helper-optimise-call-expression': 7.22.5
+      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.21.5)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      semver: 6.3.1
 
   /@babel/helper-create-regexp-features-plugin@7.12.17(@babel/core@7.21.5):
     resolution: {integrity: sha512-p2VGmBu9oefLZ2nQpgnEnG0ZlRPvL8gAGvPUMQwUdaE8k49rOMuZpOwdQoy5qJf6K8jL3bcAMhVUlHAjIgJHUg==}
@@ -779,7 +850,7 @@ packages:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/helper-annotate-as-pure': 7.22.5
       regexpu-core: 4.7.1
 
   /@babel/helper-define-polyfill-provider@0.2.0(@babel/core@7.21.5):
@@ -789,8 +860,8 @@ packages:
     dependencies:
       '@babel/core': 7.21.5
       '@babel/helper-compilation-targets': 7.21.5(@babel/core@7.21.5)
-      '@babel/helper-module-imports': 7.21.4
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-module-imports': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/traverse': 7.21.5(supports-color@5.5.0)
       debug: 4.3.4(supports-color@5.5.0)
       lodash.debounce: 4.0.8
@@ -803,35 +874,66 @@ packages:
     resolution: {integrity: sha512-IYl4gZ3ETsWocUWgsFZLM5i1BYx9SoemminVEXadgLBa9TdeorzgLKm8wWLA6J1N/kT3Kch8XIk1laNzYoHKvQ==}
     engines: {node: '>=6.9.0'}
 
+  /@babel/helper-environment-visitor@7.22.5:
+    resolution: {integrity: sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==}
+    engines: {node: '>=6.9.0'}
+
   /@babel/helper-explode-assignable-expression@7.13.0:
     resolution: {integrity: sha512-qS0peLTDP8kOisG1blKbaoBg/o9OSa1qoumMjTK5pM+KDTtpxpsiubnCGP34vK8BXGcb2M9eigwgvoJryrzwWA==}
     dependencies:
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.5
 
   /@babel/helper-function-name@7.21.0:
     resolution: {integrity: sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.20.7
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.5
+
+  /@babel/helper-function-name@7.22.5:
+    resolution: {integrity: sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/template': 7.22.5
+      '@babel/types': 7.22.5
 
   /@babel/helper-hoist-variables@7.18.6:
     resolution: {integrity: sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.5
 
   /@babel/helper-member-expression-to-functions@7.21.5:
     resolution: {integrity: sha512-nIcGfgwpH2u4n9GG1HpStW5Ogx7x7ekiFHbjjFRKXbn5zUvqO9ZgotCO4x1aNbKn/x/xOUaXEhyNHCwtFCpxWg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.5
+    dev: true
+
+  /@babel/helper-member-expression-to-functions@7.22.5:
+    resolution: {integrity: sha512-aBiH1NKMG0H2cGZqspNvsaBe6wNGjbJjuLy29aU+eDZjSbbN53BaxlpB02xm9v34pLTZ1nIQPFYn2qMZoa5BQQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.22.5
+
+  /@babel/helper-module-imports@7.18.6:
+    resolution: {integrity: sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.22.5
+    dev: true
 
   /@babel/helper-module-imports@7.21.4:
     resolution: {integrity: sha512-orajc5T2PsRYUN3ZryCEFeMDYwyw09c/pZeaQEZPH0MpKzSvn3e0uXsDBu3k03VI+9DBiRo+l22BfKTpKwa/Wg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.4
+      '@babel/types': 7.21.5
+
+  /@babel/helper-module-imports@7.22.5:
+    resolution: {integrity: sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.22.5
 
   /@babel/helper-module-transforms@7.21.5:
     resolution: {integrity: sha512-bI2Z9zBGY2q5yMHoBvJ2a9iX3ZOAzJPm7Q8Yz6YeoUjU/Cvhmi2G4QyTNyPBqqXSgTjUxRg3L0xV45HvkNWWBw==}
@@ -841,18 +943,51 @@ packages:
       '@babel/helper-module-imports': 7.21.4
       '@babel/helper-simple-access': 7.21.5
       '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/helper-validator-identifier': 7.22.5
+      '@babel/helper-validator-identifier': 7.19.1
       '@babel/template': 7.20.7
       '@babel/traverse': 7.21.5(supports-color@5.5.0)
-      '@babel/types': 7.22.4
+      '@babel/types': 7.21.5
     transitivePeerDependencies:
       - supports-color
+
+  /@babel/helper-module-transforms@7.22.9(@babel/core@7.12.9):
+    resolution: {integrity: sha512-t+WA2Xn5K+rTeGtC8jCsdAH52bjggG5TKRuRrAGNM/mjIbO4GxvlLMFOEz9wXY5I2XQ60PMFsAG2WIcG82dQMQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.12.9
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-module-imports': 7.22.5
+      '@babel/helper-simple-access': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/helper-validator-identifier': 7.22.5
+
+  /@babel/helper-module-transforms@7.22.9(@babel/core@7.21.5):
+    resolution: {integrity: sha512-t+WA2Xn5K+rTeGtC8jCsdAH52bjggG5TKRuRrAGNM/mjIbO4GxvlLMFOEz9wXY5I2XQ60PMFsAG2WIcG82dQMQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.21.5
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-module-imports': 7.22.5
+      '@babel/helper-simple-access': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/helper-validator-identifier': 7.22.5
 
   /@babel/helper-optimise-call-expression@7.18.6:
     resolution: {integrity: sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.5
+    dev: true
+
+  /@babel/helper-optimise-call-expression@7.22.5:
+    resolution: {integrity: sha512-HBwaojN0xFRx4yIvpwGqxiV2tUfl7401jlok564NgB9EHS1y6QT17FmKWm4ztqjeVdXLuC4fSvHc5ePpQjoTbw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.22.5
 
   /@babel/helper-plugin-utils@7.10.4:
     resolution: {integrity: sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==}
@@ -861,12 +996,16 @@ packages:
     resolution: {integrity: sha512-0WDaIlXKOX/3KfBK/dwP1oQGiPh6rjMkT7HIRv7i5RR2VUMwrx5ZL0dwBkKx7+SW1zwNdgjHd34IMk5ZjTeHVg==}
     engines: {node: '>=6.9.0'}
 
+  /@babel/helper-plugin-utils@7.22.5:
+    resolution: {integrity: sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==}
+    engines: {node: '>=6.9.0'}
+
   /@babel/helper-remap-async-to-generator@7.13.0:
     resolution: {integrity: sha512-pUQpFBE9JvC9lrQbpX0TmeNIy5s7GnZjna2lhhcHC7DzgBs6fWn722Y5cfwgrtrqc7NAJwMvOa0mKhq6XaE4jg==}
     dependencies:
-      '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-wrap-function': 7.13.0
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.5
     transitivePeerDependencies:
       - supports-color
 
@@ -874,14 +1013,26 @@ packages:
     resolution: {integrity: sha512-/y7vBgsr9Idu4M6MprbOVUfH3vs7tsIfnVWv/Ml2xgwvyH6LTngdfbf5AdsKwkJy4zgy1X/kuNrEKvhhK28Yrg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-environment-visitor': 7.21.5
-      '@babel/helper-member-expression-to-functions': 7.21.5
-      '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/template': 7.20.7
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-member-expression-to-functions': 7.22.5
+      '@babel/helper-optimise-call-expression': 7.22.5
+      '@babel/template': 7.22.5
       '@babel/traverse': 7.21.5(supports-color@5.5.0)
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.5
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@babel/helper-replace-supers@7.22.9(@babel/core@7.21.5):
+    resolution: {integrity: sha512-LJIKvvpgPOPUThdYqcX6IXRuIcTkcAub0IaDRGCZH0p5GPUp7PhRU9QVgFcDDd51BaPkk77ZjqFwh6DZTAEmGg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.21.5
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-member-expression-to-functions': 7.22.5
+      '@babel/helper-optimise-call-expression': 7.22.5
 
   /@babel/helper-simple-access@7.21.5:
     resolution: {integrity: sha512-ENPDAMC1wAjR0uaCUwliBdiSl1KBJAVnMTzXqi64c2MG8MPR6ii4qf7bSXDqSFbr4W6W028/rf5ivoHop5/mkg==}
@@ -889,11 +1040,24 @@ packages:
     dependencies:
       '@babel/types': 7.22.4
 
+  /@babel/helper-simple-access@7.22.5:
+    resolution: {integrity: sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.22.5
+
   /@babel/helper-skip-transparent-expression-wrappers@7.20.0:
     resolution: {integrity: sha512-5y1JYeNKfvnT8sZcK9DVRtpTbGiomYIHviSP3OQWmDPU3DeH4a1ZlT/N2lyQ5P8egjcRaT/Y9aNqUxK0WsnIIg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.5
+    dev: true
+
+  /@babel/helper-skip-transparent-expression-wrappers@7.22.5:
+    resolution: {integrity: sha512-tK14r66JZKiC43p8Ki33yLBVJKlQDFoA8GYN67lWCDCqoL6EMMSuM9b+Iff2jHaM/RRFYl7K+iiru7hbRqNx8Q==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.22.5
 
   /@babel/helper-split-export-declaration@7.18.6:
     resolution: {integrity: sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==}
@@ -901,8 +1065,22 @@ packages:
     dependencies:
       '@babel/types': 7.22.4
 
+  /@babel/helper-split-export-declaration@7.22.6:
+    resolution: {integrity: sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.22.5
+
   /@babel/helper-string-parser@7.21.5:
     resolution: {integrity: sha512-5pTUx3hAJaZIdW99sJ6ZUUgWq/Y+Hja7TowEnLNMm1VivRgZQL3vpBY3qUACVsvw+yQU6+YgfBVmcbLaZtrA1w==}
+    engines: {node: '>=6.9.0'}
+
+  /@babel/helper-string-parser@7.22.5:
+    resolution: {integrity: sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==}
+    engines: {node: '>=6.9.0'}
+
+  /@babel/helper-validator-identifier@7.19.1:
+    resolution: {integrity: sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==}
     engines: {node: '>=6.9.0'}
 
   /@babel/helper-validator-identifier@7.22.5:
@@ -913,13 +1091,17 @@ packages:
     resolution: {integrity: sha512-rmL/B8/f0mKS2baE9ZpyTcTavvEuWhTTW8amjzXNvYG4AwBsqTLikfXsEofsJEfKHf+HQVQbFOHy6o+4cnC/fQ==}
     engines: {node: '>=6.9.0'}
 
+  /@babel/helper-validator-option@7.22.5:
+    resolution: {integrity: sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==}
+    engines: {node: '>=6.9.0'}
+
   /@babel/helper-wrap-function@7.13.0:
     resolution: {integrity: sha512-1UX9F7K3BS42fI6qd2A4BjKzgGjToscyZTdp1DjknHLCIvpgne6918io+aL5LXFcER/8QWiwpoY902pVEqgTXA==}
     dependencies:
-      '@babel/helper-function-name': 7.21.0
-      '@babel/template': 7.20.7
+      '@babel/helper-function-name': 7.22.5
+      '@babel/template': 7.22.5
       '@babel/traverse': 7.21.5(supports-color@5.5.0)
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.5
     transitivePeerDependencies:
       - supports-color
 
@@ -929,9 +1111,17 @@ packages:
     dependencies:
       '@babel/template': 7.20.7
       '@babel/traverse': 7.21.5(supports-color@5.5.0)
-      '@babel/types': 7.22.4
+      '@babel/types': 7.21.5
     transitivePeerDependencies:
       - supports-color
+
+  /@babel/highlight@7.18.6:
+    resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-validator-identifier': 7.22.5
+      chalk: 2.4.2
+      js-tokens: 4.0.0
 
   /@babel/highlight@7.22.5:
     resolution: {integrity: sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==}
@@ -941,12 +1131,27 @@ packages:
       chalk: 2.4.2
       js-tokens: 4.0.0
 
+  /@babel/parser@7.21.5:
+    resolution: {integrity: sha512-J+IxH2IsxV4HbnTrSWgMAQj0UEo61hDA4Ny8h8PCX0MLXiibqHbqIOVneqdocemSBc22VpBKxt4J6FQzy9HarQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dependencies:
+      '@babel/types': 7.21.5
+
   /@babel/parser@7.22.4:
     resolution: {integrity: sha512-VLLsx06XkEYqBtE5YGPwfSGwfrjnyPP5oiGty3S8pQLFDFLaS8VwWSIxkTXpcvr5zeYLE6+MBNl2npl/YnfofA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
       '@babel/types': 7.22.4
+    dev: true
+
+  /@babel/parser@7.22.7:
+    resolution: {integrity: sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dependencies:
+      '@babel/types': 7.22.5
 
   /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.13.12(@babel/core@7.21.5):
     resolution: {integrity: sha512-d0u3zWKcoZf379fOeJdr1a5WPDny4aOFZ6hlfKivgK0LY7ZxNfoaHL2fWwdGtHyVvra38FC+HVYkO+byfSA8AQ==}
@@ -954,8 +1159,8 @@ packages:
       '@babel/core': ^7.13.0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
-      '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/plugin-proposal-optional-chaining': 7.13.12(@babel/core@7.21.5)
 
   /@babel/plugin-proposal-async-generator-functions@7.13.15(@babel/core@7.21.5):
@@ -964,7 +1169,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-remap-async-to-generator': 7.13.0
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.21.5)
     transitivePeerDependencies:
@@ -976,10 +1181,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-create-class-features-plugin': 7.21.5(@babel/core@7.21.5)
-      '@babel/helper-plugin-utils': 7.21.5
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-create-class-features-plugin': 7.22.9(@babel/core@7.21.5)
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-proposal-dynamic-import@7.13.8(@babel/core@7.21.5):
     resolution: {integrity: sha512-ONWKj0H6+wIRCkZi9zSbZtE/r73uOhMVHh256ys0UzfM7I3d4n+spZNWjOnJv2gzopumP2Wxi186vI8N0Y2JyQ==}
@@ -987,7 +1190,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.21.5)
 
   /@babel/plugin-proposal-export-default-from@7.12.13(@babel/core@7.21.5):
@@ -996,7 +1199,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-export-default-from': 7.12.13(@babel/core@7.21.5)
 
   /@babel/plugin-proposal-export-namespace-from@7.12.13(@babel/core@7.21.5):
@@ -1005,7 +1208,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.21.5)
 
   /@babel/plugin-proposal-json-strings@7.13.8(@babel/core@7.21.5):
@@ -1014,7 +1217,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.21.5)
 
   /@babel/plugin-proposal-logical-assignment-operators@7.13.8(@babel/core@7.21.5):
@@ -1023,7 +1226,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.21.5)
 
   /@babel/plugin-proposal-nullish-coalescing-operator@7.13.8(@babel/core@7.21.5):
@@ -1032,7 +1235,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.21.5)
 
   /@babel/plugin-proposal-numeric-separator@7.12.13(@babel/core@7.21.5):
@@ -1041,7 +1244,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.21.5)
 
   /@babel/plugin-proposal-object-rest-spread@7.12.1(@babel/core@7.12.9):
@@ -1050,7 +1253,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.12.9)
       '@babel/plugin-transform-parameters': 7.13.0(@babel/core@7.12.9)
 
@@ -1062,7 +1265,7 @@ packages:
       '@babel/compat-data': 7.21.5
       '@babel/core': 7.21.5
       '@babel/helper-compilation-targets': 7.21.5(@babel/core@7.21.5)
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.21.5)
       '@babel/plugin-transform-parameters': 7.13.0(@babel/core@7.21.5)
 
@@ -1072,7 +1275,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.21.5)
 
   /@babel/plugin-proposal-optional-chaining@7.13.12(@babel/core@7.21.5):
@@ -1081,8 +1284,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
-      '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.21.5)
 
   /@babel/plugin-proposal-private-methods@7.13.0(@babel/core@7.21.5):
@@ -1091,10 +1294,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-create-class-features-plugin': 7.21.5(@babel/core@7.21.5)
-      '@babel/helper-plugin-utils': 7.21.5
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-create-class-features-plugin': 7.22.9(@babel/core@7.21.5)
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-proposal-unicode-property-regex@7.12.13(@babel/core@7.21.5):
     resolution: {integrity: sha512-XyJmZidNfofEkqFV5VC/bLabGmO5QzenPO/YOfGuEbgU+2sSwMmio3YLb4WtBgcmmdwZHyVyv8on77IUjQ5Gvg==}
@@ -1104,7 +1305,7 @@ packages:
     dependencies:
       '@babel/core': 7.21.5
       '@babel/helper-create-regexp-features-plugin': 7.12.17(@babel/core@7.21.5)
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.21.5):
     resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
@@ -1112,7 +1313,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.21.5):
     resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
@@ -1120,7 +1321,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.21.5):
     resolution: {integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==}
@@ -1128,7 +1329,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-export-default-from@7.12.13(@babel/core@7.21.5):
     resolution: {integrity: sha512-gVry0zqoums0hA+EniCYK3gABhjYSLX1dVuwYpPw9DrLNA4/GovXySHVg4FGRsZht09ON/5C2NVx3keq+qqVGQ==}
@@ -1136,7 +1337,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.21.5):
     resolution: {integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==}
@@ -1144,7 +1345,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.21.5):
     resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
@@ -1152,7 +1353,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-jsx@7.12.1(@babel/core@7.12.9):
     resolution: {integrity: sha512-1yRi7yAtB0ETgxdY9ti/p2TivUxJkTdhu/ZbF9MshVGqOx1TdB3b7xCXs49Fupgg50N45KcAsRP/ZqWjs9SRjg==}
@@ -1160,7 +1361,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-jsx@7.21.4(@babel/core@7.21.5):
     resolution: {integrity: sha512-5hewiLct5OKyh6PLKEYaFclcqtIgCb6bmELouxjF6up5q3Sov7rOayW4RwhbaBL0dit8rA80GNfY+UuDp2mBbQ==}
@@ -1171,13 +1372,23 @@ packages:
       '@babel/core': 7.21.5
       '@babel/helper-plugin-utils': 7.21.5
 
+  /@babel/plugin-syntax-jsx@7.22.5(@babel/core@7.21.5):
+    resolution: {integrity: sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
+    dev: true
+
   /@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.21.5):
     resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.21.5):
     resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
@@ -1185,7 +1396,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.21.5):
     resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
@@ -1193,7 +1404,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.12.9):
     resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
@@ -1201,7 +1412,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.21.5):
     resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
@@ -1209,7 +1420,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.21.5):
     resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
@@ -1217,7 +1428,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.21.5):
     resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
@@ -1225,7 +1436,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-top-level-await@7.12.13(@babel/core@7.21.5):
     resolution: {integrity: sha512-A81F9pDwyS7yM//KwbCSDqy3Uj4NMIurtplxphWxoYtNPov7cJsDkAFNNyVlIZ3jwGycVsurZ+LtOA8gZ376iQ==}
@@ -1233,7 +1444,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-typescript@7.21.4(@babel/core@7.21.5):
     resolution: {integrity: sha512-xz0D39NvhQn4t4RNsHmDnnsaQizIlUkdtYvLs8La1BlfjQ6JEwxkJGeqJMW2tAXx+q6H+WFuUTXNdYVpEya0YA==}
@@ -1245,13 +1456,23 @@ packages:
       '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
+  /@babel/plugin-syntax-typescript@7.22.5(@babel/core@7.21.5):
+    resolution: {integrity: sha512-1mS2o03i7t1c6VzH6fdQ3OA8tcEIxwG18zIPRp+UY1Ihv6W+XZzBCVxExF9upussPXJ0xE9XRHwMoNs1ep/nRQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
+    dev: true
+
   /@babel/plugin-transform-arrow-functions@7.13.0(@babel/core@7.21.5):
     resolution: {integrity: sha512-96lgJagobeVmazXFaDrbmCLQxBysKu7U6Do3mLsx27gf5Dk85ezysrs2BZUpXD703U/Su1xTBDxxar2oa4jAGg==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-async-to-generator@7.13.0(@babel/core@7.21.5):
     resolution: {integrity: sha512-3j6E004Dx0K3eGmhxVJxwwI89CTJrce7lg3UrtFuDAVQ/2+SJ/h/aSFOeE6/n0WB1GsOffsJp6MnPQNQ8nmwhg==}
@@ -1259,8 +1480,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-module-imports': 7.21.4
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-module-imports': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-remap-async-to-generator': 7.13.0
     transitivePeerDependencies:
       - supports-color
@@ -1271,7 +1492,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-block-scoping@7.21.0(@babel/core@7.21.5):
     resolution: {integrity: sha512-Mdrbunoh9SxwFZapeHVrwFmri16+oYotcZysSzhNIVDwIAb1UV+kvnxULSYq9J3/q5MDG+4X6w8QVgD1zhBXNQ==}
@@ -1288,15 +1509,13 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-function-name': 7.21.0
-      '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/helper-plugin-utils': 7.21.5
-      '@babel/helper-replace-supers': 7.21.5
-      '@babel/helper-split-export-declaration': 7.18.6
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-function-name': 7.22.5
+      '@babel/helper-optimise-call-expression': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.21.5)
+      '@babel/helper-split-export-declaration': 7.22.6
       globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
 
   /@babel/plugin-transform-computed-properties@7.13.0(@babel/core@7.21.5):
     resolution: {integrity: sha512-RRqTYTeZkZAz8WbieLTvKUEUxZlUTdmL5KGMyZj7FnMfLNKV4+r5549aORG/mgojRmFlQMJDUupwAMiF2Q7OUg==}
@@ -1304,7 +1523,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-destructuring@7.13.17(@babel/core@7.21.5):
     resolution: {integrity: sha512-UAUqiLv+uRLO+xuBKKMEpC+t7YRNVRqBsWWq1yKXbBZBje/t3IXCiSinZhjn/DC3qzBfICeYd2EFGEbHsh5RLA==}
@@ -1312,7 +1531,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-dotall-regex@7.12.13(@babel/core@7.21.5):
     resolution: {integrity: sha512-foDrozE65ZFdUC2OfgeOCrEPTxdB3yjqxpXh8CH+ipd9CHd4s/iq81kcUpyH8ACGNEPdFqbtzfgzbT/ZGlbDeQ==}
@@ -1321,7 +1540,7 @@ packages:
     dependencies:
       '@babel/core': 7.21.5
       '@babel/helper-create-regexp-features-plugin': 7.12.17(@babel/core@7.21.5)
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-duplicate-keys@7.12.13(@babel/core@7.21.5):
     resolution: {integrity: sha512-NfADJiiHdhLBW3pulJlJI2NB0t4cci4WTZ8FtdIuNc2+8pslXdPtRRAEWqUY+m9kNOk2eRYbTAOipAxlrOcwwQ==}
@@ -1329,7 +1548,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-exponentiation-operator@7.12.13(@babel/core@7.21.5):
     resolution: {integrity: sha512-fbUelkM1apvqez/yYx1/oICVnGo2KM5s63mhGylrmXUxK/IAXSIf87QIxVfZldWf4QsOafY6vV3bX8aMHSvNrA==}
@@ -1338,7 +1557,7 @@ packages:
     dependencies:
       '@babel/core': 7.21.5
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.12.13
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-for-of@7.13.0(@babel/core@7.21.5):
     resolution: {integrity: sha512-IHKT00mwUVYE0zzbkDgNRP6SRzvfGCYsOxIRz8KsiaaHCcT9BWIkO+H9QRJseHBLOGBZkHUdHiqj6r0POsdytg==}
@@ -1346,7 +1565,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-function-name@7.12.13(@babel/core@7.21.5):
     resolution: {integrity: sha512-6K7gZycG0cmIwwF7uMK/ZqeCikCGVBdyP2J5SKNCXO5EOHcqi+z7Jwf8AmyDNcBgxET8DrEtCt/mPKPyAzXyqQ==}
@@ -1354,8 +1573,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-function-name': 7.21.0
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-function-name': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-literals@7.12.13(@babel/core@7.21.5):
     resolution: {integrity: sha512-FW+WPjSR7hiUxMcKqyNjP05tQ2kmBCdpEpZHY1ARm96tGQCCBvXKnpjILtDplUnJ/eHZ0lALLM+d2lMFSpYJrQ==}
@@ -1363,7 +1582,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-member-expression-literals@7.12.13(@babel/core@7.21.5):
     resolution: {integrity: sha512-kxLkOsg8yir4YeEPHLuO2tXP9R/gTjpuTOjshqSpELUN3ZAg2jfDnKUvzzJxObun38sw3wm4Uu69sX/zA7iRvg==}
@@ -1371,7 +1590,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-modules-amd@7.13.0(@babel/core@7.21.5):
     resolution: {integrity: sha512-EKy/E2NHhY/6Vw5d1k3rgoobftcNUmp9fGjb9XZwQLtTctsRBOTRO7RHHxfIky1ogMN5BxN7p9uMA3SzPfotMQ==}
@@ -1379,11 +1598,9 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-module-transforms': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.21.5)
+      '@babel/helper-plugin-utils': 7.22.5
       babel-plugin-dynamic-import-node: 2.3.3
-    transitivePeerDependencies:
-      - supports-color
 
   /@babel/plugin-transform-modules-commonjs@7.14.0(@babel/core@7.21.5):
     resolution: {integrity: sha512-EX4QePlsTaRZQmw9BsoPeyh5OCtRGIhwfLquhxGp5e32w+dyL8htOcDwamlitmNFK6xBZYlygjdye9dbd9rUlQ==}
@@ -1391,12 +1608,21 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-module-transforms': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
-      '@babel/helper-simple-access': 7.21.5
+      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.21.5)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-simple-access': 7.22.5
       babel-plugin-dynamic-import-node: 2.3.3
-    transitivePeerDependencies:
-      - supports-color
+
+  /@babel/plugin-transform-modules-commonjs@7.22.5(@babel/core@7.21.5):
+    resolution: {integrity: sha512-B4pzOXj+ONRmuaQTg05b3y/4DuFz3WcCNAXPLb2Q0GT0TrGKGxNKV4jwsXts+StaM0LQczZbOpj8o1DLPDJIiA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.5
+      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.21.5)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-simple-access': 7.22.5
 
   /@babel/plugin-transform-modules-systemjs@7.13.8(@babel/core@7.21.5):
     resolution: {integrity: sha512-hwqctPYjhM6cWvVIlOIe27jCIBgHCsdH2xCJVAYQm7V5yTMoilbVMi9f6wKg0rpQAOn6ZG4AOyvCqFF/hUh6+A==}
@@ -1405,12 +1631,10 @@ packages:
     dependencies:
       '@babel/core': 7.21.5
       '@babel/helper-hoist-variables': 7.18.6
-      '@babel/helper-module-transforms': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.21.5)
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-validator-identifier': 7.22.5
       babel-plugin-dynamic-import-node: 2.3.3
-    transitivePeerDependencies:
-      - supports-color
 
   /@babel/plugin-transform-modules-umd@7.13.0(@babel/core@7.21.5):
     resolution: {integrity: sha512-D/ILzAh6uyvkWjKKyFE/W0FzWwasv6vPTSqPcjxFqn6QpX3u8DjRVliq4F2BamO2Wee/om06Vyy+vPkNrd4wxw==}
@@ -1418,10 +1642,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-module-transforms': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.21.5)
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-named-capturing-groups-regex@7.12.13(@babel/core@7.21.5):
     resolution: {integrity: sha512-Xsm8P2hr5hAxyYblrfACXpQKdQbx4m2df9/ZZSQ8MAhsadw06+jW7s9zsSw6he+mJZXRlVMyEnVktJo4zjk1WA==}
@@ -1437,7 +1659,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-object-super@7.12.13(@babel/core@7.21.5):
     resolution: {integrity: sha512-JzYIcj3XtYspZDV8j9ulnoMPZZnF/Cj0LUxPOjR89BdBVx+zYJI9MdMIlUZjbXDX+6YVeS6I3e8op+qQ3BYBoQ==}
@@ -1445,10 +1667,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
-      '@babel/helper-replace-supers': 7.21.5
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.21.5)
 
   /@babel/plugin-transform-parameters@7.13.0(@babel/core@7.12.9):
     resolution: {integrity: sha512-Jt8k/h/mIwE2JFEOb3lURoY5C85ETcYPnbuAJ96zRBzh1XHtQZfs62ChZ6EP22QlC8c7Xqr9q+e1SU5qttwwjw==}
@@ -1456,7 +1676,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-parameters@7.13.0(@babel/core@7.21.5):
     resolution: {integrity: sha512-Jt8k/h/mIwE2JFEOb3lURoY5C85ETcYPnbuAJ96zRBzh1XHtQZfs62ChZ6EP22QlC8c7Xqr9q+e1SU5qttwwjw==}
@@ -1464,7 +1684,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-property-literals@7.12.13(@babel/core@7.21.5):
     resolution: {integrity: sha512-nqVigwVan+lR+g8Fj8Exl0UQX2kymtjcWfMOYM1vTYEKujeyv2SkMgazf2qNcK7l4SDiKyTA/nHCPqL4e2zo1A==}
@@ -1472,7 +1692,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-react-display-name@7.12.13(@babel/core@7.21.5):
     resolution: {integrity: sha512-MprESJzI9O5VnJZrL7gg1MpdqmiFcUv41Jc7SahxYsNP2kDkFqClxxTZq+1Qv4AFCamm+GXMRDQINNn+qrxmiA==}
@@ -1480,7 +1700,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-react-jsx-development@7.12.17(@babel/core@7.21.5):
     resolution: {integrity: sha512-BPjYV86SVuOaudFhsJR1zjgxxOhJDt6JHNoD48DxWEIxUCAMjV1ys6DYw4SDYZh0b1QsS2vfIA9t/ZsQGsDOUQ==}
@@ -1501,7 +1721,7 @@ packages:
       '@babel/helper-module-imports': 7.21.4
       '@babel/helper-plugin-utils': 7.21.5
       '@babel/plugin-syntax-jsx': 7.21.4(@babel/core@7.21.5)
-      '@babel/types': 7.22.4
+      '@babel/types': 7.21.5
 
   /@babel/plugin-transform-react-pure-annotations@7.12.1(@babel/core@7.21.5):
     resolution: {integrity: sha512-RqeaHiwZtphSIUZ5I85PEH19LOSzxfuEazoY7/pWASCAIBuATQzpSVD+eT6MebeeZT2F4eSL0u4vw6n4Nm0Mjg==}
@@ -1509,8 +1729,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-regenerator@7.13.15(@babel/core@7.21.5):
     resolution: {integrity: sha512-Bk9cOLSz8DiurcMETZ8E2YtIVJbFCPGW28DJWUakmyVWtQSm6Wsf0p4B4BfEr/eL2Nkhe/CICiUiMOCi1TPhuQ==}
@@ -1526,7 +1746,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-runtime@7.13.15(@babel/core@7.21.5):
     resolution: {integrity: sha512-d+ezl76gx6Jal08XngJUkXM4lFXK/5Ikl9Mh4HKDxSfGJXmZ9xG64XT2oivBzfxb/eQ62VfvoMkaCZUKJMVrBA==}
@@ -1534,8 +1754,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-module-imports': 7.21.4
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-module-imports': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
       babel-plugin-polyfill-corejs2: 0.2.0(@babel/core@7.21.5)
       babel-plugin-polyfill-corejs3: 0.2.0(@babel/core@7.21.5)
       babel-plugin-polyfill-regenerator: 0.2.0(@babel/core@7.21.5)
@@ -1549,7 +1769,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-spread@7.13.0(@babel/core@7.21.5):
     resolution: {integrity: sha512-V6vkiXijjzYeFmQTr3dBxPtZYLPcUfY34DebOU27jIl2M/Y8Egm52Hw82CSjjPqd54GTlJs5x+CR7HeNr24ckg==}
@@ -1557,8 +1777,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
-      '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
 
   /@babel/plugin-transform-sticky-regex@7.12.13(@babel/core@7.21.5):
     resolution: {integrity: sha512-Jc3JSaaWT8+fr7GRvQP02fKDsYk4K/lYwWq38r/UGfaxo89ajud321NH28KRQ7xy1Ybc0VUE5Pz8psjNNDUglg==}
@@ -1566,7 +1786,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-template-literals@7.13.0(@babel/core@7.21.5):
     resolution: {integrity: sha512-d67umW6nlfmr1iehCcBv69eSUSySk1EsIS8aTDX4Xo9qajAh6mYtcl4kJrBkGXuxZPEgVr7RVfAvNW6YQkd4Mw==}
@@ -1574,7 +1794,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-typeof-symbol@7.12.13(@babel/core@7.21.5):
     resolution: {integrity: sha512-eKv/LmUJpMnu4npgfvs3LiHhJua5fo/CysENxa45YCQXZwKnGCQKAg87bvoqSW1fFT+HA32l03Qxsm8ouTY3ZQ==}
@@ -1582,7 +1802,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-typescript@7.21.3(@babel/core@7.21.5):
     resolution: {integrity: sha512-RQxPz6Iqt8T0uw/WsJNReuBpWpBqs/n7mNo18sKLoTbMp+UrEekhH+pKSVC7gWz+DNjo9gryfV8YzCiT45RgMw==}
@@ -1599,13 +1819,26 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/plugin-transform-typescript@7.22.9(@babel/core@7.21.5):
+    resolution: {integrity: sha512-BnVR1CpKiuD0iobHPaM1iLvcwPYN2uVFAqoLVSpEDKWuOikoCv5HbKLxclhKYUXlWkX86DoZGtqI4XhbOsyrMg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.5
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-create-class-features-plugin': 7.22.9(@babel/core@7.21.5)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-typescript': 7.22.5(@babel/core@7.21.5)
+    dev: true
+
   /@babel/plugin-transform-unicode-escapes@7.12.13(@babel/core@7.21.5):
     resolution: {integrity: sha512-0bHEkdwJ/sN/ikBHfSmOXPypN/beiGqjo+o4/5K+vxEFNPRPdImhviPakMKG4x96l85emoa0Z6cDflsdBusZbw==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-unicode-regex@7.12.13(@babel/core@7.21.5):
     resolution: {integrity: sha512-mDRzSNY7/zopwisPZ5kM9XKCfhchqIYwAKRERtEnhYscZB79VRekuRSoYbN0+KVe3y8+q1h6A4svXtP7N+UoCA==}
@@ -1614,7 +1847,7 @@ packages:
     dependencies:
       '@babel/core': 7.21.5
       '@babel/helper-create-regexp-features-plugin': 7.12.17(@babel/core@7.21.5)
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/preset-env@7.13.15(@babel/core@7.21.5):
     resolution: {integrity: sha512-D4JAPMXcxk69PKe81jRJ21/fP/uYdcTZ3hJDF5QX2HSI9bBxxYw/dumdR6dGumhjxlprHPE4XWoPaqzZUVy2MA==}
@@ -1624,8 +1857,8 @@ packages:
       '@babel/compat-data': 7.21.5
       '@babel/core': 7.21.5
       '@babel/helper-compilation-targets': 7.21.5(@babel/core@7.21.5)
-      '@babel/helper-plugin-utils': 7.21.5
-      '@babel/helper-validator-option': 7.21.0
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-validator-option': 7.22.5
       '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.13.12(@babel/core@7.21.5)
       '@babel/plugin-proposal-async-generator-functions': 7.13.15(@babel/core@7.21.5)
       '@babel/plugin-proposal-class-properties': 7.13.0(@babel/core@7.21.5)
@@ -1667,7 +1900,7 @@ packages:
       '@babel/plugin-transform-literals': 7.12.13(@babel/core@7.21.5)
       '@babel/plugin-transform-member-expression-literals': 7.12.13(@babel/core@7.21.5)
       '@babel/plugin-transform-modules-amd': 7.13.0(@babel/core@7.21.5)
-      '@babel/plugin-transform-modules-commonjs': 7.14.0(@babel/core@7.21.5)
+      '@babel/plugin-transform-modules-commonjs': 7.22.5(@babel/core@7.21.5)
       '@babel/plugin-transform-modules-systemjs': 7.13.8(@babel/core@7.21.5)
       '@babel/plugin-transform-modules-umd': 7.13.0(@babel/core@7.21.5)
       '@babel/plugin-transform-named-capturing-groups-regex': 7.12.13(@babel/core@7.21.5)
@@ -1685,7 +1918,7 @@ packages:
       '@babel/plugin-transform-unicode-escapes': 7.12.13(@babel/core@7.21.5)
       '@babel/plugin-transform-unicode-regex': 7.12.13(@babel/core@7.21.5)
       '@babel/preset-modules': 0.1.4(@babel/core@7.21.5)
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.5
       babel-plugin-polyfill-corejs2: 0.2.0(@babel/core@7.21.5)
       babel-plugin-polyfill-corejs3: 0.2.0(@babel/core@7.21.5)
       babel-plugin-polyfill-regenerator: 0.2.0(@babel/core@7.21.5)
@@ -1700,10 +1933,10 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-proposal-unicode-property-regex': 7.12.13(@babel/core@7.21.5)
       '@babel/plugin-transform-dotall-regex': 7.12.13(@babel/core@7.21.5)
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.5
       esutils: 2.0.3
 
   /@babel/preset-react@7.13.13(@babel/core@7.21.5):
@@ -1712,8 +1945,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
-      '@babel/helper-validator-option': 7.21.0
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-validator-option': 7.22.5
       '@babel/plugin-transform-react-display-name': 7.12.13(@babel/core@7.21.5)
       '@babel/plugin-transform-react-jsx': 7.21.5(@babel/core@7.21.5)
       '@babel/plugin-transform-react-jsx-development': 7.12.17(@babel/core@7.21.5)
@@ -1721,6 +1954,20 @@ packages:
 
   /@babel/preset-stage-0@7.8.3:
     resolution: {integrity: sha512-+l6FlG1j73t4wh78W41StbcCz0/9a1/y+vxfnjtHl060kSmcgMfGzK9MEkLvrCOXfhp9RCX+d88sm6rOqxEIEQ==}
+
+  /@babel/preset-typescript@7.22.5(@babel/core@7.21.5):
+    resolution: {integrity: sha512-YbPaal9LxztSGhmndR46FmAbkJ/1fAsw293tSU+I5E5h+cnJ3d4GTwyUgGYmOXJYdGA+uNePle4qbaRzj2NISQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-validator-option': 7.22.5
+      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.21.5)
+      '@babel/plugin-transform-modules-commonjs': 7.22.5(@babel/core@7.21.5)
+      '@babel/plugin-transform-typescript': 7.22.9(@babel/core@7.21.5)
+    dev: true
 
   /@babel/register@7.13.16(@babel/core@7.21.5):
     resolution: {integrity: sha512-dh2t11ysujTwByQjXNgJ48QZ2zcXKQVdV8s0TbeMI0flmtGWCdTwK9tJiACHXPLmncm5+ktNn/diojA45JE4jg==}
@@ -1746,7 +1993,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.13.11
-    dev: false
 
   /@babel/runtime@7.22.5:
     resolution: {integrity: sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==}
@@ -1758,32 +2004,56 @@ packages:
     resolution: {integrity: sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==}
     engines: {node: '>=6.9.0'}
     dependencies:
+      '@babel/code-frame': 7.21.4
+      '@babel/parser': 7.21.5
+      '@babel/types': 7.21.5
+
+  /@babel/template@7.22.5:
+    resolution: {integrity: sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
       '@babel/code-frame': 7.22.5
-      '@babel/parser': 7.22.4
-      '@babel/types': 7.22.4
+      '@babel/parser': 7.22.7
+      '@babel/types': 7.22.5
 
   /@babel/traverse@7.21.5(supports-color@5.5.0):
     resolution: {integrity: sha512-AhQoI3YjWi6u/y/ntv7k48mcrCXmus0t79J9qPNlk/lAsFlCiJ047RmbfMOawySTHtywXhbXgpx/8nXMYd+oFw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.22.5
+      '@babel/code-frame': 7.21.4
       '@babel/generator': 7.21.5
       '@babel/helper-environment-visitor': 7.21.5
       '@babel/helper-function-name': 7.21.0
       '@babel/helper-hoist-variables': 7.18.6
       '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/parser': 7.22.4
-      '@babel/types': 7.22.4
+      '@babel/parser': 7.21.5
+      '@babel/types': 7.21.5
       debug: 4.3.4(supports-color@5.5.0)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
+
+  /@babel/types@7.21.5:
+    resolution: {integrity: sha512-m4AfNvVF2mVC/F7fDEdH2El3HzUg9It/XsCxZiOTTA3m3qYfcSVSbTfM6Q9xG+hYDniZssYhlXKKUMD5m8tF4Q==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.21.5
+      '@babel/helper-validator-identifier': 7.19.1
+      to-fast-properties: 2.0.0
 
   /@babel/types@7.22.4:
     resolution: {integrity: sha512-Tx9x3UBHTTsMSW85WB2kphxYQVvrZ/t1FxD88IpSgIjiUJlCm9z+xWIDwyo1vffTwSqteqyznB8ZE9vYYk16zA==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-string-parser': 7.21.5
+      '@babel/helper-validator-identifier': 7.22.5
+      to-fast-properties: 2.0.0
+
+  /@babel/types@7.22.5:
+    resolution: {integrity: sha512-zo3MIHGOkPOfoRXitsgHLjEXmlDaD/5KU1Uzuc9GNiZPhSqVxVRtxuPaSBZDsYZ9qV88AjtMtWW7ww98loJ9KA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.22.5
       '@babel/helper-validator-identifier': 7.22.5
       to-fast-properties: 2.0.0
 
@@ -1855,7 +2125,7 @@ packages:
       p-limit: 2.3.0
       preferred-pm: 3.0.3
       resolve-from: 5.0.0
-      semver: 7.5.4
+      semver: 7.5.3
       spawndamnit: 2.0.0
       term-size: 2.2.1
       tty-table: 4.2.1
@@ -2086,7 +2356,7 @@ packages:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
     dependencies:
       eslint: 8.46.0
-      eslint-visitor-keys: 3.4.2
+      eslint-visitor-keys: 3.4.3
     dev: true
 
   /@eslint-community/regexpp@4.6.2:
@@ -2094,8 +2364,8 @@ packages:
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
     dev: true
 
-  /@eslint/eslintrc@2.1.1:
-    resolution: {integrity: sha512-9t7ZA7NGGK8ckelF0PQCfcxIUzs1Md5rrO6U/c+FIQNanea5UZC0wqKXH4vHBccmu4ZJgZ2idtPeW7+Q2npOEA==}
+  /@eslint/eslintrc@2.1.2:
+    resolution: {integrity: sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
@@ -2111,8 +2381,8 @@ packages:
       - supports-color
     dev: true
 
-  /@eslint/js@8.46.0:
-    resolution: {integrity: sha512-a8TLtmPi8xzPkCbp/OGFUo5yhRkHM2Ko9kOWP4znJr0WAhWyThaw3PnwX4vOTWOAMsV2uRt32PPDcEz63esSaA==}
+  /@eslint/js@8.47.0:
+    resolution: {integrity: sha512-P6omY1zv5MItm93kLM8s2vr1HICJH8v0dvddDhysbIuZ+vcjOHg5Zbkf1mTkcmi2JA9oBG2anOkRnW8WJTS8Og==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
@@ -2144,6 +2414,20 @@ packages:
     resolution: {integrity: sha512-SQ7Kzhh9+D+ZW9MA0zkYv3VXhIDNx+LzM6EJ+/65I3QY+enU6Itte7E5XX7EWrqLW2FN4n06GWzBnPoC3th2aQ==}
     dev: true
 
+  /@jest/expect-utils@29.6.1:
+    resolution: {integrity: sha512-o319vIf5pEMx0LmzSxxkYYxo4wrRLKHq9dP1yJU7FoPTB0LfAKSz8SWD6D/6U3v/O52t9cF5t+MeJiRsfk7zMw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      jest-get-type: 29.4.3
+    dev: true
+
+  /@jest/schemas@29.6.0:
+    resolution: {integrity: sha512-rxLjXyJBTL4LQeJW3aKo0M/+GkCOXsO+8i9Iu7eDb6KwtP65ayoDsitrdPBtujxQ88k4wI2FNYfa6TOGwSn6cQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@sinclair/typebox': 0.27.8
+    dev: true
+
   /@jest/types@26.6.2:
     resolution: {integrity: sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==}
     engines: {node: '>= 10.14.2'}
@@ -2152,6 +2436,18 @@ packages:
       '@types/istanbul-reports': 3.0.0
       '@types/node': 18.16.3
       '@types/yargs': 15.0.13
+      chalk: 4.1.2
+    dev: true
+
+  /@jest/types@29.6.1:
+    resolution: {integrity: sha512-tPKQNMPuXgvdOn2/Lg9HNfUvjYVGolt04Hp03f5hAk878uwOLikN+JzeLY0HcVgKgFl9Hs3EIqpu3WX27XNhnw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/schemas': 29.6.0
+      '@types/istanbul-lib-coverage': 2.0.3
+      '@types/istanbul-reports': 3.0.0
+      '@types/node': 18.16.3
+      '@types/yargs': 17.0.24
       chalk: 4.1.2
     dev: true
 
@@ -2448,7 +2744,7 @@ packages:
       promise-all-reject-late: 1.0.1
       promise-call-limit: 1.0.1
       read-package-json-fast: 3.0.2
-      semver: 7.5.4
+      semver: 7.5.0
       ssri: 10.0.1
       treeverse: 3.0.0
       walk-up-path: 1.0.0
@@ -2484,7 +2780,7 @@ packages:
       promise-inflight: 1.0.1(bluebird@3.7.2)
       promise-retry: 2.0.1
       semver: 7.5.4
-      which: 3.0.1
+      which: 3.0.0
     transitivePeerDependencies:
       - bluebird
     dev: true
@@ -2551,7 +2847,7 @@ packages:
     resolution: {integrity: sha512-gGq0NJkIGSwdbUt4yhdF8ZrmkGKVz9vAdVzpOfnom+V8PLSmSOVhZwbNvZZS1EYcJN5hzzKBxmmVVAInM6HQLg==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
-      which: 3.0.1
+      which: 3.0.0
     dev: true
 
   /@npmcli/query@3.0.0:
@@ -2569,7 +2865,7 @@ packages:
       '@npmcli/promise-spawn': 6.0.2
       node-gyp: 9.3.1
       read-package-json-fast: 3.0.2
-      which: 3.0.1
+      which: 3.0.0
     transitivePeerDependencies:
       - bluebird
       - supports-color
@@ -2805,7 +3101,7 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@types/estree': 1.0.1
+      '@types/estree': 1.0.0
       estree-walker: 2.0.2
       picomatch: 2.3.1
       rollup: 3.21.1
@@ -2816,9 +3112,41 @@ packages:
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dev: true
 
+  /@sinclair/typebox@0.27.8:
+    resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
+    dev: true
+
   /@sindresorhus/is@0.7.0:
     resolution: {integrity: sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==}
     engines: {node: '>=4'}
+
+  /@solid-primitives/utils@6.2.0(solid-js@1.7.7):
+    resolution: {integrity: sha512-T62WlLwKkbmicsw/xpwMQyv9MmZRSaVyutXfS5icc9v0cb8qGMUxRxr5LVvZHYQCZ9DEFboZB0r711xsbVBbeA==}
+    peerDependencies:
+      solid-js: ^1.6.12
+    dependencies:
+      solid-js: 1.7.7
+    dev: false
+
+  /@solidjs/router@0.8.2(solid-js@1.7.7):
+    resolution: {integrity: sha512-gUKW+LZqxtX6y/Aw6JKyy4gQ9E7dLqp513oB9pSYJR1HM5c56Pf7eijzyXX+b3WuXig18Cxqah4tMtF0YGu80w==}
+    peerDependencies:
+      solid-js: ^1.5.3
+    dependencies:
+      solid-js: 1.7.7
+    dev: true
+
+  /@solidjs/testing-library@0.8.2(@solidjs/router@0.8.2)(solid-js@1.7.7):
+    resolution: {integrity: sha512-2fV484Y1WWERjro6iwDl9mtKE/UWyS+qJHeLs88gwR/jbNgk/ADRaqFx8dHPxLj5wJmLBO1v5xJhySS8uGljpA==}
+    engines: {node: '>= 14'}
+    peerDependencies:
+      '@solidjs/router': '>=0.6.0'
+      solid-js: '>=1.0.0'
+    dependencies:
+      '@solidjs/router': 0.8.2(solid-js@1.7.7)
+      '@testing-library/dom': 9.3.1
+      solid-js: 1.7.7
+    dev: true
 
   /@swc/helpers@0.4.11:
     resolution: {integrity: sha512-rEUrBSGIoSFuYxwBYtlUFMlE2CwGhmW+w9355/5oduSw8e5h2+Tj4UrAGNNgP9915++wj5vkQo0UuOBqOAq4nw==}
@@ -2835,9 +3163,38 @@ packages:
       '@types/aria-query': 4.2.1
       aria-query: 4.2.2
       chalk: 4.1.2
-      dom-accessibility-api: 0.5.4
-      lz-string: 1.4.4
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
       pretty-format: 26.6.2
+    dev: true
+
+  /@testing-library/dom@9.3.1:
+    resolution: {integrity: sha512-0DGPd9AR3+iDTjGoMpxIkAsUihHZ3Ai6CneU6bRRrffXMgzCdlNk43jTrD2/5LT6CBb3MWTP8v510JzYtahD2w==}
+    engines: {node: '>=14'}
+    dependencies:
+      '@babel/code-frame': 7.22.5
+      '@babel/runtime': 7.22.5
+      '@types/aria-query': 5.0.1
+      aria-query: 5.1.3
+      chalk: 4.1.2
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      pretty-format: 27.5.1
+    dev: true
+
+  /@testing-library/jest-dom@5.16.5:
+    resolution: {integrity: sha512-N5ixQ2qKpi5OLYfwQmUb/5mSV9LneAcaUfp32pn4yCnpb8r/Yz0pXFPck21dIicKmi+ta5WRAknkZCfA8refMA==}
+    engines: {node: '>=8', npm: '>=6', yarn: '>=1'}
+    dependencies:
+      '@adobe/css-tools': 4.2.0
+      '@babel/runtime': 7.22.5
+      '@types/testing-library__jest-dom': 5.14.8
+      aria-query: 5.3.0
+      chalk: 3.0.0
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.5.16
+      lodash: 4.17.21
+      redent: 3.0.0
     dev: true
 
   /@testing-library/preact@2.0.1(preact@10.13.1):
@@ -2862,7 +3219,7 @@ packages:
       react-test-renderer:
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.5
+      '@babel/runtime': 7.21.0
       '@types/react': 17.0.52
       '@types/react-dom': 18.2.4
       '@types/react-test-renderer': 17.0.1
@@ -2880,7 +3237,7 @@ packages:
       react: '*'
       react-dom: '*'
     dependencies:
-      '@babel/runtime': 7.22.5
+      '@babel/runtime': 7.21.0
       '@testing-library/dom': 7.30.4
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -2902,14 +3259,55 @@ packages:
     resolution: {integrity: sha512-S6oPal772qJZHoRZLFc/XoZW2gFvwXusYUmXPXkgxJLuEk2vOt7jc4Yo6z/vtI0EBkbPBVrJJ0B+prLIKiWqHg==}
     dev: true
 
+  /@types/aria-query@5.0.1:
+    resolution: {integrity: sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==}
+    dev: true
+
+  /@types/babel__core@7.20.1:
+    resolution: {integrity: sha512-aACu/U/omhdk15O4Nfb+fHgH/z3QsfQzpnvRZhYhThms83ZnAOZz7zZAWO7mn2yyNQaA4xTO8GLK3uqFU4bYYw==}
+    dependencies:
+      '@babel/parser': 7.22.4
+      '@babel/types': 7.22.4
+      '@types/babel__generator': 7.6.4
+      '@types/babel__template': 7.4.1
+      '@types/babel__traverse': 7.20.1
+    dev: true
+
+  /@types/babel__generator@7.6.4:
+    resolution: {integrity: sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==}
+    dependencies:
+      '@babel/types': 7.22.4
+    dev: true
+
+  /@types/babel__template@7.4.1:
+    resolution: {integrity: sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==}
+    dependencies:
+      '@babel/parser': 7.22.4
+      '@babel/types': 7.22.4
+    dev: true
+
+  /@types/babel__traverse@7.20.1:
+    resolution: {integrity: sha512-MitHFXnhtgwsGZWtT68URpOvLN4EREih1u3QtQiN4VdAxWKRVvGCSvw/Qth0M0Qq3pJpnGOu5JaM/ydK7OGbqg==}
+    dependencies:
+      '@babel/types': 7.22.4
+    dev: true
+
   /@types/chai-subset@1.3.3:
     resolution: {integrity: sha512-frBecisrNGz+F4T6bcc+NLeolfiojh5FxW2klu669+8BARtyQv2C/GkNW6FUodVe4BroGMP/wER/YDGc7rEllw==}
     dependencies:
-      '@types/chai': 4.3.4
+      '@types/chai': 4.3.5
     dev: true
 
   /@types/chai@4.3.4:
     resolution: {integrity: sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==}
+    dev: true
+
+  /@types/chai@4.3.5:
+    resolution: {integrity: sha512-mEo1sAde+UCE6b2hxn332f1g1E8WfYRu6p5SvTKr2ZKC1f7gFJXk4h5PyGP9Dt6gCaG8y8XhwnXWC6Iy2cmBng==}
+    dev: true
+
+  /@types/estree@1.0.0:
+    resolution: {integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==}
     dev: true
 
   /@types/estree@1.0.1:
@@ -2947,6 +3345,13 @@ packages:
     resolution: {integrity: sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==}
     dependencies:
       '@types/istanbul-lib-report': 3.0.0
+    dev: true
+
+  /@types/jest@29.5.3:
+    resolution: {integrity: sha512-1Nq7YrO/vJE/FYnqYyw0FS8LdrjExSgIiHyKg7xPpn+yi8Q4huZryKnkJatN1ZRH89Kw2v33/8ZMB7DuZeSLlA==}
+    dependencies:
+      expect: 29.6.1
+      pretty-format: 29.6.1
     dev: true
 
   /@types/json-schema@7.0.12:
@@ -3042,6 +3447,16 @@ packages:
     resolution: {integrity: sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==}
     dev: true
 
+  /@types/stack-utils@2.0.1:
+    resolution: {integrity: sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==}
+    dev: true
+
+  /@types/testing-library__jest-dom@5.14.8:
+    resolution: {integrity: sha512-NRfJE9Cgpmu4fx716q9SYmU4jxxhYRU1BQo239Txt/9N3EC745XZX1Yl7h/SBIDlo1ANVOCRB4YDXjaQdoKCHQ==}
+    dependencies:
+      '@types/jest': 29.5.3
+    dev: true
+
   /@types/unist@2.0.3:
     resolution: {integrity: sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==}
 
@@ -3051,6 +3466,12 @@ packages:
 
   /@types/yargs@15.0.13:
     resolution: {integrity: sha512-kQ5JNTrbDv3Rp5X2n/iUu37IJBDU2gsZ5R/g1/KHOOEc5IKfUFjXT6DENPGduh08I/pamwtEq4oul7gUqKTQDQ==}
+    dependencies:
+      '@types/yargs-parser': 20.2.0
+    dev: true
+
+  /@types/yargs@17.0.24:
+    resolution: {integrity: sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==}
     dependencies:
       '@types/yargs-parser': 20.2.0
     dev: true
@@ -3192,7 +3613,7 @@ packages:
     engines: {node: ^16.0.0 || >=18.0.0}
     dependencies:
       '@typescript-eslint/types': 6.2.1
-      eslint-visitor-keys: 3.4.2
+      eslint-visitor-keys: 3.4.3
     dev: true
 
   /@vitest/expect@0.30.1:
@@ -3203,10 +3624,27 @@ packages:
       chai: 4.3.7
     dev: true
 
+  /@vitest/expect@0.32.2:
+    resolution: {integrity: sha512-6q5yzweLnyEv5Zz1fqK5u5E83LU+gOMVBDuxBl2d2Jfx1BAp5M+rZgc5mlyqdnxquyoiOXpXmFNkcGcfFnFH3Q==}
+    dependencies:
+      '@vitest/spy': 0.32.2
+      '@vitest/utils': 0.32.2
+      chai: 4.3.7
+    dev: true
+
   /@vitest/runner@0.30.1:
     resolution: {integrity: sha512-W62kT/8i0TF1UBCNMRtRMOBWJKRnNyv9RrjIgdUryEe0wNpGZvvwPDLuzYdxvgSckzjp54DSpv1xUbv4BQ0qVA==}
     dependencies:
       '@vitest/utils': 0.30.1
+      concordance: 5.0.4
+      p-limit: 4.0.0
+      pathe: 1.1.0
+    dev: true
+
+  /@vitest/runner@0.32.2:
+    resolution: {integrity: sha512-06vEL0C1pomOEktGoLjzZw+1Fb+7RBRhmw/06WkDrd1akkT9i12su0ku+R/0QM69dfkIL/rAIDTG+CSuQVDcKw==}
+    dependencies:
+      '@vitest/utils': 0.32.2
       concordance: 5.0.4
       p-limit: 4.0.0
       pathe: 1.1.0
@@ -3220,8 +3658,22 @@ packages:
       pretty-format: 27.5.1
     dev: true
 
+  /@vitest/snapshot@0.32.2:
+    resolution: {integrity: sha512-JwhpeH/PPc7GJX38vEfCy9LtRzf9F4er7i4OsAJyV7sjPwjj+AIR8cUgpMTWK4S3TiamzopcTyLsZDMuldoi5A==}
+    dependencies:
+      magic-string: 0.30.0
+      pathe: 1.1.0
+      pretty-format: 27.5.1
+    dev: true
+
   /@vitest/spy@0.30.1:
     resolution: {integrity: sha512-YfJeIf37GvTZe04ZKxzJfnNNuNSmTEGnla2OdL60C8od16f3zOfv9q9K0nNii0NfjDJRt/CVN/POuY5/zTS+BA==}
+    dependencies:
+      tinyspy: 2.1.0
+    dev: true
+
+  /@vitest/spy@0.32.2:
+    resolution: {integrity: sha512-Q/ZNILJ4ca/VzQbRM8ur3Si5Sardsh1HofatG9wsJY1RfEaw0XKP8IVax2lI1qnrk9YPuG9LA2LkZ0EI/3d4ug==}
     dependencies:
       tinyspy: 2.1.0
     dev: true
@@ -3234,10 +3686,18 @@ packages:
       pretty-format: 27.5.1
     dev: true
 
+  /@vitest/utils@0.32.2:
+    resolution: {integrity: sha512-lnJ0T5i03j0IJaeW73hxe2AuVnZ/y1BhhCOuIcl9LIzXnbpXJT9Lrt6brwKHXLOiA7MZ6N5hSJjt0xE1dGNCzQ==}
+    dependencies:
+      diff-sequences: 29.4.3
+      loupe: 2.3.6
+      pretty-format: 27.5.1
+    dev: true
+
   /@vue/compiler-core@3.2.47:
     resolution: {integrity: sha512-p4D7FDnQb7+YJmO2iPEv0SQNeNzcbHdGByJDsT4lynf63AFkOTFN07HsiRSvjGo0QrxR/o3d0hUyNCUnBU2Tig==}
     dependencies:
-      '@babel/parser': 7.22.4
+      '@babel/parser': 7.22.7
       '@vue/shared': 3.2.47
       estree-walker: 2.0.2
       source-map: 0.6.1
@@ -3246,7 +3706,7 @@ packages:
   /@vue/compiler-core@3.3.4:
     resolution: {integrity: sha512-cquyDNvZ6jTbf/+x+AgM2Arrp6G4Dzbb0R64jiG804HRMfRiFXWI6kqUVqZ6ZR0bQhIoQjB4+2bhNtVwndW15g==}
     dependencies:
-      '@babel/parser': 7.22.4
+      '@babel/parser': 7.22.7
       '@vue/shared': 3.3.4
       estree-walker: 2.0.2
       source-map-js: 1.0.2
@@ -3271,7 +3731,7 @@ packages:
   /@vue/compiler-sfc@3.2.47:
     resolution: {integrity: sha512-rog05W+2IFfxjMcFw10tM9+f7i/+FFpZJJ5XHX72NP9eC2uRD+42M3pYcQqDXVYoj74kHMSEdQ/WmCjt8JFksQ==}
     dependencies:
-      '@babel/parser': 7.22.4
+      '@babel/parser': 7.22.7
       '@vue/compiler-core': 3.2.47
       '@vue/compiler-dom': 3.2.47
       '@vue/compiler-ssr': 3.2.47
@@ -3301,7 +3761,7 @@ packages:
   /@vue/reactivity-transform@3.2.47:
     resolution: {integrity: sha512-m8lGXw8rdnPVVIdIFhf0LeQ/ixyHkH5plYuS83yop5n7ggVJU+z5v0zecwEnX7fa7HNLBhh2qngJJkxpwEEmYA==}
     dependencies:
-      '@babel/parser': 7.22.4
+      '@babel/parser': 7.22.7
       '@vue/compiler-core': 3.2.47
       '@vue/shared': 3.2.47
       estree-walker: 2.0.2
@@ -3555,6 +4015,12 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  /acorn@8.8.2:
+    resolution: {integrity: sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+    dev: true
+
   /after@0.8.2:
     resolution: {integrity: sha512-QbJ0NTQ/I9DI3uSJA4cbexiwQeRAfjPScqIbSjUDd9TOrcg6pTkdgziesOqxBMBzit8vFCTwrP27t13vFOORRA==}
 
@@ -3656,8 +4122,8 @@ packages:
     resolution: {integrity: sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==}
     engines: {node: '>=4'}
 
-  /ansi-regex@4.1.1:
-    resolution: {integrity: sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==}
+  /ansi-regex@4.1.0:
+    resolution: {integrity: sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==}
     engines: {node: '>=6'}
 
   /ansi-regex@5.0.1:
@@ -3759,6 +4225,18 @@ packages:
       '@babel/runtime-corejs3': 7.13.17
     dev: true
 
+  /aria-query@5.1.3:
+    resolution: {integrity: sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==}
+    dependencies:
+      deep-equal: 2.2.2
+    dev: true
+
+  /aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+    dependencies:
+      dequal: 2.0.3
+    dev: true
+
   /arr-diff@4.0.0:
     resolution: {integrity: sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==}
     engines: {node: '>=0.10.0'}
@@ -3789,7 +4267,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.2.0
-      es-abstract: 1.22.1
+      es-abstract: 1.21.2
       get-intrinsic: 1.2.1
       is-string: 1.0.7
     dev: true
@@ -3819,7 +4297,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.2.0
-      es-abstract: 1.22.1
+      es-abstract: 1.21.2
       es-shim-unscopables: 1.0.0
     dev: true
 
@@ -3829,7 +4307,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.2.0
-      es-abstract: 1.22.1
+      es-abstract: 1.21.2
       es-shim-unscopables: 1.0.0
     dev: true
 
@@ -3838,21 +4316,10 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.2.0
-      es-abstract: 1.22.1
+      es-abstract: 1.21.2
       es-shim-unscopables: 1.0.0
       get-intrinsic: 1.2.1
     dev: true
-
-  /arraybuffer.prototype.slice@1.0.1:
-    resolution: {integrity: sha512-09x0ZWFEjj4WD8PDbykUwo3t9arLn8NIzmmYEJFpYekOAQjpkGSyrQhNoRTcwwcFRu+ycWF78QZ63oWTqSjBcw==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      array-buffer-byte-length: 1.0.0
-      call-bind: 1.0.2
-      define-properties: 1.2.0
-      get-intrinsic: 1.2.1
-      is-array-buffer: 3.0.2
-      is-shared-array-buffer: 1.0.2
 
   /arraybuffer.slice@0.0.7:
     resolution: {integrity: sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==}
@@ -4001,6 +4468,19 @@ packages:
     dependencies:
       '@babel/helper-plugin-utils': 7.10.4
 
+  /babel-plugin-jsx-dom-expressions@0.36.10(@babel/core@7.21.5):
+    resolution: {integrity: sha512-QA2k/14WGw+RgcGGnEuLWwnu4em6CGhjeXtjvgOYyFHYS2a+CzPeaVQHDOlfuiBcjq/3hWMspHMIMnPEOIzdBg==}
+    peerDependencies:
+      '@babel/core': ^7.20.12
+    dependencies:
+      '@babel/core': 7.21.5
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.21.5)
+      '@babel/types': 7.22.4
+      html-entities: 2.3.3
+      validate-html-nesting: 1.2.2
+    dev: true
+
   /babel-plugin-macros@2.8.0:
     resolution: {integrity: sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==}
     dependencies:
@@ -4046,8 +4526,8 @@ packages:
     peerDependencies:
       styled-components: '>= 2 || 5'
     dependencies:
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-module-imports': 7.21.4
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-module-imports': 7.22.5
       babel-plugin-syntax-jsx: 6.18.0
       lodash: 4.17.21
       styled-components: 5.2.3(react-dom@17.0.2)(react-is@17.0.2)(react@17.0.2)
@@ -4072,8 +4552,17 @@ packages:
     peerDependencies:
       webpack: ^4.4.0
     dependencies:
-      '@babel/helper-module-imports': 7.21.4
+      '@babel/helper-module-imports': 7.22.5
       webpack: 4.46.0
+
+  /babel-preset-solid@1.7.7(@babel/core@7.21.5):
+    resolution: {integrity: sha512-tdxVzx3kgcIjNXAOmGRbzIhFBPeJjSakiN9yM+IYdL/+LtXNnbGqb0Va5tJb8Sjbk+QVEriovCyuzB5T7jeTvg==}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.21.5
+      babel-plugin-jsx-dom-expressions: 0.36.10(@babel/core@7.21.5)
+    dev: true
 
   /babel-runtime@6.26.0:
     resolution: {integrity: sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==}
@@ -4665,6 +5154,14 @@ packages:
       escape-string-regexp: 1.0.5
       supports-color: 5.5.0
 
+  /chalk@3.0.0:
+    resolution: {integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==}
+    engines: {node: '>=8'}
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+    dev: true
+
   /chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -5090,7 +5587,7 @@ packages:
     dependencies:
       date-time: 3.1.0
       esutils: 2.0.3
-      fast-diff: 1.3.0
+      fast-diff: 1.2.0
       js-string-escape: 1.0.1
       lodash: 4.17.21
       md5-hex: 3.0.1
@@ -5266,7 +5763,7 @@ packages:
     dependencies:
       nice-try: 1.0.5
       path-key: 2.0.1
-      semver: 5.7.2
+      semver: 5.7.1
       shebang-command: 1.2.0
       which: 1.3.1
 
@@ -5382,6 +5879,10 @@ packages:
     engines: {node: '>= 6'}
     dev: true
 
+  /css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+    dev: true
+
   /cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -5470,6 +5971,9 @@ packages:
     resolution: {integrity: sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==}
     dev: true
 
+  /csstype@3.1.2:
+    resolution: {integrity: sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==}
+
   /csv-generate@3.4.3:
     resolution: {integrity: sha512-w/T+rqR0vwvHqWs/1ZyMDWtHHSJaN06klRqJXBEpDJaM/+dZkso0OKh1VcuuYvK3XM53KysVNq8Ko/epCK8wOw==}
     dev: true
@@ -5538,7 +6042,7 @@ packages:
       pretty-bytes: 5.6.0
       proxy-from-env: 1.0.0
       request-progress: 3.0.0
-      semver: 7.5.4
+      semver: 7.5.0
       supports-color: 8.1.1
       tmp: 0.2.1
       untildify: 4.0.0
@@ -5757,12 +6261,35 @@ packages:
   /deep-equal@1.1.1:
     resolution: {integrity: sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==}
     dependencies:
-      is-arguments: 1.1.0
+      is-arguments: 1.1.1
       is-date-object: 1.0.5
       is-regex: 1.1.4
       object-is: 1.1.5
       object-keys: 1.1.1
       regexp.prototype.flags: 1.5.0
+
+  /deep-equal@2.2.2:
+    resolution: {integrity: sha512-xjVyBf0w5vH0I42jdAZzOKVldmPgSulmiyPRywoyq7HXC9qdgo17kxJE+rdnif5Tz6+pIrpJI8dCpMNLIGkUiA==}
+    dependencies:
+      array-buffer-byte-length: 1.0.0
+      call-bind: 1.0.2
+      es-get-iterator: 1.1.3
+      get-intrinsic: 1.2.1
+      is-arguments: 1.1.1
+      is-array-buffer: 3.0.2
+      is-date-object: 1.0.5
+      is-regex: 1.1.4
+      is-shared-array-buffer: 1.0.2
+      isarray: 2.0.5
+      object-is: 1.1.5
+      object-keys: 1.1.1
+      object.assign: 4.1.4
+      regexp.prototype.flags: 1.5.0
+      side-channel: 1.0.4
+      which-boxed-primitive: 1.0.2
+      which-collection: 1.0.1
+      which-typed-array: 1.1.9
+    dev: true
 
   /deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
@@ -5878,6 +6405,11 @@ packages:
     resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
     dev: false
 
+  /dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+    dev: true
+
   /des.js@1.0.1:
     resolution: {integrity: sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==}
     dependencies:
@@ -5899,6 +6431,11 @@ packages:
 
   /detect-node@2.0.5:
     resolution: {integrity: sha512-qi86tE6hRcFHy8jI1m2VG+LaPUR1LhqDa5G8tVjuUXmOrpuAgqsA1pN0+ldgr3aKUH+QLI9hCY/OcRYisERejw==}
+
+  /diff-sequences@29.4.3:
+    resolution: {integrity: sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dev: true
 
   /diffie-hellman@5.0.3:
     resolution: {integrity: sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==}
@@ -5942,8 +6479,8 @@ packages:
       esutils: 2.0.3
     dev: true
 
-  /dom-accessibility-api@0.5.4:
-    resolution: {integrity: sha512-TvrjBckDy2c6v6RLxPv5QXOnU+SmF9nBII5621Ve5fu6Z/BDrENurBEvlC1f44lKEUVqOpK4w9E5Idc5/EgkLQ==}
+  /dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
     dev: true
 
   /dom-converter@0.2.0:
@@ -6077,7 +6614,7 @@ packages:
     dependencies:
       commander: 2.20.3
       lru-cache: 4.1.5
-      semver: 5.7.2
+      semver: 5.7.1
       sigmund: 1.0.1
     dev: true
 
@@ -6232,12 +6769,11 @@ packages:
     dependencies:
       is-arrayish: 0.2.1
 
-  /es-abstract@1.22.1:
-    resolution: {integrity: sha512-ioRRcXMO6OFyRpyzV3kE1IIBd4WG5/kltnzdxSCqoP8CMGs/Li+M1uF5o7lOkZVFjDs+NLesthnF66Pg/0q0Lw==}
+  /es-abstract@1.21.2:
+    resolution: {integrity: sha512-y/B5POM2iBnIxCiernH1G7rC9qQoM77lLIMQLuob0zhp8C56Po81+2Nj0WFKnd0pNReDTnkYryc+zhOzpEIROg==}
     engines: {node: '>= 0.4'}
     dependencies:
       array-buffer-byte-length: 1.0.0
-      arraybuffer.prototype.slice: 1.0.1
       available-typed-arrays: 1.0.5
       call-bind: 1.0.2
       es-set-tostringtag: 2.0.1
@@ -6258,23 +6794,33 @@ packages:
       is-regex: 1.1.4
       is-shared-array-buffer: 1.0.2
       is-string: 1.0.7
-      is-typed-array: 1.1.12
+      is-typed-array: 1.1.10
       is-weakref: 1.0.2
       object-inspect: 1.12.3
       object-keys: 1.1.1
       object.assign: 4.1.4
       regexp.prototype.flags: 1.5.0
-      safe-array-concat: 1.0.0
       safe-regex-test: 1.0.0
       string.prototype.trim: 1.2.7
       string.prototype.trimend: 1.0.6
       string.prototype.trimstart: 1.0.6
-      typed-array-buffer: 1.0.0
-      typed-array-byte-length: 1.0.0
-      typed-array-byte-offset: 1.0.0
       typed-array-length: 1.0.4
       unbox-primitive: 1.0.2
-      which-typed-array: 1.1.11
+      which-typed-array: 1.1.9
+
+  /es-get-iterator@1.1.3:
+    resolution: {integrity: sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==}
+    dependencies:
+      call-bind: 1.0.2
+      get-intrinsic: 1.2.1
+      has-symbols: 1.0.3
+      is-arguments: 1.1.1
+      is-map: 2.0.2
+      is-set: 2.0.2
+      is-string: 1.0.7
+      isarray: 2.0.5
+      stop-iteration-iterator: 1.0.0
+    dev: true
 
   /es-set-tostringtag@2.0.1:
     resolution: {integrity: sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==}
@@ -6519,6 +7065,11 @@ packages:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
 
+  /escape-string-regexp@2.0.0:
+    resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
+    engines: {node: '>=8'}
+    dev: true
+
   /escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
@@ -6596,7 +7147,7 @@ packages:
       doctrine: 2.1.0
       eslint: 8.46.0
       estraverse: 5.3.0
-      jsx-ast-utils: 3.3.5
+      jsx-ast-utils: 3.3.3
       minimatch: 3.1.2
       object.entries: 1.1.6
       object.fromentries: 2.0.6
@@ -6623,8 +7174,8 @@ packages:
       estraverse: 5.3.0
     dev: true
 
-  /eslint-visitor-keys@3.4.2:
-    resolution: {integrity: sha512-8drBzUEyZ2llkpCA67iYrgEssKDUu68V8ChqqOfFupIaG/LCVPUT+CoGJpT77zJprs4T/W7p07LP7zAIMuweVw==}
+  /eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
@@ -6635,8 +7186,8 @@ packages:
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.46.0)
       '@eslint-community/regexpp': 4.6.2
-      '@eslint/eslintrc': 2.1.1
-      '@eslint/js': 8.46.0
+      '@eslint/eslintrc': 2.1.2
+      '@eslint/js': 8.47.0
       '@humanwhocodes/config-array': 0.11.10
       '@humanwhocodes/module-importer': 1.0.1
       '@nodelib/fs.walk': 1.2.8
@@ -6647,7 +7198,7 @@ packages:
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
-      eslint-visitor-keys: 3.4.2
+      eslint-visitor-keys: 3.4.3
       espree: 9.6.1
       esquery: 1.5.0
       esutils: 2.0.3
@@ -6680,7 +7231,7 @@ packages:
     dependencies:
       acorn: 8.10.0
       acorn-jsx: 5.3.2(acorn@8.10.0)
-      eslint-visitor-keys: 3.4.2
+      eslint-visitor-keys: 3.4.3
     dev: true
 
   /esprima@4.0.1:
@@ -6855,6 +7406,18 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /expect@29.6.1:
+    resolution: {integrity: sha512-XEdDLonERCU1n9uR56/Stx9OqojaLAQtZf9PrCHH9Hl8YXiEIka3H4NXJ3NOIBmQJTg7+j7buh34PMHfJujc8g==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/expect-utils': 29.6.1
+      '@types/node': 18.16.3
+      jest-get-type: 29.4.3
+      jest-matcher-utils: 29.6.1
+      jest-message-util: 29.6.1
+      jest-util: 29.6.1
+    dev: true
+
   /express@4.17.1(supports-color@6.1.0):
     resolution: {integrity: sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==}
     engines: {node: '>= 0.10.0'}
@@ -6985,8 +7548,19 @@ packages:
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  /fast-diff@1.3.0:
-    resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
+  /fast-diff@1.2.0:
+    resolution: {integrity: sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==}
+    dev: true
+
+  /fast-glob@3.2.12:
+    resolution: {integrity: sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==}
+    engines: {node: '>=8.6.0'}
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.5
     dev: true
 
   /fast-glob@3.3.1:
@@ -7342,7 +7916,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       at-least-node: 1.0.0
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       jsonfile: 6.1.0
       universalify: 2.0.0
     dev: true
@@ -7412,7 +7986,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.2.0
-      es-abstract: 1.22.1
+      es-abstract: 1.21.2
       functions-have-names: 1.2.3
 
   /functions-have-names@1.2.3:
@@ -7564,6 +8138,16 @@ packages:
       is-glob: 4.0.3
     dev: true
 
+  /glob@7.1.6:
+    resolution: {integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==}
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.2
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+
   /glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     dependencies:
@@ -7631,7 +8215,7 @@ packages:
     dependencies:
       array-union: 2.1.0
       dir-glob: 3.0.1
-      fast-glob: 3.3.1
+      fast-glob: 3.2.12
       ignore: 5.2.4
       merge2: 1.4.1
       slash: 3.0.0
@@ -7679,6 +8263,10 @@ packages:
       timed-out: 4.0.1
       url-parse-lax: 3.0.0
       url-to-options: 1.0.1
+
+  /graceful-fs@4.2.10:
+    resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
+    dev: true
 
   /graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -7901,7 +8489,7 @@ packages:
   /history@4.10.1:
     resolution: {integrity: sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==}
     dependencies:
-      '@babel/runtime': 7.22.5
+      '@babel/runtime': 7.21.0
       loose-envify: 1.4.0
       resolve-pathname: 3.0.0
       tiny-invariant: 1.1.0
@@ -7959,6 +8547,10 @@ packages:
 
   /html-entities@1.4.0:
     resolution: {integrity: sha512-8nxjcBcd8wovbeKx7h3wTji4e6+rhaVuPNpMqwWgnHh+N9ToqsCs6XztWRBPQ+UtzsoMAdKZtUENoVzU/EMtZA==}
+
+  /html-entities@2.3.3:
+    resolution: {integrity: sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==}
+    dev: true
 
   /html-minifier@3.5.21:
     resolution: {integrity: sha512-LKUKwuJDhxNa3uf/LPR/KVjm/l3rBqtYeCOAekvG8F1vItxMUpueGd94i/asDDr8/1u7InxzFA5EeGjhhG5mMA==}
@@ -8379,18 +8971,19 @@ packages:
       is-alphabetical: 1.0.4
       is-decimal: 1.0.4
 
-  /is-arguments@1.1.0:
-    resolution: {integrity: sha512-1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==}
+  /is-arguments@1.1.1:
+    resolution: {integrity: sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
+      has-tostringtag: 1.0.0
 
   /is-array-buffer@3.0.2:
     resolution: {integrity: sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==}
     dependencies:
       call-bind: 1.0.2
       get-intrinsic: 1.2.1
-      is-typed-array: 1.1.12
+      is-typed-array: 1.1.10
 
   /is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
@@ -8589,6 +9182,10 @@ packages:
     resolution: {integrity: sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==}
     dev: true
 
+  /is-map@2.0.2:
+    resolution: {integrity: sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==}
+    dev: true
+
   /is-module@1.0.0:
     resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
     dev: true
@@ -8687,6 +9284,10 @@ packages:
     resolution: {integrity: sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==}
     engines: {node: '>=0.10.0'}
 
+  /is-set@2.0.2:
+    resolution: {integrity: sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==}
+    dev: true
+
   /is-shared-array-buffer@1.0.2:
     resolution: {integrity: sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==}
     dependencies:
@@ -8725,11 +9326,15 @@ packages:
     dependencies:
       has-symbols: 1.0.3
 
-  /is-typed-array@1.1.12:
-    resolution: {integrity: sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==}
+  /is-typed-array@1.1.10:
+    resolution: {integrity: sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==}
     engines: {node: '>= 0.4'}
     dependencies:
-      which-typed-array: 1.1.11
+      available-typed-arrays: 1.0.5
+      call-bind: 1.0.2
+      for-each: 0.3.3
+      gopd: 1.0.1
+      has-tostringtag: 1.0.0
 
   /is-typedarray@1.0.0:
     resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
@@ -8740,10 +9345,26 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /is-weakmap@2.0.1:
+    resolution: {integrity: sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==}
+    dev: true
+
   /is-weakref@1.0.2:
     resolution: {integrity: sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==}
     dependencies:
       call-bind: 1.0.2
+
+  /is-weakset@2.0.2:
+    resolution: {integrity: sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==}
+    dependencies:
+      call-bind: 1.0.2
+      get-intrinsic: 1.2.1
+    dev: true
+
+  /is-what@4.1.15:
+    resolution: {integrity: sha512-uKua1wfy3Yt+YqsD6mTUEa2zSi3G1oPlqTflgaPJ7z63vUGN5pxFpnQfeSLMFnJDEsdvOtkp1rUWkYjB4YfhgA==}
+    engines: {node: '>=12.13'}
+    dev: true
 
   /is-whitespace-character@1.0.4:
     resolution: {integrity: sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w==}
@@ -8778,6 +9399,7 @@ packages:
 
   /isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
+    dev: true
 
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -8802,6 +9424,58 @@ packages:
     dependencies:
       has-to-string-tag-x: 1.4.1
       is-object: 1.0.2
+
+  /jest-diff@29.6.1:
+    resolution: {integrity: sha512-FsNCvinvl8oVxpNLttNQX7FAq7vR+gMDGj90tiP7siWw1UdakWUGqrylpsYrpvj908IYckm5Y0Q7azNAozU1Kg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      chalk: 4.1.2
+      diff-sequences: 29.4.3
+      jest-get-type: 29.4.3
+      pretty-format: 29.6.1
+    dev: true
+
+  /jest-get-type@29.4.3:
+    resolution: {integrity: sha512-J5Xez4nRRMjk8emnTpWrlkyb9pfRQQanDrvWHhsR1+VUfbwxi30eVcZFlcdGInRibU4G5LwHXpI7IRHU0CY+gg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dev: true
+
+  /jest-matcher-utils@29.6.1:
+    resolution: {integrity: sha512-SLaztw9d2mfQQKHmJXKM0HCbl2PPVld/t9Xa6P9sgiExijviSp7TnZZpw2Fpt+OI3nwUO/slJbOfzfUMKKC5QA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      chalk: 4.1.2
+      jest-diff: 29.6.1
+      jest-get-type: 29.4.3
+      pretty-format: 29.6.1
+    dev: true
+
+  /jest-message-util@29.6.1:
+    resolution: {integrity: sha512-KoAW2zAmNSd3Gk88uJ56qXUWbFk787QKmjjJVOjtGFmmGSZgDBrlIL4AfQw1xyMYPNVD7dNInfIbur9B2rd/wQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@babel/code-frame': 7.22.5
+      '@jest/types': 29.6.1
+      '@types/stack-utils': 2.0.1
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      micromatch: 4.0.5
+      pretty-format: 29.6.1
+      slash: 3.0.0
+      stack-utils: 2.0.6
+    dev: true
+
+  /jest-util@29.6.1:
+    resolution: {integrity: sha512-NRFCcjc+/uO3ijUVyNOQJluf8PtGCe/W6cix36+M3cTFgiYqFOOW5MgN4JOOcvbUhcKTYVd1CvHz/LWi8d16Mg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/types': 29.6.1
+      '@types/node': 18.16.3
+      chalk: 4.1.2
+      ci-info: 3.8.0
+      graceful-fs: 4.2.11
+      picomatch: 2.3.1
+    dev: true
 
   /js-beautify@1.14.6:
     resolution: {integrity: sha512-GfofQY5zDp+cuHc+gsEXKPpNw2KbPddreEo35O6jT6i0RVK6LhsoYBhq5TvK4/n74wnA0QbK8gGd+jUZwTMKJw==}
@@ -8850,7 +9524,7 @@ packages:
         optional: true
     dependencies:
       abab: 2.0.6
-      acorn: 8.10.0
+      acorn: 8.8.2
       acorn-globals: 7.0.1
       cssstyle: 3.0.0
       data-urls: 4.0.0
@@ -8863,6 +9537,44 @@ packages:
       https-proxy-agent: 5.0.1
       is-potential-custom-element-name: 1.0.1
       nwsapi: 2.2.2
+      parse5: 7.1.2
+      rrweb-cssom: 0.6.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 4.1.2
+      w3c-xmlserializer: 4.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 2.0.0
+      whatwg-mimetype: 3.0.0
+      whatwg-url: 12.0.1
+      ws: 8.13.0
+      xml-name-validator: 4.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: true
+
+  /jsdom@22.1.0:
+    resolution: {integrity: sha512-/9AVW7xNbsBv6GfWho4TTNjEo9fe6Zhf9O7s0Fhhr3u+awPwAJMKwAMXnkk5vBxflqLW9hTHX/0cs+P3gW+cQw==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      canvas: ^2.5.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+    dependencies:
+      abab: 2.0.6
+      cssstyle: 3.0.0
+      data-urls: 4.0.0
+      decimal.js: 10.4.3
+      domexception: 4.0.0
+      form-data: 4.0.0
+      html-encoding-sniffer: 3.0.0
+      http-proxy-agent: 5.0.0
+      https-proxy-agent: 5.0.1
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.7
       parse5: 7.1.2
       rrweb-cssom: 0.6.0
       saxes: 6.0.0
@@ -8987,14 +9699,12 @@ packages:
       verror: 1.10.0
     dev: true
 
-  /jsx-ast-utils@3.3.5:
-    resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
+  /jsx-ast-utils@3.3.3:
+    resolution: {integrity: sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==}
     engines: {node: '>=4.0'}
     dependencies:
       array-includes: 3.1.6
-      array.prototype.flat: 1.3.1
       object.assign: 4.1.4
-      object.values: 1.1.6
     dev: true
 
   /just-diff-apply@5.5.0:
@@ -9315,8 +10025,8 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
-  /lz-string@1.4.4:
-    resolution: {integrity: sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==}
+  /lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
     dev: true
 
@@ -9351,7 +10061,7 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       pify: 4.0.1
-      semver: 5.7.2
+      semver: 5.7.1
 
   /make-dir@3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
@@ -9540,6 +10250,13 @@ packages:
       trim-newlines: 3.0.1
       type-fest: 0.13.1
       yargs-parser: 18.1.3
+    dev: true
+
+  /merge-anything@5.1.7:
+    resolution: {integrity: sha512-eRtbOb1N5iyH0tkQDAoQ4Ipsp/5qSR79Dzrz8hEPxRX10RWWR/iQXdoKmBSRCThY1Fh5EhISDtpSc93fpxUniQ==}
+    engines: {node: '>=12.13'}
+    dependencies:
+      is-what: 4.1.15
     dev: true
 
   /merge-descriptors@1.0.1:
@@ -10111,7 +10828,7 @@ packages:
     dependencies:
       hosted-git-info: 2.8.9
       resolve: 1.22.2
-      semver: 5.7.2
+      semver: 5.7.1
       validate-npm-package-license: 3.0.4
     dev: true
 
@@ -10306,6 +11023,10 @@ packages:
     resolution: {integrity: sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==}
     dev: true
 
+  /nwsapi@2.2.7:
+    resolution: {integrity: sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==}
+    dev: true
+
   /oauth-sign@0.9.0:
     resolution: {integrity: sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==}
     dev: true
@@ -10357,7 +11078,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.2.0
-      es-abstract: 1.22.1
+      es-abstract: 1.21.2
     dev: true
 
   /object.fromentries@2.0.6:
@@ -10366,7 +11087,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.2.0
-      es-abstract: 1.22.1
+      es-abstract: 1.21.2
     dev: true
 
   /object.getownpropertydescriptors@2.1.2:
@@ -10375,13 +11096,13 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.2.0
-      es-abstract: 1.22.1
+      es-abstract: 1.21.2
 
   /object.hasown@1.1.2:
     resolution: {integrity: sha512-B5UIT3J1W+WuWIU55h0mjlwaqxiE5vYENJXIXZ4VFe05pNYrkKuK0U/6aFcb0pKywYJh7IhfoqUfKVmrJJHZHw==}
     dependencies:
       define-properties: 1.2.0
-      es-abstract: 1.22.1
+      es-abstract: 1.21.2
     dev: true
 
   /object.pick@1.3.0:
@@ -10396,7 +11117,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.2.0
-      es-abstract: 1.22.1
+      es-abstract: 1.21.2
 
   /obuf@1.1.2:
     resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
@@ -11303,7 +12024,7 @@ packages:
     resolution: {integrity: sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==}
     engines: {node: '>=6.0.0'}
     dependencies:
-      fast-diff: 1.3.0
+      fast-diff: 1.2.0
     dev: true
 
   /prettier@2.8.8:
@@ -11344,6 +12065,15 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+    dev: true
+
+  /pretty-format@29.6.1:
+    resolution: {integrity: sha512-7jRj+yXO0W7e4/tSJKoR7HRIHLPPjtNaUGG2xxKQnGvPNRkgWcQ0AZX6P4KBRJN4FcTBWb3sa7DVUJmocYuoog==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/schemas': 29.6.0
       ansi-styles: 5.2.0
       react-is: 17.0.2
     dev: true
@@ -11697,7 +12427,7 @@ packages:
     peerDependencies:
       react: '>=15 || 17'
     dependencies:
-      '@babel/runtime': 7.22.5
+      '@babel/runtime': 7.21.0
       history: 4.10.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -11722,7 +12452,7 @@ packages:
     peerDependencies:
       react: '>=15 || 17'
     dependencies:
-      '@babel/runtime': 7.22.5
+      '@babel/runtime': 7.21.0
       history: 4.10.1
       hoist-non-react-statics: 3.3.2
       loose-envify: 1.4.0
@@ -11781,7 +12511,7 @@ packages:
       '@mdx-js/mdx': 1.6.22
       '@mdx-js/react': 1.6.22(react@17.0.2)
       github-slugger: 1.3.0
-      glob: 7.2.3
+      glob: 7.1.6
       loader-utils: 1.4.0
       mdast-util-to-string: 1.1.0
       react-static: 7.3.0(react-hot-loader@4.13.0)
@@ -11838,7 +12568,7 @@ packages:
       '@babel/preset-react': 7.13.13(@babel/core@7.21.5)
       '@babel/preset-stage-0': 7.8.3
       '@babel/register': 7.13.16(@babel/core@7.21.5)
-      '@babel/runtime': 7.22.5
+      '@babel/runtime': 7.21.0
       '@reach/router': 1.3.4(react-dom@17.0.2)(react@17.0.2)
       autoprefixer: 9.8.6
       axios: 0.19.2
@@ -11858,7 +12588,7 @@ packages:
       file-loader: 3.0.1(webpack@4.46.0)
       fs-extra: 7.0.1
       git-promise: 0.3.1
-      glob: 7.2.3
+      glob: 7.1.6
       gunzip-maybe: 1.4.2
       html-webpack-plugin: 3.2.0(webpack@4.46.0)
       inquirer: 6.5.2
@@ -12320,6 +13050,15 @@ packages:
     resolution: {integrity: sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==}
     deprecated: https://github.com/lydell/resolve-url#deprecated
 
+  /resolve@1.22.1:
+    resolution: {integrity: sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==}
+    hasBin: true
+    dependencies:
+      is-core-module: 2.12.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+    dev: true
+
   /resolve@1.22.2:
     resolution: {integrity: sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==}
     hasBin: true
@@ -12446,7 +13185,7 @@ packages:
       picomatch: 2.3.1
       rollup: 3.21.1
       source-map: 0.7.4
-      yargs: 17.7.2
+      yargs: 17.7.1
     dev: true
 
   /rollup@2.79.1:
@@ -12502,15 +13241,6 @@ packages:
     dependencies:
       tslib: 2.6.1
     dev: true
-
-  /safe-array-concat@1.0.0:
-    resolution: {integrity: sha512-9dVEFruWIsnie89yym+xWTAYASdpw3CJV7Li/6zBewGf9z2i1j31rP6jnY0pHEO4QZh6N0K11bFjWmdR8UGdPQ==}
-    engines: {node: '>=0.4'}
-    dependencies:
-      call-bind: 1.0.2
-      get-intrinsic: 1.2.1
-      has-symbols: 1.0.3
-      isarray: 2.0.5
 
   /safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
@@ -12588,8 +13318,12 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /semver@5.7.2:
-    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
+  /semver@5.7.1:
+    resolution: {integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==}
+    hasBin: true
+
+  /semver@6.3.0:
+    resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==}
     hasBin: true
 
   /semver@6.3.1:
@@ -12599,6 +13333,22 @@ packages:
   /semver@7.0.0:
     resolution: {integrity: sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==}
     hasBin: true
+
+  /semver@7.5.0:
+    resolution: {integrity: sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      lru-cache: 6.0.0
+    dev: true
+
+  /semver@7.5.3:
+    resolution: {integrity: sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      lru-cache: 6.0.0
+    dev: true
 
   /semver@7.5.4:
     resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
@@ -12638,6 +13388,10 @@ packages:
     dependencies:
       randombytes: 2.1.0
     dev: true
+
+  /seroval@0.5.1:
+    resolution: {integrity: sha512-ZfhQVB59hmIauJG5Ydynupy8KHyr5imGNtdDhbZG68Ufh1Ynkv9KOYOAABf71oVbQxJ8VkWnMHAjEHE7fWkH5g==}
+    engines: {node: '>=10'}
 
   /serve-handler@6.1.3:
     resolution: {integrity: sha512-FosMqFBNrLyeiIDvP1zgO6YoTzFYHxLDEIavhlmQ+knB2Z7l1t+kGLHkZIDN7UVWqQAmKI3D20A6F6jo3nDd4w==}
@@ -12977,6 +13731,23 @@ packages:
       smart-buffer: 4.2.0
     dev: true
 
+  /solid-js@1.7.7:
+    resolution: {integrity: sha512-SPdYVke/Z6Za24PBTbULyQYPrhGO1ZbPany76atO2zF2dmYn2pCotbsw1JtlgWnr9dK2JbwPGnA3ODTGPLhZNw==}
+    dependencies:
+      csstype: 3.1.2
+      seroval: 0.5.1
+
+  /solid-refresh@0.5.3(solid-js@1.7.7):
+    resolution: {integrity: sha512-Otg5it5sjOdZbQZJnvo99TEBAr6J7PQ5AubZLNU6szZzg3RQQ5MX04oteBIIGDs0y2Qv8aXKm9e44V8z+UnFdw==}
+    peerDependencies:
+      solid-js: ^1.3
+    dependencies:
+      '@babel/generator': 7.21.5
+      '@babel/helper-module-imports': 7.21.4
+      '@babel/types': 7.22.4
+      solid-js: 1.7.7
+    dev: true
+
   /sort-keys-length@1.0.1:
     resolution: {integrity: sha512-GRbEOUqCxemTAk/b32F2xa8wDTs+Z1QHOkbhJDQTvv/6G3ZkbJ+frYWsTcc7cBB3Fu4wy4XlLCuNtJuMn7Gsvw==}
     engines: {node: '>=0.10.0'}
@@ -13150,6 +13921,13 @@ packages:
     resolution: {integrity: sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==}
     deprecated: 'Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility'
 
+  /stack-utils@2.0.6:
+    resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      escape-string-regexp: 2.0.0
+    dev: true
+
   /stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
     dev: true
@@ -13170,6 +13948,13 @@ packages:
 
   /std-env@3.3.2:
     resolution: {integrity: sha512-uUZI65yrV2Qva5gqE0+A7uVAvO40iPo6jGhs7s8keRfHCmtg+uB2X6EiLGCI9IgL1J17xGhvoOqSz79lzICPTA==}
+    dev: true
+
+  /stop-iteration-iterator@1.0.0:
+    resolution: {integrity: sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      internal-slot: 1.0.5
     dev: true
 
   /stream-browserify@2.0.2:
@@ -13241,7 +14026,7 @@ packages:
     dependencies:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
-      strip-ansi: 7.1.0
+      strip-ansi: 7.0.1
     dev: true
 
   /string.prototype.matchall@4.0.8:
@@ -13249,7 +14034,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.2.0
-      es-abstract: 1.22.1
+      es-abstract: 1.21.2
       get-intrinsic: 1.2.1
       has-symbols: 1.0.3
       internal-slot: 1.0.5
@@ -13263,7 +14048,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.2.0
-      es-abstract: 1.22.1
+      es-abstract: 1.21.2
     dev: true
 
   /string.prototype.trim@1.2.7:
@@ -13272,21 +14057,21 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.2.0
-      es-abstract: 1.22.1
+      es-abstract: 1.21.2
 
   /string.prototype.trimend@1.0.6:
     resolution: {integrity: sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==}
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.2.0
-      es-abstract: 1.22.1
+      es-abstract: 1.21.2
 
   /string.prototype.trimstart@1.0.6:
     resolution: {integrity: sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==}
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.2.0
-      es-abstract: 1.22.1
+      es-abstract: 1.21.2
 
   /string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
@@ -13324,7 +14109,7 @@ packages:
     resolution: {integrity: sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==}
     engines: {node: '>=6'}
     dependencies:
-      ansi-regex: 4.1.1
+      ansi-regex: 4.1.0
 
   /strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -13333,8 +14118,8 @@ packages:
       ansi-regex: 5.0.1
     dev: true
 
-  /strip-ansi@7.1.0:
-    resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
+  /strip-ansi@7.0.1:
+    resolution: {integrity: sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==}
     engines: {node: '>=12'}
     dependencies:
       ansi-regex: 6.0.1
@@ -13553,7 +14338,7 @@ packages:
     engines: {node: ^14.18.0 || >=16.0.0}
     dependencies:
       '@pkgr/utils': 2.4.2
-      tslib: 2.6.1
+      tslib: 2.5.0
     dev: true
 
   /tapable@1.1.3:
@@ -13654,7 +14439,7 @@ packages:
     hasBin: true
     dependencies:
       '@jridgewell/source-map': 0.3.2
-      acorn: 8.10.0
+      acorn: 8.8.2
       commander: 2.20.3
       source-map-support: 0.5.21
     dev: true
@@ -13709,8 +14494,17 @@ packages:
     resolution: {integrity: sha512-iyziEiyFxX4kyxSp+MtY1oCH/lvjH3PxFN8PGCDeqcZWAJ/i+9y+nL85w99PxVzrIvew/GSkSbDYtiGVa85Afg==}
     dev: true
 
+  /tinybench@2.5.0:
+    resolution: {integrity: sha512-kRwSG8Zx4tjF9ZiyH4bhaebu+EDz1BOx9hOigYHlUW4xxI/wKIUQUqo018UlU4ar6ATPBsaMrdbKZ+tmPdohFA==}
+    dev: true
+
   /tinypool@0.4.0:
     resolution: {integrity: sha512-2ksntHOKf893wSAH4z/+JbPpi92esw8Gn9N2deXX+B0EO92hexAVI9GIZZPx7P5aYo5KULfeOSt3kMOmSOy6uA==}
+    engines: {node: '>=14.0.0'}
+    dev: true
+
+  /tinypool@0.5.0:
+    resolution: {integrity: sha512-paHQtnrlS1QZYKF/GnLoOM/DN9fqaGOFbCbxzAhwniySnzl9Ebk8w73/dd34DAhe/obUbPAOldTyYXQZxnPBPQ==}
     engines: {node: '>=14.0.0'}
     dev: true
 
@@ -13879,6 +14673,10 @@ packages:
   /tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
+  /tslib@2.5.0:
+    resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
+    dev: true
+
   /tslib@2.6.1:
     resolution: {integrity: sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==}
     dev: true
@@ -13974,39 +14772,12 @@ packages:
       media-typer: 0.3.0
       mime-types: 2.1.35
 
-  /typed-array-buffer@1.0.0:
-    resolution: {integrity: sha512-Y8KTSIglk9OZEr8zywiIHG/kmQ7KWyjseXs1CbSo8vC42w7hg2HgYTxSWwP0+is7bWDc1H+Fo026CpHFwm8tkw==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: 1.0.2
-      get-intrinsic: 1.2.1
-      is-typed-array: 1.1.12
-
-  /typed-array-byte-length@1.0.0:
-    resolution: {integrity: sha512-Or/+kvLxNpeQ9DtSydonMxCx+9ZXOswtwJn17SNLvhptaXYDJvkFFP5zbfU/uLmvnBJlI4yrnXRxpdWH/M5tNA==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: 1.0.2
-      for-each: 0.3.3
-      has-proto: 1.0.1
-      is-typed-array: 1.1.12
-
-  /typed-array-byte-offset@1.0.0:
-    resolution: {integrity: sha512-RD97prjEt9EL8YgAgpOkf3O4IF9lhJFr9g0htQkm0rchFp/Vx7LW5Q8fSXXub7BXAODyUQohRMyOc3faCPd0hg==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      available-typed-arrays: 1.0.5
-      call-bind: 1.0.2
-      for-each: 0.3.3
-      has-proto: 1.0.1
-      is-typed-array: 1.1.12
-
   /typed-array-length@1.0.4:
     resolution: {integrity: sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==}
     dependencies:
       call-bind: 1.0.2
       for-each: 0.3.3
-      is-typed-array: 1.1.12
+      is-typed-array: 1.1.10
 
   /typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
@@ -14357,7 +15128,7 @@ packages:
     resolution: {integrity: sha512-g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA==}
     dependencies:
       define-properties: 1.2.0
-      es-abstract: 1.22.1
+      es-abstract: 1.21.2
       has-symbols: 1.0.3
       object.getownpropertydescriptors: 2.1.2
 
@@ -14392,6 +15163,10 @@ packages:
   /uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
+    dev: true
+
+  /validate-html-nesting@1.2.2:
+    resolution: {integrity: sha512-hGdgQozCsQJMyfK5urgFcWEqsSSrK63Awe0t/IMR0bZ0QMtnuaiHzThW81guu3qx9abLi99NEuiaN6P9gVYsNg==}
     dev: true
 
   /validate-npm-package-license@3.0.4:
@@ -14470,6 +15245,46 @@ packages:
       - terser
     dev: true
 
+  /vite-node@0.32.2(@types/node@18.16.3)(terser@5.17.1):
+    resolution: {integrity: sha512-dTQ1DCLwl2aEseov7cfQ+kDMNJpM1ebpyMMMwWzBvLbis8Nla/6c9WQcqpPssTwS6Rp/+U6KwlIj8Eapw4bLdA==}
+    engines: {node: '>=v14.18.0'}
+    hasBin: true
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.4(supports-color@5.5.0)
+      mlly: 1.2.0
+      pathe: 1.1.0
+      picocolors: 1.0.0
+      vite: 3.2.5(@types/node@18.16.3)(terser@5.17.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
+  /vite-plugin-solid@2.7.0(solid-js@1.7.7)(vite@3.2.5):
+    resolution: {integrity: sha512-avp/Jl5zOp/Itfo67xtDB2O61U7idviaIp4mLsjhCa13PjKNasz+IID0jYTyqUp9SFx6/PmBr6v4KgDppqompg==}
+    peerDependencies:
+      solid-js: ^1.7.2
+      vite: ^3.0.0 || ^4.0.0
+    dependencies:
+      '@babel/core': 7.21.5
+      '@babel/preset-typescript': 7.22.5(@babel/core@7.21.5)
+      '@types/babel__core': 7.20.1
+      babel-preset-solid: 1.7.7(@babel/core@7.21.5)
+      merge-anything: 5.1.7
+      solid-js: 1.7.7
+      solid-refresh: 0.5.3(solid-js@1.7.7)
+      vite: 3.2.5(@types/node@18.16.3)(terser@5.17.1)
+      vitefu: 0.2.4(vite@3.2.5)
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /vite-tsconfig-paths@4.2.0(typescript@5.1.6)(vite@3.2.5):
     resolution: {integrity: sha512-jGpus0eUy5qbbMVGiTxCL1iB9ZGN6Bd37VGLJU39kTDD6ZfULTTb1bcc5IeTWqWJKiWV5YihCaibeASPiGi8kw==}
     peerDependencies:
@@ -14515,11 +15330,22 @@ packages:
       '@types/node': 18.16.3
       esbuild: 0.15.18
       postcss: 8.4.21
-      resolve: 1.22.2
+      resolve: 1.22.1
       rollup: 2.79.1
       terser: 5.17.1
     optionalDependencies:
       fsevents: 2.3.2
+    dev: true
+
+  /vitefu@0.2.4(vite@3.2.5):
+    resolution: {integrity: sha512-fanAXjSaf9xXtOOeno8wZXIhgia+CZury481LsDaV++lSvcU2R9Ch2bPh3PYFyoHW+w9LqAeYRISVQjUIew14g==}
+    peerDependencies:
+      vite: ^3.0.0 || ^4.0.0
+    peerDependenciesMeta:
+      vite:
+        optional: true
+    dependencies:
+      vite: 3.2.5(@types/node@18.16.3)(terser@5.17.1)
     dev: true
 
   /vitest@0.30.1(jsdom@21.1.1)(terser@5.17.1):
@@ -14561,7 +15387,7 @@ packages:
       '@vitest/snapshot': 0.30.1
       '@vitest/spy': 0.30.1
       '@vitest/utils': 0.30.1
-      acorn: 8.10.0
+      acorn: 8.8.2
       acorn-walk: 8.2.0
       cac: 6.7.14
       chai: 4.3.7
@@ -14579,6 +15405,72 @@ packages:
       tinypool: 0.4.0
       vite: 3.2.5(@types/node@18.16.3)(terser@5.17.1)
       vite-node: 0.30.1(@types/node@18.16.3)(terser@5.17.1)
+      why-is-node-running: 2.2.2
+    transitivePeerDependencies:
+      - less
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
+  /vitest@0.32.2(jsdom@22.1.0)(terser@5.17.1):
+    resolution: {integrity: sha512-hU8GNNuQfwuQmqTLfiKcqEhZY72Zxb7nnN07koCUNmntNxbKQnVbeIS6sqUgR3eXSlbOpit8+/gr1KpqoMgWCQ==}
+    engines: {node: '>=v14.18.0'}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@vitest/browser': '*'
+      '@vitest/ui': '*'
+      happy-dom: '*'
+      jsdom: '*'
+      playwright: '*'
+      safaridriver: '*'
+      webdriverio: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+      playwright:
+        optional: true
+      safaridriver:
+        optional: true
+      webdriverio:
+        optional: true
+    dependencies:
+      '@types/chai': 4.3.5
+      '@types/chai-subset': 1.3.3
+      '@types/node': 18.16.3
+      '@vitest/expect': 0.32.2
+      '@vitest/runner': 0.32.2
+      '@vitest/snapshot': 0.32.2
+      '@vitest/spy': 0.32.2
+      '@vitest/utils': 0.32.2
+      acorn: 8.8.2
+      acorn-walk: 8.2.0
+      cac: 6.7.14
+      chai: 4.3.7
+      concordance: 5.0.4
+      debug: 4.3.4(supports-color@5.5.0)
+      jsdom: 22.1.0
+      local-pkg: 0.4.3
+      magic-string: 0.30.0
+      pathe: 1.1.0
+      picocolors: 1.0.0
+      std-env: 3.3.2
+      strip-literal: 1.0.1
+      tinybench: 2.5.0
+      tinypool: 0.5.0
+      vite: 3.2.5(@types/node@18.16.3)(terser@5.17.1)
+      vite-node: 0.32.2(@types/node@18.16.3)(terser@5.17.1)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less
@@ -14864,8 +15756,21 @@ packages:
       is-string: 1.0.7
       is-symbol: 1.0.4
 
+  /which-collection@1.0.1:
+    resolution: {integrity: sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==}
+    dependencies:
+      is-map: 2.0.2
+      is-set: 2.0.2
+      is-weakmap: 2.0.1
+      is-weakset: 2.0.2
+    dev: true
+
+  /which-module@2.0.0:
+    resolution: {integrity: sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==}
+
   /which-module@2.0.1:
     resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
+    dev: true
 
   /which-pm-runs@1.1.0:
     resolution: {integrity: sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==}
@@ -14880,8 +15785,8 @@ packages:
       path-exists: 4.0.0
     dev: true
 
-  /which-typed-array@1.1.11:
-    resolution: {integrity: sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==}
+  /which-typed-array@1.1.9:
+    resolution: {integrity: sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==}
     engines: {node: '>= 0.4'}
     dependencies:
       available-typed-arrays: 1.0.5
@@ -14889,6 +15794,7 @@ packages:
       for-each: 0.3.3
       gopd: 1.0.1
       has-tostringtag: 1.0.0
+      is-typed-array: 1.1.10
 
   /which@1.3.1:
     resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
@@ -14904,8 +15810,8 @@ packages:
       isexe: 2.0.0
     dev: true
 
-  /which@3.0.1:
-    resolution: {integrity: sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==}
+  /which@3.0.0:
+    resolution: {integrity: sha512-nla//68K9NU6yRiwDY/Q8aU6siKlSs64aEC7+IV56QoAuyQT2ovsJcgGYGyqMOmI/CGN1BOR6mM5EN0FBO+zyQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     hasBin: true
     dependencies:
@@ -15095,7 +16001,7 @@ packages:
       require-main-filename: 2.0.0
       set-blocking: 2.0.0
       string-width: 3.1.0
-      which-module: 2.0.1
+      which-module: 2.0.0
       y18n: 4.0.3
       yargs-parser: 13.1.2
 
@@ -15114,6 +16020,19 @@ packages:
       which-module: 2.0.1
       y18n: 4.0.3
       yargs-parser: 18.1.3
+    dev: true
+
+  /yargs@17.7.1:
+    resolution: {integrity: sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==}
+    engines: {node: '>=12'}
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.1.1
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
     dev: true
 
   /yargs@17.7.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -541,9 +541,6 @@ importers:
 
   packages/solid-urql:
     dependencies:
-      '@solid-primitives/utils':
-        specifier: ^6.2.0
-        version: 6.2.0(solid-js@1.7.7)
       '@urql/core':
         specifier: ^4.0.0
         version: link:../core
@@ -571,10 +568,10 @@ importers:
         version: 2.7.0(solid-js@1.7.7)(vite@3.2.5)
       vite-tsconfig-paths:
         specifier: ^4.2.0
-        version: 4.2.0(typescript@5.1.6)(vite@3.2.5)
+        version: 4.2.0(vite@3.2.5)
       vitest:
         specifier: ^0.32.2
-        version: 0.32.2(jsdom@22.1.0)(terser@5.17.1)
+        version: 0.32.2(jsdom@22.1.0)
 
   packages/storage-rn:
     devDependencies:
@@ -757,10 +754,10 @@ packages:
       '@babel/helpers': 7.21.5
       '@babel/parser': 7.21.5
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.21.5(supports-color@5.5.0)
+      '@babel/traverse': 7.21.5
       '@babel/types': 7.21.5
       convert-source-map: 1.9.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.0
@@ -945,7 +942,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.18.6
       '@babel/helper-validator-identifier': 7.19.1
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.21.5(supports-color@5.5.0)
+      '@babel/traverse': 7.21.5
       '@babel/types': 7.21.5
     transitivePeerDependencies:
       - supports-color
@@ -1110,7 +1107,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.21.5(supports-color@5.5.0)
+      '@babel/traverse': 7.21.5
       '@babel/types': 7.21.5
     transitivePeerDependencies:
       - supports-color
@@ -2015,6 +2012,23 @@ packages:
       '@babel/code-frame': 7.22.5
       '@babel/parser': 7.22.7
       '@babel/types': 7.22.5
+
+  /@babel/traverse@7.21.5:
+    resolution: {integrity: sha512-AhQoI3YjWi6u/y/ntv7k48mcrCXmus0t79J9qPNlk/lAsFlCiJ047RmbfMOawySTHtywXhbXgpx/8nXMYd+oFw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.21.4
+      '@babel/generator': 7.21.5
+      '@babel/helper-environment-visitor': 7.21.5
+      '@babel/helper-function-name': 7.21.0
+      '@babel/helper-hoist-variables': 7.18.6
+      '@babel/helper-split-export-declaration': 7.18.6
+      '@babel/parser': 7.21.5
+      '@babel/types': 7.21.5
+      debug: 4.3.4
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
 
   /@babel/traverse@7.21.5(supports-color@5.5.0):
     resolution: {integrity: sha512-AhQoI3YjWi6u/y/ntv7k48mcrCXmus0t79J9qPNlk/lAsFlCiJ047RmbfMOawySTHtywXhbXgpx/8nXMYd+oFw==}
@@ -3120,14 +3134,6 @@ packages:
     resolution: {integrity: sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==}
     engines: {node: '>=4'}
 
-  /@solid-primitives/utils@6.2.0(solid-js@1.7.7):
-    resolution: {integrity: sha512-T62WlLwKkbmicsw/xpwMQyv9MmZRSaVyutXfS5icc9v0cb8qGMUxRxr5LVvZHYQCZ9DEFboZB0r711xsbVBbeA==}
-    peerDependencies:
-      solid-js: ^1.6.12
-    dependencies:
-      solid-js: 1.7.7
-    dev: false
-
   /@solidjs/router@0.8.2(solid-js@1.7.7):
     resolution: {integrity: sha512-gUKW+LZqxtX6y/Aw6JKyy4gQ9E7dLqp513oB9pSYJR1HM5c56Pf7eijzyXX+b3WuXig18Cxqah4tMtF0YGu80w==}
     peerDependencies:
@@ -4028,7 +4034,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6139,6 +6145,17 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.3
+
+  /debug@4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
 
   /debug@4.3.4(supports-color@5.5.0):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -8642,7 +8659,7 @@ packages:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -8695,7 +8712,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -14657,6 +14674,17 @@ packages:
       typescript: 5.1.6
     dev: true
 
+  /tsconfck@2.1.1:
+    resolution: {integrity: sha512-ZPCkJBKASZBmBUNqGHmRhdhM8pJYDdOXp4nRgj/O0JwUwsMq50lCDRQP/M5GBNAA0elPrq4gAeu4dkaVCuKWww==}
+    engines: {node: ^14.13.1 || ^16 || >=18}
+    hasBin: true
+    peerDependencies:
+      typescript: ^4.3.5 || ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dev: true
+
   /tsconfck@2.1.1(typescript@5.1.6):
     resolution: {integrity: sha512-ZPCkJBKASZBmBUNqGHmRhdhM8pJYDdOXp4nRgj/O0JwUwsMq50lCDRQP/M5GBNAA0elPrq4gAeu4dkaVCuKWww==}
     engines: {node: ^14.13.1 || ^16 || >=18}
@@ -15245,17 +15273,17 @@ packages:
       - terser
     dev: true
 
-  /vite-node@0.32.2(@types/node@18.16.3)(terser@5.17.1):
+  /vite-node@0.32.2(@types/node@18.16.3):
     resolution: {integrity: sha512-dTQ1DCLwl2aEseov7cfQ+kDMNJpM1ebpyMMMwWzBvLbis8Nla/6c9WQcqpPssTwS6Rp/+U6KwlIj8Eapw4bLdA==}
     engines: {node: '>=v14.18.0'}
     hasBin: true
     dependencies:
       cac: 6.7.14
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       mlly: 1.2.0
       pathe: 1.1.0
       picocolors: 1.0.0
-      vite: 3.2.5(@types/node@18.16.3)(terser@5.17.1)
+      vite: 3.2.5(@types/node@18.16.3)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -15279,7 +15307,7 @@ packages:
       merge-anything: 5.1.7
       solid-js: 1.7.7
       solid-refresh: 0.5.3(solid-js@1.7.7)
-      vite: 3.2.5(@types/node@18.16.3)(terser@5.17.1)
+      vite: 3.2.5(@types/node@18.16.3)
       vitefu: 0.2.4(vite@3.2.5)
     transitivePeerDependencies:
       - supports-color
@@ -15300,6 +15328,57 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
+    dev: true
+
+  /vite-tsconfig-paths@4.2.0(vite@3.2.5):
+    resolution: {integrity: sha512-jGpus0eUy5qbbMVGiTxCL1iB9ZGN6Bd37VGLJU39kTDD6ZfULTTb1bcc5IeTWqWJKiWV5YihCaibeASPiGi8kw==}
+    peerDependencies:
+      vite: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
+    dependencies:
+      debug: 4.3.4
+      globrex: 0.1.2
+      tsconfck: 2.1.1
+      vite: 3.2.5(@types/node@18.16.3)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /vite@3.2.5(@types/node@18.16.3):
+    resolution: {integrity: sha512-4mVEpXpSOgrssFZAOmGIr85wPHKvaDAcXqxVxVRZhljkJOMZi1ibLibzjLHzJvcok8BMguLc7g1W6W/GqZbLdQ==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': '>= 14'
+      less: '*'
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 18.16.3
+      esbuild: 0.15.18
+      postcss: 8.4.21
+      resolve: 1.22.1
+      rollup: 2.79.1
+    optionalDependencies:
+      fsevents: 2.3.2
     dev: true
 
   /vite@3.2.5(@types/node@18.16.3)(terser@5.17.1):
@@ -15345,7 +15424,7 @@ packages:
       vite:
         optional: true
     dependencies:
-      vite: 3.2.5(@types/node@18.16.3)(terser@5.17.1)
+      vite: 3.2.5(@types/node@18.16.3)
     dev: true
 
   /vitest@0.30.1(jsdom@21.1.1)(terser@5.17.1):
@@ -15415,7 +15494,7 @@ packages:
       - terser
     dev: true
 
-  /vitest@0.32.2(jsdom@22.1.0)(terser@5.17.1):
+  /vitest@0.32.2(jsdom@22.1.0):
     resolution: {integrity: sha512-hU8GNNuQfwuQmqTLfiKcqEhZY72Zxb7nnN07koCUNmntNxbKQnVbeIS6sqUgR3eXSlbOpit8+/gr1KpqoMgWCQ==}
     engines: {node: '>=v14.18.0'}
     hasBin: true
@@ -15459,7 +15538,7 @@ packages:
       cac: 6.7.14
       chai: 4.3.7
       concordance: 5.0.4
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       jsdom: 22.1.0
       local-pkg: 0.4.3
       magic-string: 0.30.0
@@ -15469,8 +15548,8 @@ packages:
       strip-literal: 1.0.1
       tinybench: 2.5.0
       tinypool: 0.5.0
-      vite: 3.2.5(@types/node@18.16.3)(terser@5.17.1)
-      vite-node: 0.32.2(@types/node@18.16.3)(terser@5.17.1)
+      vite: 3.2.5(@types/node@18.16.3)
+      vite-node: 0.32.2(@types/node@18.16.3)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less


### PR DESCRIPTION
Resolves #3303 

## Summary

Add new `urql-solid` package implementing `solid-js` bindings.

Api is nearly same as for react/preact with difference being that some props are passed as union of value and accessor. 

## Set of changes

Adds following `solid-js` hooks
- `createQuery`
- `createMutation`
- `createSubscription`
