### PR TITLE
fix(graphcache): Fix partial and info usage in default directives

### DIFF
--- a/.changeset/heavy-shirts-smash.md
+++ b/.changeset/heavy-shirts-smash.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix `@_optional` directive not setting `info.partial = true` on cache miss and fix usage of `info.parentKey` and `info.parentFieldKey` usage in default directives.

--- a/exchanges/graphcache/src/helpers/defaultDirectives.ts
+++ b/exchanges/graphcache/src/helpers/defaultDirectives.ts
@@ -1,0 +1,21 @@
+import type { Resolver, DirectivesConfig } from '../types';
+
+const optional: Resolver = (_parent, _args, cache, info) => {
+  const result = cache.resolve(info.parentKey, info.parentFieldKey);
+  if (result === undefined) {
+    info.partial = true;
+    return null;
+  } else {
+    return result;
+  }
+};
+
+const required: Resolver = (_parent, _args, cache, info) => {
+  const result = cache.resolve(info.parentKey, info.parentFieldKey);
+  return result == null ? undefined : result;
+};
+
+export const defaultDirectives: DirectivesConfig = {
+  optional: () => optional,
+  required: () => required,
+};

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -39,12 +39,12 @@ type DocumentNode = TypedDocumentNode<any, any>;
 type RootField = 'query' | 'mutation' | 'subscription';
 
 const defaultDirectives: DirectivesConfig = {
-  optional: () => (_parent, args, cache, info) => {
-    const result = cache.resolve(info.parentFieldKey, info.fieldName, args);
+  optional: () => (_parent, _args, cache, info) => {
+    const result = cache.resolve(info.parentKey, info.parentFieldKey);
     return result === undefined ? null : result;
   },
-  required: () => (_parent, args, cache, info) => {
-    const result = cache.resolve(info.parentFieldKey, info.fieldName, args);
+  required: () => (_parent, _args, cache, info) => {
+    const result = cache.resolve(info.parentKey, info.parentFieldKey);
     return result === null ? undefined : result;
   },
 };

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -41,7 +41,12 @@ type RootField = 'query' | 'mutation' | 'subscription';
 const defaultDirectives: DirectivesConfig = {
   optional: () => (_parent, _args, cache, info) => {
     const result = cache.resolve(info.parentKey, info.parentFieldKey);
-    return result === undefined ? null : result;
+    if (result === undefined) {
+      info.partial = true;
+      return null;
+    } else {
+      return result;
+    }
   },
   required: () => (_parent, _args, cache, info) => {
     const result = cache.resolve(info.parentKey, info.parentFieldKey);

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -19,6 +19,7 @@ import {
 } from '../types';
 
 import { invariant } from '../helpers/help';
+import { defaultDirectives } from '../helpers/defaultDirectives';
 import { contextRef, ensureLink } from '../operations/shared';
 import { _query, _queryFragment } from '../operations/query';
 import { _write, _writeFragment } from '../operations/write';
@@ -37,22 +38,6 @@ import {
 
 type DocumentNode = TypedDocumentNode<any, any>;
 type RootField = 'query' | 'mutation' | 'subscription';
-
-const defaultDirectives: DirectivesConfig = {
-  optional: () => (_parent, _args, cache, info) => {
-    const result = cache.resolve(info.parentKey, info.parentFieldKey);
-    if (result === undefined) {
-      info.partial = true;
-      return null;
-    } else {
-      return result;
-    }
-  },
-  required: () => (_parent, _args, cache, info) => {
-    const result = cache.resolve(info.parentKey, info.parentFieldKey);
-    return result === null ? undefined : result;
-  },
-};
 
 /** Implementation of the {@link Cache} interface as created internally by the {@link cacheExchange}.
  * @internal


### PR DESCRIPTION
## Set of changes

- Fix `info.parentKey` and `info.parentFieldKey` usage in default directives
- Add missing `info.partial = true` setter to `@_optional`
