### PR TITLE
docs: Rename persisted-fetch-exchange to persisted-exchange in architecture.md

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -193,7 +193,7 @@ Some more exchanges that we can use with our `Client` are:
 - [`ssrExchange`](./advanced/server-side-rendering.md): Allows for a server-side renderer to
   collect results for client-side rehydration.
 - [`retryExchange`](./advanced/retry-operations.md): Allows operations to be retried on errors
-- [`persistedFetchExchange`](./advanced/persistence-and-uploads.md#automatic-persisted-queries): Provides support for Automatic
+- [`persistedExchange`](./advanced/persistence-and-uploads.md#automatic-persisted-queries): Provides support for Automatic
   Persisted Queries
 - [`authExchange`](./advanced/authentication.md): Allows refresh authentication to be implemented easily.
 - [`requestPolicyExchange`](./api/request-policy-exchange.md): Automatically refreshes results given a TTL.


### PR DESCRIPTION
https://github.com/urql-graphql/urql/blob/656495100ea3861075b70b48516b10914efbcfd6/exchanges/persisted/CHANGELOG.md?plain=1#L42

<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR, but please make sure to open an issue or discuss
  your changes first, if you’re looking to submit a larger PR.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary
Rename persisted-fetch-exchange to persisted-exchange in `architecture.md` as the usage was confusing. 

## Set of changes

Updated the doc file.
