### PR TITLE
fix(graphcache): Fix extra variables regression

### DIFF
--- a/.changeset/odd-parrots-fix.md
+++ b/.changeset/odd-parrots-fix.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix extra variables in mutation results regressing by a change made in [#3317](https://github.com/urql-graphql/urql/pull/3317). The original operation wasn't being preserved anymore.

--- a/exchanges/graphcache/src/cacheExchange.test.ts
+++ b/exchanges/graphcache/src/cacheExchange.test.ts
@@ -1260,6 +1260,100 @@ describe('optimistic updates', () => {
   });
 });
 
+describe('extra variables', () => {
+  it.only('allows extra variables to be applied to updates', () => {
+    vi.useFakeTimers();
+
+    const mutation = gql`
+      mutation TestMutation($test: Boolean) {
+        test(test: $test) {
+          id
+        }
+      }
+    `;
+
+    const mutationData = {
+      __typename: 'Mutation',
+      test: {
+        __typename: 'Author',
+        id: '123',
+      },
+    };
+
+    const client = createClient({
+      url: 'http://0.0.0.0',
+      exchanges: [],
+    });
+
+    const { source: ops$, next } = makeSubject<Operation>();
+
+    const opQuery = client.createRequestOperation('query', {
+      key: 1,
+      query: queryOne,
+      variables: undefined,
+    });
+
+    const opMutation = client.createRequestOperation('mutation', {
+      key: 2,
+      query: mutation,
+      variables: {
+        test: true,
+        extra: 'extra',
+      },
+    });
+
+    const response = vi.fn((forwardOp: Operation): OperationResult => {
+      if (forwardOp.key === 1) {
+        return { ...queryResponse, operation: forwardOp, data: queryOneData };
+      } else if (forwardOp.key === 2) {
+        return {
+          ...queryResponse,
+          operation: forwardOp,
+          data: mutationData,
+        };
+      }
+
+      return undefined as any;
+    });
+
+    const result = vi.fn();
+    const forward: ExchangeIO = ops$ =>
+      pipe(ops$, delay(3), map(response), share);
+
+    const updates = {
+      Mutation: {
+        test: vi.fn() as any,
+      },
+    };
+
+    pipe(
+      cacheExchange({ updates })({ forward, client, dispatchDebug })(ops$),
+      filter(x => x.operation.kind === 'mutation'),
+      tap(result),
+      publish
+    );
+
+    next(opQuery);
+    vi.runAllTimers();
+    expect(response).toHaveBeenCalledTimes(1);
+    expect(result).toHaveBeenCalledTimes(0);
+
+    next(opMutation);
+    vi.runAllTimers();
+
+    expect(response).toHaveBeenCalledTimes(2);
+    expect(result).toHaveBeenCalledTimes(1);
+    expect(updates.Mutation.test).toHaveBeenCalledTimes(1);
+
+    const context = updates.Mutation.test.mock.calls[0][3];
+
+    expect(context.variables).toEqual({
+      test: true,
+      extra: 'extra',
+    });
+  });
+});
+
 describe('custom resolvers', () => {
   it('follows resolvers on initial write', () => {
     const client = createClient({


### PR DESCRIPTION
Resolves #3355

## Summary

Changes in #3317 accidentally removed code that preserved the original operation for optimistic and non-optimistic mutation updaters, and needed to be reverted to their previous state.
This was caused by a merge conflict between `optimistic` mutation markers and the changes in #3317 and the prior lines that retrieved the original operation had gotten lost in testing.

A new unit test was added to prevent further regressions.

## Set of changes

- Add unit tests for extra variables to prevent regressions
- Update code for `optimistic` flagging
- Add removed lines to retrieve original operation in mutation result updates
