### PR TITLE
fix(persisted): Add dev warning for persisted-miss results for an already persisted-miss errored operation (repeated retries)

### DIFF
--- a/.changeset/late-plants-poke.md
+++ b/.changeset/late-plants-poke.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-persisted': patch
+---
+
+Warn about cached persisted-miss results in development, when a `persistedExchange()` sees a persisted-miss error for a result that's already seen a persisted-miss error (i.e. two misses). This shouldn't happen unless something is caching persisted errors and we should warn about this appropriately.

--- a/exchanges/persisted/src/persistedExchange.test.ts
+++ b/exchanges/persisted/src/persistedExchange.test.ts
@@ -147,6 +147,10 @@ it('fails gracefully when an invalid result with `PersistedQueryNotFound` is alw
       miss: true,
     },
   });
+
+  expect(console.warn).toHaveBeenLastCalledWith(
+    expect.stringMatching(/two misses/i)
+  );
 });
 
 it('skips operation when generateHash returns a nullish value', async () => {

--- a/exchanges/persisted/src/persistedExchange.test.ts
+++ b/exchanges/persisted/src/persistedExchange.test.ts
@@ -119,6 +119,36 @@ it('retries query persisted query resulted in unsupported', async () => {
   expect(operations[2].extensions).toEqual(undefined);
 });
 
+it('fails gracefully when an invalid result with `PersistedQueryNotFound` is always delivered', async () => {
+  const { result, operations, exchangeArgs } = makeExchangeArgs();
+
+  result.mockImplementation(operation => ({
+    ...queryResponse,
+    operation,
+    error: new CombinedError({
+      graphQLErrors: [{ message: 'PersistedQueryNotFound' }],
+    }),
+  }));
+
+  const res = await pipe(
+    fromValue(queryOperation),
+    persistedExchange()(exchangeArgs),
+    take(1),
+    toPromise
+  );
+
+  expect(res.operation.context.persistAttempt).toBe(true);
+  expect(operations.length).toBe(2);
+
+  expect(operations[1].extensions).toEqual({
+    persistedQuery: {
+      version: 1,
+      sha256Hash: expect.any(String),
+      miss: true,
+    },
+  });
+});
+
 it('skips operation when generateHash returns a nullish value', async () => {
   const { result, operations, exchangeArgs } = makeExchangeArgs();
 

--- a/exchanges/persisted/src/persistedExchange.ts
+++ b/exchanges/persisted/src/persistedExchange.ts
@@ -216,6 +216,18 @@ export const persistedExchange =
               retries.next(followupOperation);
               return null;
             } else if (result.error && isPersistedMiss(result.error)) {
+              if (result.operation.extensions.persistedQuery.miss) {
+                if (process.env.NODE_ENV !== 'production') {
+                  console.warn(
+                    'persistedExchange()’s results include two misses for the same operation.\n' +
+                      'This is not expected as it means a persisted error has been delivered for a non-persisted query!\n' +
+                      'Another exchange with a cache may be delivering an outdated result. For example, a server-side ssrExchange() may be caching an errored result.\n' +
+                      'Try moving the persistedExchange() in past these exchanges, for example in front of your fetchExchange.'
+                  );
+                }
+
+                return result;
+              }
               // Update operation with unsupported attempt
               const followupOperation = makeOperation(
                 result.operation.kind,


### PR DESCRIPTION
Closes #3441

## Summary

When a `persistedExchange()` sees a persisted-miss error, it will retry the operation while disabling persisted serialization using the `miss: true` flag. However, we had no guard to check whether `miss: true` was already set.

This meant that if an API/exchange erroneously keeps replying with persisted-miss errors then `persistedExchange()` wouldn't stop retrying the operation.
When an `ssrExchange()` on the server-side caches this error, this is made worse, since `ssrExchange`'s results are synchronous and this hence causes an infinite loop.

A development-time warning has been added that explicitly tells people that this is what's going on and how to resolve it.

## Set of changes

- Add failing test for repeated persisted-miss errors
- Handle & Ignore repeated persisted-miss errors and log development warning
