### PR TITLE
fix(graphcache): Record dependencies for __typename accesses

### DIFF
--- a/.changeset/cyan-melons-drive.md
+++ b/.changeset/cyan-melons-drive.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Record a dependency when `__typename` field is read. This removes a prior, outdated exception to avoid confusion when using `cache.resolve(entity, '__typename')` which doesn't cause the cache to record a dependency.

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -422,12 +422,10 @@ export const gc = () => {
 };
 
 const updateDependencies = (entityKey: string, fieldKey?: string) => {
-  if (fieldKey !== '__typename') {
-    if (entityKey !== currentData!.queryRootKey) {
-      currentDependencies!.add(entityKey);
-    } else if (fieldKey !== undefined) {
-      currentDependencies!.add(joinKeys(entityKey, fieldKey));
-    }
+  if (entityKey !== currentData!.queryRootKey) {
+    currentDependencies!.add(entityKey);
+  } else if (fieldKey !== undefined && fieldKey !== '__typename') {
+    currentDependencies!.add(joinKeys(entityKey, fieldKey));
   }
 };
 


### PR DESCRIPTION
## Summary

This changes the expected behaviour for when dependencies are recorded for caches accesses.

> **Note:** Dependencies are basically entity or field keys marking a cache read or write. When a cache write updates a dependency, then all cache reads (i.e. queries) that have the same cache dependency will be updated accordingly, i.e. re-queried. This is how Graphcache issues updates to queries after cache writes.

While this wasn't a bug, any usage of `cache.resolve(entity, '__typename')` wouldn't actually record a dependency, which could cause confusion. The exception has now been removed.

## Set of changes

- Remove dependency exception for accessing `__typename` on entities
