### PR TITLE
fix(graphcache): Fix info.partial edge case for @_optional

### DIFF
--- a/.changeset/few-garlics-judge.md
+++ b/.changeset/few-garlics-judge.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Reset `partial` result marker when reading from selections when a child value sees a cache miss. This only affects resolvers on child values enabling `info.partial` while a parent may abort early instead.


### PR DESCRIPTION
## Summary

**Note:** It shouldn't currently be possible to trigger this edge case! However, I can't predict whether the code will change and cause us to create a case for this in the future, so changing this is the safest course of action.

When a field, hypothetically speaking, flips `info.partial = true`, but a parent field aborts with a cache miss, and a parent field then recovers by setting the value to `null`, then `info.partial` won't be reset to its prior value, which could've been `false`. 

## Set of changes

- Restore `ctx.partial` to initial value in `readSelection` loop on early return
- Restore `ctx.partial` to initial alue in `readResolverResult`'s and `readLink`'s array loop in early return case