### PR TITLE
feat(next): nonce support

### DIFF
--- a/.changeset/kind-trains-wink.md
+++ b/.changeset/kind-trains-wink.md
@@ -2,4 +2,4 @@
 '@urql/next': minor
 ---
 
-support for nonce
+Support a `nonce` prop on `DataHydrationContextProvider` that passes it onto its script tags' attributes

--- a/.changeset/kind-trains-wink.md
+++ b/.changeset/kind-trains-wink.md
@@ -1,0 +1,5 @@
+---
+'@urql/next': minor
+---
+
+support for nonce

--- a/packages/next-urql/src/DataHydrationContext.ts
+++ b/packages/next-urql/src/DataHydrationContext.ts
@@ -23,12 +23,13 @@ function transportDataToJS(data: any) {
 }
 
 export const DataHydrationContextProvider = ({
+  nonce,
   children,
-}: React.PropsWithChildren<{}>) => {
+}: React.PropsWithChildren<{ nonce?: string }>) => {
   const dataHydrationContext = React.useRef<DataHydrationValue>();
   if (typeof window == 'undefined') {
     if (!dataHydrationContext.current)
-      dataHydrationContext.current = buildContext();
+      dataHydrationContext.current = buildContext({ nonce });
   }
 
   return React.createElement(
@@ -54,7 +55,7 @@ export function useDataHydrationContext(): DataHydrationValue | undefined {
 }
 
 let key = 0;
-function buildContext(): DataHydrationValue {
+function buildContext({ nonce }: { nonce?: string }): DataHydrationValue {
   const dataHydrationContext: DataHydrationValue = {
     isInjecting: false,
     operationValuesByKey: {},
@@ -71,6 +72,7 @@ function buildContext(): DataHydrationValue {
 
       return React.createElement('script', {
         key: key++,
+        nonce: nonce,
         dangerouslySetInnerHTML: { __html },
       });
     },

--- a/packages/next-urql/src/Provider.ts
+++ b/packages/next-urql/src/Provider.ts
@@ -47,14 +47,19 @@ export function UrqlProvider({
   children,
   ssr,
   client,
-}: React.PropsWithChildren<{ ssr: SSRExchange; client: Client }>) {
+  nonce,
+}: React.PropsWithChildren<{
+  ssr: SSRExchange;
+  client: Client;
+  nonce?: string;
+}>) {
   return React.createElement(
     Provider,
     { value: client },
     React.createElement(
       SSRContext.Provider,
       { value: ssr },
-      React.createElement(DataHydrationContextProvider, {}, children)
+      React.createElement(DataHydrationContextProvider, { nonce }, children)
     )
   );
 }


### PR DESCRIPTION
## Summary
Next.js 13.5 has put in some work into achieving a strict CSP through [documentation](https://nextjs.org/docs/pages/building-your-application/configuring/content-security-policy), [example](https://github.com/vercel/next.js/tree/canary/examples/with-strict-csp), and [code](https://github.com/vercel/next.js/discussions/54907).

When trying it out, I discovered the next urql provider doesn't pass through a nonce. This PR adds a optional nonce parameter to the provider:

```
    <UrqlProvider client={client} ssr={ssr} nonce={nonce} >
      {children}
    </UrqlProvider>
``` 

When passed, the script will render with it:
```
<script nonce="NjJiMGYxNDUtZTRjMS00ODYwLWI3ZTUtYmZmMDVkMzY1YTUw">(window[Symbol.for("urql_transport")] ??= []).push({"rehydrate":{"-8349710366": ... />
```

## Set of changes
* added nonce parameter to UrqlProvider and through to script creation

## Not changed
* examples - nonce requires middleware and I think it wouldn't be worth complicating the example with it
* documentation - it could be worth putting a small paragraph about nonce support below https://formidable.com/open-source/urql/docs/advanced/server-side-rendering/#disabling-rsc-fetch-caching and reference some of the links in the summary.