### PR TITLE
docs(next): Enable suspense in non-rsc example

### DIFF
--- a/docs/advanced/server-side-rendering.md
+++ b/docs/advanced/server-side-rendering.md
@@ -238,6 +238,7 @@ const ssr = ssrExchange();
 const client = createClient({
   url: 'https://trygql.formidable.dev/graphql/web-collections',
   exchanges: [cacheExchange, ssr, fetchExchange],
+  suspense: true,
 });
 
 export default function Layout({ children }: React.PropsWithChildren) {


### PR DESCRIPTION
## Summary

The non-rsc example is missing the `suspense: true` argument, so the query never runs on the server like the copy suggests.

## Set of changes

Just enabling suspense in the docs, like it's done in the Next non-rsc example in https://github.com/urql-graphql/urql/blob/main/examples/with-next/app/non-rsc/layout.tsx
