### PR TITLE
fix(graphcache): Improve Graphcache resolver consistency

### DIFF
--- a/.changeset/hungry-experts-admire.md
+++ b/.changeset/hungry-experts-admire.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': minor
+---
+
+Allow scalar values on the parent to be accessed from `parent[info.fieldName]` consistently. Prior to this change `parent[fieldAlias]` would get populated, which wouldn’t always result in a field that’s consistently accessible.

--- a/.changeset/tame-ways-obey.md
+++ b/.changeset/tame-ways-obey.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix cases where `ResolveInfo`’s `parentFieldKey` was incorrectly populated with a key that isn’t a field key (allowing for `cache.resolve(info.parentKey, info.parentFieldKey)` to be possible) but was instead set to `info.parentKey` combined with the field key.

--- a/exchanges/graphcache/src/helpers/dict.ts
+++ b/exchanges/graphcache/src/helpers/dict.ts
@@ -1,6 +1,0 @@
-export const makeDict = (): any => Object.create(null);
-
-export const isDictEmpty = (x: any) => {
-  for (const _ in x) return false;
-  return true;
-};

--- a/exchanges/graphcache/src/operations/query.ts
+++ b/exchanges/graphcache/src/operations/query.ts
@@ -421,10 +421,6 @@ const readSelection = (
       // The field is a scalar and can be retrieved directly from the result
       dataFieldValue = resultValue;
     } else if (InMemoryData.currentOperation === 'read' && resolver) {
-      // We have to update the information in context to reflect the info
-      // that the resolver will receive
-      updateContext(ctx, output, typename, entityKey, fieldKey, fieldName);
-
       // We have a resolver for this field.
       // Prepare the actual fieldValue, so that the resolver can use it,
       // as to avoid the user having to do `cache.resolve(parent, info.fieldKey)`
@@ -437,6 +433,10 @@ const readSelection = (
           [fieldName]: fieldValue,
         };
       }
+
+      // We have to update the information in context to reflect the info
+      // that the resolver will receive
+      updateContext(ctx, parent, typename, entityKey, fieldKey, fieldName);
 
       dataFieldValue = resolver(
         parent,

--- a/exchanges/graphcache/src/operations/query.ts
+++ b/exchanges/graphcache/src/operations/query.ts
@@ -423,7 +423,7 @@ const readSelection = (
     } else if (InMemoryData.currentOperation === 'read' && resolver) {
       // We have to update the information in context to reflect the info
       // that the resolver will receive
-      updateContext(ctx, output, typename, entityKey, key, fieldName);
+      updateContext(ctx, output, typename, entityKey, fieldKey, fieldName);
 
       // We have a resolver for this field.
       // Prepare the actual fieldValue, so that the resolver can use it,

--- a/exchanges/graphcache/src/operations/query.ts
+++ b/exchanges/graphcache/src/operations/query.ts
@@ -426,13 +426,20 @@ const readSelection = (
       updateContext(ctx, output, typename, entityKey, key, fieldName);
 
       // We have a resolver for this field.
-      // Prepare the actual fieldValue, so that the resolver can use it
-      if (fieldValue !== undefined) {
-        output[fieldAlias] = fieldValue;
+      // Prepare the actual fieldValue, so that the resolver can use it,
+      // as to avoid the user having to do `cache.resolve(parent, info.fieldKey)`
+      // only to get a scalar value.
+      let parent = output;
+      if (node.selectionSet === undefined && fieldValue !== undefined) {
+        parent = {
+          ...output,
+          [fieldAlias]: fieldValue,
+          [fieldName]: fieldValue,
+        };
       }
 
       dataFieldValue = resolver(
-        output,
+        parent,
         fieldArgs || ({} as Variables),
         store,
         ctx

--- a/exchanges/graphcache/src/operations/write.ts
+++ b/exchanges/graphcache/src/operations/write.ts
@@ -354,7 +354,7 @@ const writeSelection = (
         data,
         typename,
         entityKey || typename,
-        joinKeys(typename, fieldKey),
+        fieldKey,
         fieldName
       );
 

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -19,7 +19,6 @@ import {
   joinKeys,
 } from './keys';
 
-import { makeDict } from '../helpers/dict';
 import { invariant, currentDebugStack } from '../helpers/help';
 
 type Dict<T> = Record<string, T>;
@@ -283,7 +282,7 @@ const setNode = <T>(
   // On the map itself we get or create the entity as a dict
   let entity = keymap.get(entityKey) as Dict<T | undefined>;
   if (entity === undefined) {
-    keymap.set(entityKey, (entity = makeDict()));
+    keymap.set(entityKey, (entity = Object.create(null)));
   }
 
   // If we're setting undefined we delete the node's entry
@@ -614,7 +613,7 @@ export const persistData = () => {
   if (currentData!.storage) {
     currentOptimistic = true;
     currentOperation = 'read';
-    const entries: SerializedEntries = makeDict();
+    const entries: SerializedEntries = {};
     for (const key of currentData!.persist.keys()) {
       const { entityKey, fieldKey } = deserializeKeyInfo(key);
       let x: void | Link | EntityField;

--- a/exchanges/graphcache/src/store/store.test.ts
+++ b/exchanges/graphcache/src/store/store.test.ts
@@ -425,7 +425,7 @@ describe('Store with OptimisticMutationConfig', () => {
       randomData,
       'Todo',
       'Todo:1',
-      'Todo:1.createdAt',
+      'createdAt',
       'createdAt'
     );
 


### PR DESCRIPTION
## Summary

While looking at a code snippet, I found that we didn't come back to providing `parent[info.fieldName]` for scalar resolvers. This is an easy way of making this work. It does add a bit of overhead, but I think it's the only way to add this without a breaking change (and without doing a weird set/delete dance, which is likely to be slower)

The other issue is that `info.parentFieldKey` isn't consistently populated with the `fieldKey` (as is implied and documented) but with `info.parentKey` joined with the `fieldKey`, i.e. a full key.

This means that `cache.resolve(parent, info.parentFieldKey)` wouldn't work in resolvers, but would work in updaters.

## Set of changes

- Replace incorrect `updateContext` calls to fix `info.parentFieldKey` in resolvers
- Update parent input for scalar fields to have both `parent[fieldAlias]` and `parent[fieldName]` set to the record value
