### PR TITLE
feat(graphcache): add logger interface

### DIFF
--- a/.changeset/tender-files-tie.md
+++ b/.changeset/tender-files-tie.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': minor
+---
+
+Add optional `logger` to the options, this allows you to filter out warnings or disable them all together

--- a/docs/api/graphcache.md
+++ b/docs/api/graphcache.md
@@ -32,6 +32,7 @@ options and returns an [`Exchange`](./core.md#exchange).
 | `optimistic` | A mapping of mutation fields to resolvers that may be used to provide _Graphcache_ with an optimistic result for a given mutation field that should be applied to the cached data temporarily.                                |
 | `schema`     | A serialized GraphQL schema that is used by _Graphcache_ to resolve partial data, interfaces, and enums. The schema also used to provide helpful warnings for [schema awareness](../graphcache/schema-awareness.md).          |
 | `storage`    | A persisted storage interface that may be provided to preserve cache data for [offline support](../graphcache/offline.md).                                                                                                    |
+| `logger`     | A function that will be invoked for warning/debug/... logs                                                                                                                                                                    |
 
 The `@urql/exchange-graphcache` package also exports the `offlineExchange`; which is identical to
 the `cacheExchange` but activates [offline support](../graphcache/offline.md) when the `storage` option is passed.

--- a/exchanges/graphcache/src/ast/schemaPredicates.test.ts
+++ b/exchanges/graphcache/src/ast/schemaPredicates.test.ts
@@ -57,13 +57,13 @@ describe('SchemaPredicates', () => {
 
   it('should indicate nullability', () => {
     expect(
-      SchemaPredicates.isFieldNullable(schema, 'Todo', 'text')
+      SchemaPredicates.isFieldNullable(schema, 'Todo', 'text', undefined)
     ).toBeFalsy();
     expect(
-      SchemaPredicates.isFieldNullable(schema, 'Todo', 'complete')
+      SchemaPredicates.isFieldNullable(schema, 'Todo', 'complete', undefined)
     ).toBeTruthy();
     expect(
-      SchemaPredicates.isFieldNullable(schema, 'Todo', 'author')
+      SchemaPredicates.isFieldNullable(schema, 'Todo', 'author', undefined)
     ).toBeTruthy();
   });
 
@@ -89,7 +89,12 @@ describe('SchemaPredicates', () => {
 
   it('should throw if a requested type does not exist', () => {
     expect(() =>
-      SchemaPredicates.isFieldNullable(schema, 'SomeInvalidType', 'complete')
+      SchemaPredicates.isFieldNullable(
+        schema,
+        'SomeInvalidType',
+        'complete',
+        undefined
+      )
     ).toThrow(
       'The type `SomeInvalidType` is not an object in the defined schema, but the GraphQL document is traversing it.\nhttps://bit.ly/2XbVrpR#3'
     );
@@ -97,7 +102,7 @@ describe('SchemaPredicates', () => {
 
   it('should warn in console if a requested field does not exist', () => {
     expect(
-      SchemaPredicates.isFieldNullable(schema, 'Todo', 'goof')
+      SchemaPredicates.isFieldNullable(schema, 'Todo', 'goof', undefined)
     ).toBeFalsy();
 
     expect(console.warn).toBeCalledTimes(1);

--- a/exchanges/graphcache/src/helpers/help.ts
+++ b/exchanges/graphcache/src/helpers/help.ts
@@ -7,6 +7,7 @@ import type {
   ExecutableDefinitionNode,
   InlineFragmentNode,
 } from '@0no-co/graphql.web';
+import type { Logger } from '../types';
 import { Kind } from '@0no-co/graphql.web';
 
 export type ErrorCode =
@@ -89,9 +90,17 @@ export function invariant(
   }
 }
 
-export function warn(message: string, code: ErrorCode) {
+export function warn(
+  message: string,
+  code: ErrorCode,
+  logger: Logger | undefined
+) {
   if (!cache.has(message)) {
-    console.warn(message + getDebugOutput() + helpUrl + code);
+    if (logger) {
+      logger('warn', message + getDebugOutput() + helpUrl + code);
+    } else {
+      console.warn(message + getDebugOutput() + helpUrl + code);
+    }
     cache.add(message);
   }
 }

--- a/exchanges/graphcache/src/operations/shared.ts
+++ b/exchanges/graphcache/src/operations/shared.ts
@@ -25,6 +25,7 @@ import type {
   Link,
   Entity,
   Data,
+  Logger,
 } from '../types';
 
 export interface Context {
@@ -117,7 +118,8 @@ const isFragmentHeuristicallyMatching = (
   node: FormattedNode<InlineFragmentNode | FragmentDefinitionNode>,
   typename: void | string,
   entityKey: string,
-  vars: Variables
+  vars: Variables,
+  logger?: Logger
 ) => {
   if (!typename) return false;
   const typeCondition = getTypeCondition(node);
@@ -134,7 +136,8 @@ const isFragmentHeuristicallyMatching = (
       '` may be an ' +
       'interface.\nA schema needs to be defined for this match to be deterministic, ' +
       'otherwise the fragment will be matched heuristically!',
-    16
+    16,
+    logger
   );
 
   return (
@@ -192,7 +195,8 @@ export const makeSelectionIterator = (
                     fragment,
                     typename,
                     entityKey,
-                    ctx.variables
+                    ctx.variables,
+                    ctx.store.logger
                   ));
             if (isMatching) {
               if (process.env.NODE_ENV !== 'production')
@@ -234,7 +238,8 @@ export const ensureLink = (store: Store, ref: Link<Entity>): Link => {
         '\nYou have to pass an `id` or `_id` field or create a custom `keys` config for `' +
         ref.__typename +
         '`.',
-      12
+      12,
+      store.logger
     );
   }
 

--- a/exchanges/graphcache/src/operations/write.ts
+++ b/exchanges/graphcache/src/operations/write.ts
@@ -147,7 +147,8 @@ export const _writeFragment = (
           ' but could only find ' +
           Object.keys(fragments).join(', ') +
           '.',
-        11
+        11,
+        store.logger
       );
 
       return null;
@@ -159,7 +160,8 @@ export const _writeFragment = (
       warn(
         'writeFragment(...) was called with an empty fragment.\n' +
           'You have to call it with at least one fragment in your GraphQL document.',
-        11
+        11,
+        store.logger
       );
 
       return null;
@@ -175,7 +177,8 @@ export const _writeFragment = (
         'You have to pass an `id` or `_id` field or create a custom `keys` config for `' +
         typename +
         '`.',
-      12
+      12,
+      store.logger
     );
   }
 
@@ -223,7 +226,8 @@ const writeSelection = (
     warn(
       "Couldn't find __typename when writing.\n" +
         "If you're writing to the cache manually have to pass a `__typename` property on each entity in your data.",
-      14
+      14,
+      ctx.store.logger
     );
     return;
   } else if (!isRoot && entityKey) {
@@ -260,7 +264,12 @@ const writeSelection = (
 
     if (process.env.NODE_ENV !== 'production') {
       if (ctx.store.schema && typename && fieldName !== '__typename') {
-        isFieldAvailableOnType(ctx.store.schema, typename, fieldName);
+        isFieldAvailableOnType(
+          ctx.store.schema,
+          typename,
+          fieldName,
+          ctx.store.logger
+        );
       }
     }
 
@@ -309,7 +318,8 @@ const writeSelection = (
               '` is `undefined`, but the GraphQL query expects a ' +
               expected +
               ' for this field.',
-            13
+            13,
+            ctx.store.logger
           );
         }
       }
@@ -426,7 +436,8 @@ const writeField = (
         'If this is intentional, create a `keys` config for `' +
         typename +
         '` that always returns null.',
-      15
+      15,
+      ctx.store.logger
     );
   }
 

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -17,6 +17,7 @@ import type {
   Entity,
   CacheExchangeOpts,
   DirectivesConfig,
+  Logger,
 } from '../types';
 
 import { invariant } from '../helpers/help';
@@ -48,6 +49,7 @@ export class Store<
 {
   data: InMemoryData.InMemoryData;
 
+  logger?: Logger;
   directives: DirectivesConfig;
   resolvers: ResolverConfig;
   updates: UpdatesConfig;
@@ -62,6 +64,7 @@ export class Store<
   constructor(opts?: C) {
     if (!opts) opts = {} as C;
 
+    this.logger = opts.logger;
     this.resolvers = opts.resolvers || {};
     this.directives = opts.directives || {};
     this.optimisticMutations = opts.optimistic || {};
@@ -100,12 +103,13 @@ export class Store<
     this.data = InMemoryData.make(queryName);
 
     if (this.schema && process.env.NODE_ENV !== 'production') {
-      expectValidKeyingConfig(this.schema, this.keys);
-      expectValidUpdatesConfig(this.schema, this.updates);
-      expectValidResolversConfig(this.schema, this.resolvers);
+      expectValidKeyingConfig(this.schema, this.keys, this.logger);
+      expectValidUpdatesConfig(this.schema, this.updates, this.logger);
+      expectValidResolversConfig(this.schema, this.resolvers, this.logger);
       expectValidOptimisticMutationsConfig(
         this.schema,
-        this.optimisticMutations
+        this.optimisticMutations,
+        this.logger
       );
     }
   }

--- a/exchanges/graphcache/src/types.ts
+++ b/exchanges/graphcache/src/types.ts
@@ -541,10 +541,20 @@ export type ResolverResult =
   | null
   | undefined;
 
-export type Logger = (severity: 'error' | 'warn', message: string) => void;
+export type Logger = (
+  severity: 'debug' | 'error' | 'warn',
+  message: string
+) => void;
 
 /** Input parameters for the {@link cacheExchange}. */
 export type CacheExchangeOpts = {
+  /** Configure a custom-logger for graphcache, this function wll be called with a severity and a message.
+   *
+   * @remarks
+   * By default we will invoke `console.warn` for warnings during development, however you might want to opt
+   * out of this because you are re-using urql for a different library. This setting allows you to stub the logger
+   * function or filter to only logs you want.
+   */
   logger?: Logger;
   /** Configures update functions which are called when the mapped fields are written to the cache.
    *

--- a/exchanges/graphcache/src/types.ts
+++ b/exchanges/graphcache/src/types.ts
@@ -541,8 +541,11 @@ export type ResolverResult =
   | null
   | undefined;
 
+export type Logger = (severity: 'error' | 'warn', message: string) => void;
+
 /** Input parameters for the {@link cacheExchange}. */
 export type CacheExchangeOpts = {
+  logger?: Logger;
   /** Configures update functions which are called when the mapped fields are written to the cache.
    *
    * @remarks


### PR DESCRIPTION
Resolves #3404

## Summary

This adds an option to the `graphCache` constructor named `Logger` we will use the logger to convey information that is encountered during development. In doing so a user can choose to remove the warnings by stubbing the logger with `() => {}` or adding other custom logic to filter things out.

## Set of changes

- add `Logger` interface for graph-cache
