### PR TITLE
feat(core): Update defer/stream protocol as per spec

### DIFF
--- a/.changeset/fast-jeans-pay.md
+++ b/.changeset/fast-jeans-pay.md
@@ -1,5 +1,5 @@
 ---
-"@urql/core": minor
+"@urql/core": patch
 ---
 
-implement new defer/stream spec
+Implement new `@defer` / `@stream` transport protocol spec changes.

--- a/.changeset/fast-jeans-pay.md
+++ b/.changeset/fast-jeans-pay.md
@@ -1,0 +1,5 @@
+---
+"@urql/core": minor
+---
+
+implement new defer/stream spec

--- a/packages/core/src/internal/fetchSource.ts
+++ b/packages/core/src/internal/fetchSource.ts
@@ -175,9 +175,13 @@ async function* fetchOperation(
       throw new Error(await response.text());
     }
 
+    let pending: ExecutionResult['pending'];
     for await (const payload of results) {
+      if (payload.pending) {
+        pending = payload.pending;
+      }
       result = result
-        ? mergeResultPatch(result, payload, response)
+        ? mergeResultPatch(result, payload, response, pending)
         : makeResult(operation, payload, response);
       networkMode = false;
       yield result;

--- a/packages/core/src/internal/fetchSource.ts
+++ b/packages/core/src/internal/fetchSource.ts
@@ -177,8 +177,10 @@ async function* fetchOperation(
 
     let pending: ExecutionResult['pending'];
     for await (const payload of results) {
-      if (payload.pending) {
+      if (payload.pending && !result) {
         pending = payload.pending;
+      } else if (payload.pending) {
+        pending = [...pending!, ...payload.pending];
       }
       result = result
         ? mergeResultPatch(result, payload, response, pending)

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -140,7 +140,7 @@ export interface IncrementalPayload {
    * items.
    */
   path?: readonly (string | number)[];
-  completed?: Array<{ id: string }>;
+  id?: string;
   subPath?: readonly (string | number)[];
   /** Data to patch into the result data at the given `path`.
    *

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -140,7 +140,14 @@ export interface IncrementalPayload {
    * items.
    */
   path?: readonly (string | number)[];
+  /** An id pointing at an entry in the "pending" set of deferred results
+   *
+   * @remarks
+   * When we resolve this id it will give us the path to the deferred Fragment, this
+   * can be afterwards combined with the subPath to get the eventual location of the data.
+   */
   id?: string;
+  /** A path array from the defer/stream fragment to the location of our data. */
   subPath?: readonly (string | number)[];
   /** Data to patch into the result data at the given `path`.
    *
@@ -179,6 +186,8 @@ export interface ExecutionResult {
    *
    * @remarks
    * This was nely introduced in the defer/stream spec iteration of June 2023 https://github.com/graphql/defer-stream-wg/discussions/69
+   * Pending can be present on both Incremental as well as normal execution results, the presence of pending on an incremental
+   * result points at a nested deferred/streamed fragment.
    */
   pending?: Array<{ path: readonly (string | number)[]; id: string }>;
   /** Incremental patches to be applied to a previous result as part of "Incremental Delivery".

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -139,7 +139,9 @@ export interface IncrementalPayload {
    * entry of the `path` will be an index number at which to start setting the range of
    * items.
    */
-  path: readonly (string | number)[];
+  path?: readonly (string | number)[];
+  completed?: Array<{ id: string }>;
+  subPath?: readonly (string | number)[];
   /** Data to patch into the result data at the given `path`.
    *
    * @remarks
@@ -173,6 +175,12 @@ export interface IncrementalPayload {
 }
 
 export interface ExecutionResult {
+  /** Payloads we are still waiting for from the server.
+   *
+   * @remarks
+   * This was nely introduced in the defer/stream spec iteration of June 2023 https://github.com/graphql/defer-stream-wg/discussions/69
+   */
+  pending?: Array<{ path: readonly (string | number)[]; id: string }>;
   /** Incremental patches to be applied to a previous result as part of "Incremental Delivery".
    *
    * @remarks

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -114,6 +114,8 @@ export interface RequestExtensions {
   [extension: string]: any;
 }
 
+type Path = readonly (string | number)[];
+
 /** Incremental Payloads sent as part of "Incremental Delivery" patching prior result data.
  *
  * @remarks
@@ -139,7 +141,7 @@ export interface IncrementalPayload {
    * entry of the `path` will be an index number at which to start setting the range of
    * items.
    */
-  path?: readonly (string | number)[];
+  path?: Path;
   /** An id pointing at an entry in the "pending" set of deferred results
    *
    * @remarks
@@ -148,7 +150,7 @@ export interface IncrementalPayload {
    */
   id?: string;
   /** A path array from the defer/stream fragment to the location of our data. */
-  subPath?: readonly (string | number)[];
+  subPath?: Path;
   /** Data to patch into the result data at the given `path`.
    *
    * @remarks
@@ -181,6 +183,12 @@ export interface IncrementalPayload {
   extensions?: Extensions;
 }
 
+type PendingIncrementalResult = {
+  path: Path;
+  id: string;
+  label?: string;
+};
+
 export interface ExecutionResult {
   /** Payloads we are still waiting for from the server.
    *
@@ -189,11 +197,7 @@ export interface ExecutionResult {
    * Pending can be present on both Incremental as well as normal execution results, the presence of pending on an incremental
    * result points at a nested deferred/streamed fragment.
    */
-  pending?: Array<{
-    path: readonly (string | number)[];
-    id: string;
-    label?: string;
-  }>;
+  pending?: readonly PendingIncrementalResult[];
   /** Incremental patches to be applied to a previous result as part of "Incremental Delivery".
    *
    * @remarks

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -189,7 +189,11 @@ export interface ExecutionResult {
    * Pending can be present on both Incremental as well as normal execution results, the presence of pending on an incremental
    * result points at a nested deferred/streamed fragment.
    */
-  pending?: Array<{ path: readonly (string | number)[]; id: string }>;
+  pending?: Array<{
+    path: readonly (string | number)[];
+    id: string;
+    label?: string;
+  }>;
   /** Incremental patches to be applied to a previous result as part of "Incremental Delivery".
    *
    * @remarks

--- a/packages/core/src/utils/result.test.ts
+++ b/packages/core/src/utils/result.test.ts
@@ -38,7 +38,127 @@ describe('makeResult', () => {
   });
 });
 
-describe('mergeResultPatch', () => {
+describe.only('mergeResultPatch (defer/stream latest', () => {
+  it('should read pending and append the result', () => {
+    const pending = [{ id: '0', path: [] }];
+    const prevResult: OperationResult = {
+      operation: queryOperation,
+      stale: false,
+      hasNext: true,
+      data: {
+        f2: {
+          a: 'a',
+          b: 'b',
+          c: {
+            d: 'd',
+            e: 'e',
+            f: { h: 'h', i: 'i' },
+          },
+        },
+      },
+    };
+
+    const merged = mergeResultPatch(
+      prevResult,
+      {
+        incremental: [
+          { id: '0', data: { MyFragment: 'Query' } },
+          { id: '0', subPath: ['f2', 'c', 'f'], data: { j: 'j' } },
+        ],
+        completed: [{ id: '0' }],
+        hasNext: false,
+      },
+      undefined,
+      pending
+    );
+
+    expect(merged.data).toEqual({
+      MyFragment: 'Query',
+      f2: {
+        a: 'a',
+        b: 'b',
+        c: {
+          d: 'd',
+          e: 'e',
+          f: { h: 'h', i: 'i', j: 'j' },
+        },
+      },
+    });
+  });
+
+  it('should read pending and append the result w/ overlapping fields', () => {
+    const pending = [
+      { id: '0', path: [], label: 'D1' },
+      { id: '1', path: ['f2', 'c', 'f'], label: 'D2' },
+    ];
+    const prevResult: OperationResult = {
+      operation: queryOperation,
+      stale: false,
+      hasNext: true,
+      data: {
+        f2: {
+          a: 'A',
+          b: 'B',
+          c: {
+            d: 'D',
+            e: 'E',
+            f: {
+              h: 'H',
+              i: 'I',
+            },
+          },
+        },
+      },
+      hasNext: true,
+    };
+
+    const merged = mergeResultPatch(
+      prevResult,
+      {
+        incremental: [
+          { id: '0', subPath: ['f2', 'c', 'f'], data: { j: 'J', k: 'K' } },
+        ],
+        pending: [{ id: '1', path: ['f2', 'c', 'f'], label: 'D2' }],
+        completed: [{ id: '0' }],
+        hasNext: true,
+      },
+      undefined,
+      pending
+    );
+
+    const merged2 = mergeResultPatch(
+      merged,
+      {
+        incremental: [{ id: '1', data: { l: 'L', m: 'M' } }],
+        completed: [{ id: '1' }],
+        hasNext: false,
+      },
+      undefined,
+      pending
+    );
+
+    expect(merged2.data).toEqual({
+      f2: {
+        a: 'A',
+        b: 'B',
+        c: {
+          d: 'D',
+          e: 'E',
+          f: {
+            h: 'H',
+            i: 'I',
+            j: 'J',
+            k: 'K',
+            l: 'L',
+            m: 'M',
+          },
+        },
+      },
+    });
+  });
+});
+
+describe('mergeResultPatch (defer/stream pre June-2023)', () => {
   it('should default hasNext to true if the last result was set to true', () => {
     const prevResult: OperationResult = {
       operation: subscriptionOperation,

--- a/packages/core/src/utils/result.test.ts
+++ b/packages/core/src/utils/result.test.ts
@@ -65,7 +65,8 @@ describe('mergeResultPatch (defer/stream latest', () => {
           { id: '0', data: { MyFragment: 'Query' } },
           { id: '0', subPath: ['f2', 'c', 'f'], data: { j: 'j' } },
         ],
-        completed: [{ id: '0' }],
+        // TODO: not sure if we need this but it's part of the spec
+        // completed: [{ id: '0' }],
         hasNext: false,
       },
       undefined,
@@ -109,7 +110,6 @@ describe('mergeResultPatch (defer/stream latest', () => {
           },
         },
       },
-      hasNext: true,
     };
 
     const merged = mergeResultPatch(
@@ -119,7 +119,6 @@ describe('mergeResultPatch (defer/stream latest', () => {
           { id: '0', subPath: ['f2', 'c', 'f'], data: { j: 'J', k: 'K' } },
         ],
         pending: [{ id: '1', path: ['f2', 'c', 'f'], label: 'D2' }],
-        completed: [{ id: '0' }],
         hasNext: true,
       },
       undefined,
@@ -130,7 +129,6 @@ describe('mergeResultPatch (defer/stream latest', () => {
       merged,
       {
         incremental: [{ id: '1', data: { l: 'L', m: 'M' } }],
-        completed: [{ id: '1' }],
         hasNext: false,
       },
       undefined,

--- a/packages/core/src/utils/result.test.ts
+++ b/packages/core/src/utils/result.test.ts
@@ -38,7 +38,7 @@ describe('makeResult', () => {
   });
 });
 
-describe.only('mergeResultPatch (defer/stream latest', () => {
+describe('mergeResultPatch (defer/stream latest', () => {
   it('should read pending and append the result', () => {
     const pending = [{ id: '0', path: [] }];
     const prevResult: OperationResult = {

--- a/packages/core/src/utils/result.ts
+++ b/packages/core/src/utils/result.ts
@@ -116,9 +116,8 @@ export const mergeResultPatch = (
       let path: readonly (string | number)[] = [];
       if (patch.path) {
         path = patch.path;
-      } else if (pending && patch.completed) {
-        const completed = patch.completed[incremental.indexOf(patch)];
-        const res = pending.find(pendingRes => pendingRes.id === completed.id);
+      } else if (pending) {
+        const res = pending.find(pendingRes => pendingRes.id === patch.id);
         if (patch.subPath) {
           path = [...res!.path, ...patch.subPath];
         } else {


### PR DESCRIPTION
## Summary

In the [new June 2023 spec](https://github.com/graphql/defer-stream-wg/discussions/69) we get the introduction of `pending` on both incremental and execution results, pending contains an array of id and path.

The id will be used in incremental payloads, we can then do a lookup in `pending` and find a path, the path indicates where the fragment got spread starting at the root.

Another addition here is the `subPath` which can be present on an incremental payload and builds on the path we can retrieve through `id`, when deferred selection-sets are mixed with the non-deferred one this subPath will point at where we have to start merging.
