### PR TITLE
feat(graphcache): Allow cache.resolve to return undefined for uncached fields

### DIFF
--- a/.changeset/thin-badgers-return.md
+++ b/.changeset/thin-badgers-return.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': minor
+---
+
+Allow `cache.resolve` to return `undefined` when a value is not cached to make it easier to cause a cache miss in resolvers. **Reminder:** Returning `undefined` from a resolver means a field is uncached, while returning `null` means that a field’s value is `null` without causing a cache miss.

--- a/docs/graphcache/normalized-caching.md
+++ b/docs/graphcache/normalized-caching.md
@@ -393,7 +393,7 @@ Since it can access the field's arguments from the GraphQL query document, we ca
 object is keyable, it will tell _Graphcache_ what the key of the returned entity is. In other words,
 we've told it how to get to a `Todo` from the `Query.todo` field.
 
-This mechanism is immensely more powerful than this example. We have two other use-cases that
+This mechanism is immensely more powerful than this example. We have other use-cases that
 resolvers may be used for:
 
 - Resolvers can be applied to fields with records, which means that it can be used to change or
@@ -402,6 +402,12 @@ resolvers may be used for:
 - Resolvers can return deeply nested results, which will be layered on top of the in-memory
   relational cached data of _Graphcache_, which means that it can emulate infinite pagination and
   other complex behaviour.
+- Resolvers can change when a cache miss or hit occurs. Returning `null` means that a field’s value
+  is literally `null`, which will not cause a cache miss, while returning `undefined` will mean
+  a field’s value is uncached.
+- Resolvers can return either partial entities or keys, so we can chain `cache.resolve` calls to
+  read fields from the cache, even when a field is pointing at another entity, since we can return
+  keys to the other entity directly.
 
 [Read more about resolvers on the following page about "Local Resolvers".](./local-resolvers.md)
 

--- a/exchanges/graphcache/src/operations/shared.ts
+++ b/exchanges/graphcache/src/operations/shared.ts
@@ -223,8 +223,8 @@ export const ensureData = (x: DataField): Data | NullArray<Data> | null =>
   x == null ? null : (x as Data | NullArray<Data>);
 
 export const ensureLink = (store: Store, ref: Link<Entity>): Link => {
-  if (ref == null) {
-    return ref;
+  if (!ref) {
+    return ref || null;
   } else if (Array.isArray(ref)) {
     const link = new Array(ref.length);
     for (let i = 0, l = link.length; i < l; i++)

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -422,12 +422,10 @@ export const gc = () => {
 };
 
 const updateDependencies = (entityKey: string, fieldKey?: string) => {
-  if (fieldKey !== '__typename') {
-    if (entityKey !== currentData!.queryRootKey) {
-      currentDependencies!.add(entityKey);
-    } else if (fieldKey !== undefined) {
-      currentDependencies!.add(joinKeys(entityKey, fieldKey));
-    }
+  if (entityKey !== currentData!.queryRootKey) {
+    currentDependencies!.add(entityKey);
+  } else if (fieldKey !== undefined && fieldKey !== '__typename') {
+    currentDependencies!.add(joinKeys(entityKey, fieldKey));
   }
 };
 

--- a/exchanges/graphcache/src/types.ts
+++ b/exchanges/graphcache/src/types.ts
@@ -131,7 +131,7 @@ export type Data = SystemFields & DataFields;
  * as retrieved for instance by {@link Cache.keyOfEntity} or a partial GraphQL object
  * (i.e. an object with a `__typename` and key field).
  */
-export type Entity = null | Data | string;
+export type Entity = undefined | null | Data | string;
 
 /** A key of an entity, or `null`; or a list of keys.
  *
@@ -284,7 +284,7 @@ export interface Cache {
    * If it’s passed a `string` or `null`, it will simply return what it’s been passed.
    * Objects that lack a `__typename` field will return `null`.
    */
-  keyOfEntity(entity: Entity): string | null;
+  keyOfEntity(entity: Entity | undefined): string | null;
 
   /** Returns the cache key for a field.
    *
@@ -327,14 +327,21 @@ export interface Cache {
    * );
    * ```
    */
-  resolve(entity: Entity, fieldName: string, args?: FieldArgs): DataField;
+  resolve(
+    entity: Entity | undefined,
+    fieldName: string,
+    args?: FieldArgs
+  ): DataField | undefined;
 
   /** Returns a cached value on a given entity’s field by its field key.
    *
    * @deprecated
    * Use {@link cache.resolve} instead.
    */
-  resolveFieldByKey(entity: Entity, fieldKey: string): DataField;
+  resolveFieldByKey(
+    entity: Entity | undefined,
+    fieldKey: string
+  ): DataField | undefined;
 
   /** Returns a list of cached fields for a given GraphQL object (“entity”).
    *
@@ -372,7 +379,11 @@ export interface Cache {
    * However, if a field name (and optionally, its arguments) are passed,
    * only a single field is erased.
    */
-  invalidate(entity: Entity, fieldName?: string, args?: FieldArgs): void;
+  invalidate(
+    entity: Entity | undefined,
+    fieldName?: string,
+    args?: FieldArgs
+  ): void;
 
   /** Updates a GraphQL query‘s cached data.
    *


### PR DESCRIPTION
## Summary

This updates `cache.resolve` to return `undefined` for uncached fields.

This has two reasons:
- Resolvers allow users to return `undefined` to signal a cache miss, however, this wasn't clear — both because of the documentation, and because `cache.resolve` itself never returns `undefined`. Hence, while it's popular to end a resolver in a `cache.resolve` call, this meant that a cache miss could never be caused on this field.
- Not being able to return `undefined` meant that the `Cache` interface virtually had little to no ways of actually letting a user check whether a field was cached or not. By returning `undefined` this now becomes clear

This isn't considered a breaking change since it shouldn't alter prior behaviour significantly:
- A user may now correctly see a cache miss, where before they accidentally didn't cause one
  - However, manually returning `null` still retains the prior behaviour obviously
- All methods now accept `undefined`, so the chainability is retained. When a method that was chainable receives `undefined` as its entity input, it will also typically return `undefined`, unless it's a write method.

## Set of changes

- Allow `cache.resolve` to return `undefined`
- Update `cache.link` to better handle variable number of arguments
- Allow `Entity` argument type in `Cache` to accept `undefined`
- Update `ensureLink` to handle `undefined` values gracefully
- Update docs to clarify that resolvers are allowed to return `undefined`
