### PR TITLE
fix(core): allow controll by signal from fetchOptions

### DIFF
--- a/packages/core/src/internal/fetchSource.ts
+++ b/packages/core/src/internal/fetchSource.ts
@@ -237,14 +237,17 @@ export function makeFetchSource(
   fetchOptions: RequestInit
 ): Source<OperationResult> {
   let abortController: AbortController | void;
+  function abort() {
+    if (abortController) abortController.abort();
+  }
   if (typeof AbortController !== 'undefined') {
+    if (fetchOptions.signal)
+      fetchOptions.signal.addEventListener('abort', abort, { once: true });
     fetchOptions.signal = (abortController = new AbortController()).signal;
   }
   return pipe(
     fromAsyncIterable(fetchOperation(operation, url, fetchOptions)),
     filter((result): result is OperationResult => !!result),
-    onEnd(() => {
-      if (abortController) abortController.abort();
-    })
+    onEnd(abort)
   );
 }


### PR DESCRIPTION
Resolves #3377

## Summary

The `signal` passed from `fetchOptions` by user be ignored and overrided. 

## Set of changes

Listen to `abort` event from user passed `signal` and abort the current request.
