### PR TITLE
fix(next): invalid CJS React import

### DIFF
--- a/.changeset/hungry-rings-switch.md
+++ b/.changeset/hungry-rings-switch.md
@@ -1,0 +1,5 @@
+---
+'@urql/next': patch
+---
+
+Fix invalid CJS by importing react with import-all semantics

--- a/packages/next-urql/src/DataHydrationContext.ts
+++ b/packages/next-urql/src/DataHydrationContext.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { ServerInsertedHTMLContext } from 'next/navigation';
 import type { UrqlResult } from './useUrqlValue';
 

--- a/packages/next-urql/src/Provider.ts
+++ b/packages/next-urql/src/Provider.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import * as React from 'react';
 import type { SSRExchange, Client } from 'urql';
 import { Provider } from 'urql';
 import { DataHydrationContextProvider } from './DataHydrationContext';

--- a/packages/next-urql/src/useUrqlValue.ts
+++ b/packages/next-urql/src/useUrqlValue.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import * as React from 'react';
 import { useDataHydrationContext } from './DataHydrationContext';
 import { SSRContext } from './Provider';
 


### PR DESCRIPTION
Resolves #3400 

## Summary

When leveraging the compatibility settings for React and using the default import we get a very weird statement that isn't supported by all CJS using bundlers.