### PR TITLE
fix(core): Add missing teardown handling to ssrExchange

### DIFF
--- a/.changeset/old-swans-relate.md
+++ b/.changeset/old-swans-relate.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Fix missing `teardown` operation handling in the `ssrExchange`. This could lead to duplicate network operations being executed.

--- a/packages/core/src/exchanges/ssr.ts
+++ b/packages/core/src/exchanges/ssr.ts
@@ -222,6 +222,7 @@ export const ssrExchange = (params: SSRExchangeParams = {}): SSRExchange => {
         ops$,
         filter(
           operation =>
+            operation.kind === 'teardown' ||
             !data[operation.key] ||
             !!data[operation.key]!.hasNext ||
             operation.context.requestPolicy === 'network-only'
@@ -236,6 +237,7 @@ export const ssrExchange = (params: SSRExchangeParams = {}): SSRExchange => {
         ops$,
         filter(
           operation =>
+            operation.kind !== 'teardown' &&
             !!data[operation.key] &&
             operation.context.requestPolicy !== 'network-only'
         ),


### PR DESCRIPTION
Resolves #3384

## Summary

This adds a missing exception for forwarding `teardown` operations.
Without this exception, `teardown` operations would be swallowed for operations recorded by the `ssrExchange` which would then trigger unnecessarily in some cases and could be turned into results.

## Set of changes

- Add missing `operation.kind` check to `ssrExchange`
