### PR TITLE
Make useQuery refetch async

### DIFF
--- a/packages/react-urql/src/hooks/useQuery.spec.ts
+++ b/packages/react-urql/src/hooks/useQuery.spec.ts
@@ -267,7 +267,9 @@ describe('useQuery', () => {
     expect(client.executeQuery).toBeCalledTimes(1);
 
     const [, executeQuery] = result.current;
-    act(() => executeQuery());
+    act(() => {
+      executeQuery();
+    });
     await waitForNextUpdate();
     expect(client.executeQuery).toBeCalledTimes(2);
   });

--- a/packages/react-urql/src/hooks/useQuery.ts
+++ b/packages/react-urql/src/hooks/useQuery.ts
@@ -158,7 +158,7 @@ export interface UseQueryState<
  * };
  * ```
  */
-export type UseQueryExecute = (opts?: Partial<OperationContext>) => void;
+export type UseQueryExecute = (opts?: Partial<OperationContext>) => Promise<unknown>;
 
 /** Result tuple returned by the {@link useQuery} hook.
  *
@@ -355,7 +355,7 @@ export function useQuery<
   }, [cache, state[0], state[2][1]]);
 
   const executeQuery = React.useCallback(
-    (opts?: Partial<OperationContext>) => {
+    (opts?: Partial<OperationContext>) => new Promise((resolve) => {
       const context = {
         requestPolicy: args.requestPolicy,
         ...args.context,
@@ -371,9 +371,10 @@ export function useQuery<
               })
             )
           : client.executeQuery(request, context);
+        source.then(resolve);
         return [source, state[1], deps];
       });
-    },
+    }),
     [
       client,
       cache,


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR, but please make sure to open an issue or discuss
  your changes first, if you’re looking to submit a larger PR.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

In my React app I want to be able to `await` the refetch function, for example to call another function after refetch is done

## Set of changes

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->
Mainly the React package's `useQuery.ts`. Let me know if there's a better way to promisify this using wonka
