### PR TITLE
fix(react): prioritise context.suspense

### DIFF
--- a/.changeset/real-geese-grow.md
+++ b/.changeset/real-geese-grow.md
@@ -1,5 +1,6 @@
 ---
 'urql': patch
+'@urql/preact': patch
 ---
 
 Prioritise `context.suspense` and fallback to checking `client.suspense`

--- a/.changeset/real-geese-grow.md
+++ b/.changeset/real-geese-grow.md
@@ -1,0 +1,5 @@
+---
+'urql': patch
+---
+
+Prioritise `context.suspense` and fallback to checking `client.suspense`

--- a/packages/preact-urql/src/hooks/useQuery.ts
+++ b/packages/preact-urql/src/hooks/useQuery.ts
@@ -212,7 +212,9 @@ function toSuspenseSource<T>(source: Source<T>): Source<T> {
 }
 
 const isSuspense = (client: Client, context?: Partial<OperationContext>) =>
-  client.suspense && (!context || context.suspense !== false);
+  context && context.suspense !== undefined
+    ? !!context.suspense
+    : client.suspense;
 
 const sources = new Map<number, Source<OperationResult>>();
 

--- a/packages/react-urql/src/hooks/useQuery.ts
+++ b/packages/react-urql/src/hooks/useQuery.ts
@@ -174,8 +174,10 @@ export type UseQueryResponse<
   Variables extends AnyVariables = AnyVariables,
 > = [UseQueryState<Data, Variables>, UseQueryExecute];
 
-const isSuspense = (client: Client, context?: Partial<OperationContext>) =>
-  client.suspense && (!context || context.suspense !== false);
+const isSuspense = (client: Client, context?: Partial<OperationContext>) => {
+  if (context && context.suspense !== undefined) return !!context.suspense;
+  return client.suspense;
+};
 
 /** Hook to run a GraphQL query and get updated GraphQL results.
  *

--- a/packages/react-urql/src/hooks/useQuery.ts
+++ b/packages/react-urql/src/hooks/useQuery.ts
@@ -174,10 +174,10 @@ export type UseQueryResponse<
   Variables extends AnyVariables = AnyVariables,
 > = [UseQueryState<Data, Variables>, UseQueryExecute];
 
-const isSuspense = (client: Client, context?: Partial<OperationContext>) => {
-  if (context && context.suspense !== undefined) return !!context.suspense;
-  return client.suspense;
-};
+const isSuspense = (client: Client, context?: Partial<OperationContext>) =>
+  context && context.suspense !== undefined
+    ? !!context.suspense
+    : client.suspense;
 
 /** Hook to run a GraphQL query and get updated GraphQL results.
  *


### PR DESCRIPTION
Resolves #3426 

## Summary

When `context.suspense` is defined we should respect that value and only fallback to `client.suspense` when it's undefined
