### PR TITLE
feat(core): Handle GraphQLError[] value in error observer callback of subscriptionExchange

### DIFF
--- a/.changeset/shy-maps-raise.md
+++ b/.changeset/shy-maps-raise.md
@@ -1,0 +1,6 @@
+---
+'@urql/core': patch
+---
+
+Add case for `subscriptionExchange` to handle `GraphQLError[]` received in the `error` observer callback.
+**Note:** This doesn't strictly check for the `GraphQLError` shape and only checks for arrays and receiving errors in the `ExecutionResult` on the `next` observer callback is preferred and recommended for transports.


### PR DESCRIPTION
Resolves #3345

## Summary

**Note**: I'd prefer not to ship this and there's an ongoing discussion in #3345, that requires confirmation before this change is made. This is simply already submitted for reference for the discussion.

The reason why I'd prefer not to ship this is that we're basically forced to simply check using `Array.isArray` for an array value on the error callback and then circumvent issuing a network error and instead issue a result — potentially merging prior results — when `GraphQLError[]` is passed as a value.

I find this extremely odd precisely because using `next` + `complete` feels much more natural here. `GraphQLError[]`, as part of the `ExecutionResult`'s `errors`, is a defined shape of a result and can be accepted at any time. Receiving it in `errors` basically forces a new code path for functionality that already exists.

The addition here basically just uses the `next` case for `error`.

## Set of changes

- Handle `unknown[]` as `GraphQLError[]` in `error` observer callback of `subscriptionExchange`
- Leave note to prevent this being altered or re-used for other transport protocols