### PR TITLE
docs(next): move ssr and client creation to function body

### DIFF
--- a/docs/advanced/server-side-rendering.md
+++ b/docs/advanced/server-side-rendering.md
@@ -232,16 +232,21 @@ structure it as the following.
 // app/client/layout.tsx
 'use client';
 
+import { useMemo } from 'react';
 import { UrqlProvider, ssrExchange, cacheExchange, fetchExchange, createClient } from '@urql/next';
 
-const ssr = ssrExchange();
-const client = createClient({
-  url: 'https://trygql.formidable.dev/graphql/web-collections',
-  exchanges: [cacheExchange, ssr, fetchExchange],
-  suspense: true,
-});
-
 export default function Layout({ children }: React.PropsWithChildren) {
+  const [client, ssr] = useMemo(() => {
+    const ssr = ssrExchange();
+    const client = createClient({
+      url: 'https://trygql.formidable.dev/graphql/web-collections',
+      exchanges: [cacheExchange, ssr, fetchExchange],
+      suspense: true,
+    });
+
+    return [client, ssr];
+  }, []);
+
   return (
     <UrqlProvider client={client} ssr={ssr}>
       {children}

--- a/examples/with-next/app/non-rsc/layout.tsx
+++ b/examples/with-next/app/non-rsc/layout.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useMemo } from 'react';
 import {
   UrqlProvider,
   ssrExchange,
@@ -8,14 +9,18 @@ import {
   createClient,
 } from '@urql/next';
 
-const ssr = ssrExchange();
-const client = createClient({
-  url: 'https://graphql-pokeapi.graphcdn.app/',
-  exchanges: [cacheExchange, ssr, fetchExchange],
-  suspense: true,
-});
-
 export default function Layout({ children }: React.PropsWithChildren) {
+  const [client, ssr] = useMemo(() => {
+    const ssr = ssrExchange();
+    const client = createClient({
+      url: 'https://graphql-pokeapi.graphcdn.app/',
+      exchanges: [cacheExchange, ssr, fetchExchange],
+      suspense: true,
+    });
+
+    return [client, ssr];
+  }, []);
+
   return (
     <UrqlProvider client={client} ssr={ssr}>
       {children}


### PR DESCRIPTION
Resolves #3367 

## Summary

When we are streaming the results to the client and the server instance gets re-used we risk leaking results from the `ssrExchange` across streamed renders.