### PR TITLE
docs(graphcache): add missing globalids setting

### DIFF
--- a/docs/api/graphcache.md
+++ b/docs/api/graphcache.md
@@ -32,6 +32,7 @@ options and returns an [`Exchange`](./core.md#exchange).
 | `optimistic` | A mapping of mutation fields to resolvers that may be used to provide _Graphcache_ with an optimistic result for a given mutation field that should be applied to the cached data temporarily.                                |
 | `schema`     | A serialized GraphQL schema that is used by _Graphcache_ to resolve partial data, interfaces, and enums. The schema also used to provide helpful warnings for [schema awareness](../graphcache/schema-awareness.md).          |
 | `storage`    | A persisted storage interface that may be provided to preserve cache data for [offline support](../graphcache/offline.md).                                                                                                    |
+| `globalIDs`  | A boolean or list of typenames that have globally unique ids, this changes how graphcache internally keys the entities. This can be useful for complex interface relationships.                                               |
 | `logger`     | A function that will be invoked for warning/debug/... logs                                                                                                                                                                    |
 
 The `@urql/exchange-graphcache` package also exports the `offlineExchange`; which is identical to


### PR DESCRIPTION
Noticed we had a new setting that wasn't documented