### PR TITLE
docs(next): fix import source of useRouter

### DIFF
--- a/docs/advanced/server-side-rendering.md
+++ b/docs/advanced/server-side-rendering.md
@@ -318,7 +318,7 @@ server-component on the client needs refreshing. You can forcefully
 tell the server to do so by using the Next router and calling `.refresh()`.
 
 ```tsx
-import { useRouter } from 'next/router';
+import { useRouter } from 'next/navigation';
 
 const Todo = () => {
   const router = useRouter();


### PR DESCRIPTION
In the documentation, useRouter is imported from next/router, but if you are using App Router, you need to import from next/navigation.
https://nextjs.org/docs/app/api-reference/functions/use-router#migrating-from-nextrouter

The refresh method is not exported from next/router.