### PR TITLE
fix(core): Force client.reexecuteOperation to dispatch

### DIFF
--- a/.changeset/wicked-seahorses-smash.md
+++ b/.changeset/wicked-seahorses-smash.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Explicitly unblock `client.reexecuteOperation` calls to allow stalled operations from continuing and re-executing. Previously, this could cause `@urql/exchange-graphcache` to stall if an optimistic mutation led to a cache miss.

--- a/exchanges/graphcache/src/store/data.test.ts
+++ b/exchanges/graphcache/src/store/data.test.ts
@@ -13,6 +13,7 @@ describe('garbage collection', () => {
   it('erases orphaned entities', () => {
     InMemoryData.writeRecord('Todo:1', '__typename', 'Todo');
     InMemoryData.writeRecord('Todo:1', 'id', '1');
+    InMemoryData.writeRecord('Todo:2', '__typename', 'Todo');
     InMemoryData.writeRecord('Query', '__typename', 'Query');
     InMemoryData.writeLink('Query', 'todo', 'Todo:1');
 
@@ -27,7 +28,7 @@ describe('garbage collection', () => {
     expect(InMemoryData.readRecord('Todo:1', 'id')).toBe(undefined);
 
     expect(InMemoryData.getCurrentDependencies()).toEqual(
-      new Set(['Todo:1', 'Query.todo'])
+      new Set(['Todo:1', 'Todo:2', 'Query.todo'])
     );
   });
 

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -729,6 +729,10 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
       if (operation.kind === 'teardown') {
         dispatchOperation(operation);
       } else if (operation.kind === 'mutation' || active.has(operation.key)) {
+        let queued = false;
+        for (let i = 0; i < queue.length; i++)
+          queued = queued || queue[i].key === operation.key;
+        if (!queued) dispatched.delete(operation.key);
         queue.push(operation);
         Promise.resolve().then(dispatchOperation);
       }


### PR DESCRIPTION
Resolves #3254

## Summary

Previously, when Graphcache issued an optimistic mutation that led to a cache miss, the cache-missed query operation would stall since it wasn't allowed to be issued again.

This patch prevents such “stalls” by forcing operations to be dispatched when `client.reexecuteOperation` is called. This allows Graphcache and related exchanges to force re-execution of operations, regardless of the deduplication behaviour.

## Set of changes

- Add forced dispatching to `client.reexecuteOperation`
