### PR TITLE
fix(graphcache): Fix typo in owned data null resolution for resolvers

### DIFF
--- a/.changeset/real-ducks-speak.md
+++ b/.changeset/real-ducks-speak.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix a typo that caused an inverted condition, for checking owned data, to cause incorrect results when handling `null` values and encountering them first.

--- a/exchanges/graphcache/src/operations/query.ts
+++ b/exchanges/graphcache/src/operations/query.ts
@@ -609,7 +609,7 @@ const resolveResolverResult = (
     return hasChanged ? data : prevData;
   } else if (result === null || result === undefined) {
     return result;
-  } else if (!isOwnedData && prevData === null) {
+  } else if (isOwnedData && prevData === null) {
     return null;
   } else if (isDataOrKey(result)) {
     const data = (prevData || InMemoryData.makeData(prevData)) as Data;


### PR DESCRIPTION
Resolves #3370

## Summary

This fixes a typo in an inverted condition for an owned data check in `resolveResolverResult`. The equivalent check in `resolveLink` is `isOwnedData && prevData === null`, i.e. when a prior result was `null` it keeps the field set to `null`.

Instead, the resolver did the opposite and hence turned a first resolution of a `prevData === null` result into a nulled value, i.e. preventing subsequent results from succeeding.

## Set of changes

- Fix inverted `resolveResolverResult` condition for owned `null` values
