### PR TITLE
feat(graphcache): add onCacheHydrated event

### DIFF
--- a/.changeset/stale-eagles-hide.md
+++ b/.changeset/stale-eagles-hide.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': minor
+---
+
+Add `onCacheHydrated` as an option for the `StorageAdapter`

--- a/docs/api/graphcache.md
+++ b/docs/api/graphcache.md
@@ -178,13 +178,14 @@ the cache's data to persisted storage on the user's device. it
 > **NOTE:** Offline Support is currently experimental! It hasn't been extensively tested yet and
 > may not always behave as expected. Please try it out with caution!
 
-| Method          | Type                                          | Description                                                                                                                                                                            |
-| --------------- | --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `writeData`     | `(delta: SerializedEntries) => Promise<void>` | This provided method must be able to accept an object of key-value entries that will be persisted to the storage. This method is called as a batch of updated entries becomes ready.   |
-| `readData`      | `() => Promise<SerializedEntries>`            | This provided method must be able to return a single combined object of previous key-value entries that have been previously preserved using `writeData`. It's only called on startup. |
-| `writeMetadata` | `(json: SerializedRequest[]) => void`         | This provided method must be able to persist metadata for the cache. For backwards compatibility it should be able to accept any JSON data.                                            |
-| `readMetadata`  | `() => Promise<null \| SerializedRequest[]>`  | This provided method must be able to read the persisted metadata that has previously been written using `writeMetadata`. It's only called on startup.                                  |
-| `onOnline`      | `(cb: () => void) => void`                    | This method must be able to accept a callback that is called when the user's device comes back online.                                                                                 |
+| Method            | Type                                          | Description                                                                                                                                                                            |
+| ----------------- | --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `writeData`       | `(delta: SerializedEntries) => Promise<void>` | This provided method must be able to accept an object of key-value entries that will be persisted to the storage. This method is called as a batch of updated entries becomes ready.   |
+| `readData`        | `() => Promise<SerializedEntries>`            | This provided method must be able to return a single combined object of previous key-value entries that have been previously preserved using `writeData`. It's only called on startup. |
+| `writeMetadata`   | `(json: SerializedRequest[]) => void`         | This provided method must be able to persist metadata for the cache. For backwards compatibility it should be able to accept any JSON data.                                            |
+| `readMetadata`    | `() => Promise<null \| SerializedRequest[]>`  | This provided method must be able to read the persisted metadata that has previously been written using `writeMetadata`. It's only called on startup.                                  |
+| `onOnline`        | `(cb: () => void) => void`                    | This method must be able to accept a callback that is called when the user's device comes back online.                                                                                 |
+| `onCacheHydrated` | `() => void`                                  | This method will be called when the `cacheExchange` has finished hydrating the data coming from storage.                                                                               |
 
 These options are split into three parts:
 

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -73,6 +73,7 @@ export const cacheExchange =
       store.data.hydrating = true;
       opts.storage.readData().then(entries => {
         hydrateData(store.data, opts!.storage!, entries);
+        if (opts.storage!.onCacheHydrated) opts.storage!.onCacheHydrated();
       });
     }
 

--- a/exchanges/graphcache/src/default-storage/index.ts
+++ b/exchanges/graphcache/src/default-storage/index.ts
@@ -35,6 +35,8 @@ export interface StorageOptions {
    * @defaultValue `7` days
    */
   maxAge?: number;
+  /** Gets Called when the exchange has hydrated the data from storage. */
+  onCacheHydrated?: () => void;
 }
 
 /** Sample storage adapter persisting to IndexedDB. */
@@ -219,7 +221,7 @@ export const makeDefaultStorage = (opts?: StorageOptions): DefaultStorage => {
           () => batch
         );
     },
-
+    onCacheHydrated: opts.onCacheHydrated,
     onOnline(cb: () => void) {
       if (callback) {
         window.removeEventListener('online', callback);

--- a/exchanges/graphcache/src/types.ts
+++ b/exchanges/graphcache/src/types.ts
@@ -980,6 +980,8 @@ export interface StorageAdapter {
    * will cause all failed mutations in the queue to be retried.
    */
   onOnline?(cb: () => void): any;
+  /** Called when the cache has been hydrated with the data from `readData` */
+  onCacheHydrated?(): any;
 }
 
 /** Set of keys that have been modified or accessed.


### PR DESCRIPTION
Resolves https://github.com/urql-graphql/urql/issues/3422

## Summary

We used to buffer operations while the cache hydrates from storage, this got disabled in our latest release however we can enable folks to still have this. We now support the `cacheExchange` calling `storage.onCacheHydrated` this way folks can load their shell but leave the content in a loading state while the storage hydrates the data.
