### PR TITLE
chore(core): try to parse a text/plain content-type response as json

### DIFF
--- a/.changeset/silver-planets-sniff.md
+++ b/.changeset/silver-planets-sniff.md
@@ -2,4 +2,4 @@
 '@urql/core': minor
 ---
 
-Try to parse no content-type as JSON because we are dealing with GraphQL
+Try to parse `text/plain` content-type as JSON before bailing out with an error.

--- a/.changeset/silver-planets-sniff.md
+++ b/.changeset/silver-planets-sniff.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': minor
+---
+
+Try to parse no content-type as JSON because we are dealing with GraphQL

--- a/packages/core/src/internal/fetchSource.ts
+++ b/packages/core/src/internal/fetchSource.ts
@@ -169,7 +169,7 @@ async function* fetchOperation(
       results = parseMultipartMixed(contentType, response);
     } else if (/text\/event-stream/i.test(contentType)) {
       results = parseEventStream(response);
-    } else if (!/text\//i.test(contentType)) {
+    } else if (!/text\//i.test(contentType) || !contentType) {
       results = parseJSON(response);
     } else {
       throw new Error(await response.text());

--- a/packages/core/src/internal/fetchSource.ts
+++ b/packages/core/src/internal/fetchSource.ts
@@ -169,7 +169,7 @@ async function* fetchOperation(
       results = parseMultipartMixed(contentType, response);
     } else if (/text\/event-stream/i.test(contentType)) {
       results = parseEventStream(response);
-    } else if (!/text\//i.test(contentType) || !contentType) {
+    } else if (!/text\//i.test(contentType)) {
       results = parseJSON(response);
     } else {
       if (contentType === 'text/plain') {


### PR DESCRIPTION
## Summary

As seen in https://github.com/urql-graphql/urql/discussions/3429, some servers send back the response as `text/plain` which can still be valid JSON.
