### PR TITLE
fix(svelte): Move Client subscription to writable start

### DIFF
--- a/.changeset/many-rabbits-wave.md
+++ b/.changeset/many-rabbits-wave.md
@@ -1,0 +1,5 @@
+---
+'@urql/svelte': patch
+---
+
+Fix `queryStore` and `subscriptionStore` not subscribing when `writable` calls its `StartStopNotifier`. This caused both stores to be inactive and become unresponsive when they’ve been unsubscribed from once, as they wouldn’t be able to restart their subscriptions to the `Client`.


### PR DESCRIPTION
Resolves #3329

## Summary

This moves the source subscription to the result `writable` in `queryStore` and `subscriptionStore`. We must subscribe when the `StartStopNotifier` is called, so to start the subscription whenever there isn't an active one to the `Client`.

If we don't start the subscription on demand, then unsubscribing (with all observers) from the stores will let them “die”. They won’t have an active subscription and won’t be able to start a new one.

The `writable` in Svelte already checks when to call `StartStopNotifier` via semaphore logic, so no extra code is needed.

The only risk with this fix is whether people relied on `queryStore` starting a subscription implicitly. This really shouldn't have been done before as it's pointless to instantiate a store without reading from it, so I don't consider it a breaking change — unless there's a specific reproduction that is proven to break from this change.

## Set of changes

- Move `Client` subscription into `writable` instantiation
