### PR TITLE
feat(graphcache): debug logs for cache misses

### DIFF
--- a/.changeset/mean-onions-share.md
+++ b/.changeset/mean-onions-share.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Debugging cache misses

--- a/exchanges/graphcache/src/operations/query.ts
+++ b/exchanges/graphcache/src/operations/query.ts
@@ -537,6 +537,18 @@ const readSelection = (
       ctx.partial = true;
       dataFieldValue = null;
     } else if (dataFieldValue === null && directives.required) {
+      if (
+        ctx.store.logger &&
+        process.env.NODE_ENV !== 'production' &&
+        InMemoryData.currentOperation === 'read'
+      ) {
+        ctx.store.logger(
+          'debug',
+          `Got value "null" for required field "${fieldName}"${
+            fieldArgs ? ` with args ${JSON.stringify(fieldArgs)}` : ''
+          } on type "${typename}" with id "${entityKey}"`
+        );
+      }
       dataFieldValue = undefined;
     } else {
       hasFields = hasFields || fieldName !== '__typename';
@@ -551,6 +563,18 @@ const readSelection = (
     } else if (deferRef) {
       hasNext = true;
     } else {
+      if (
+        ctx.store.logger &&
+        process.env.NODE_ENV !== 'production' &&
+        InMemoryData.currentOperation === 'read'
+      ) {
+        ctx.store.logger(
+          'debug',
+          `No value for field "${fieldName}"${
+            fieldArgs ? ` with args ${JSON.stringify(fieldArgs)}` : ''
+          } on type "${typename}" with id "${entityKey}"`
+        );
+      }
       // If the field isn't deferred or partial then we have to abort and also reset
       // the partial field
       ctx.partial = hasPartials;

--- a/exchanges/graphcache/src/operations/query.ts
+++ b/exchanges/graphcache/src/operations/query.ts
@@ -546,7 +546,7 @@ const readSelection = (
           'debug',
           `Got value "null" for required field "${fieldName}"${
             fieldArgs ? ` with args ${JSON.stringify(fieldArgs)}` : ''
-          } on type "${typename}" with id "${entityKey}"`
+          } on entity "${entityKey}"`
         );
       }
       dataFieldValue = undefined;
@@ -572,7 +572,7 @@ const readSelection = (
           'debug',
           `No value for field "${fieldName}"${
             fieldArgs ? ` with args ${JSON.stringify(fieldArgs)}` : ''
-          } on type "${typename}" with id "${entityKey}"`
+          } on entity "${entityKey}"`
         );
       }
       // If the field isn't deferred or partial then we have to abort and also reset


### PR DESCRIPTION
Resolves #3382

## Summary

This will log when we are missing a field on a selection, this can be useful for debugging cache misses in development. This is opt-in by defining the new `logger` interface and listening for `debug` logs.
