### PR TITLE
Fix `preferGetMethod` client option

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -572,7 +572,7 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
     fetchSubscriptions: opts.fetchSubscriptions,
     fetchOptions: opts.fetchOptions,
     fetch: opts.fetch,
-    preferGetMethod: !!opts.preferGetMethod,
+    preferGetMethod: opts.preferGetMethod,
     requestPolicy: opts.requestPolicy || 'cache-first',
   };
 


### PR DESCRIPTION
Urql client was ignore 'force' and 'within-url-limit' options for `preferGetMethod` by simply casting it to boolean.

Now `preferGetMethod` works as expected

