### PR TITLE
chore(next): warn for missing suspense boundary

### DIFF
--- a/.changeset/small-rings-drop.md
+++ b/.changeset/small-rings-drop.md
@@ -1,0 +1,5 @@
+---
+'@urql/next': patch
+---
+
+Show a warning when the `Suspense` boundary is missing under the UrqlProvider

--- a/packages/next-urql/src/Provider.ts
+++ b/packages/next-urql/src/Provider.ts
@@ -9,6 +9,15 @@ export const SSRContext = React.createContext<SSRExchange | undefined>(
   undefined
 );
 
+const SuspenseWarning = () => {
+  if (process.env.NODE_ENV !== 'production') {
+    console.warn(
+      'urql suspended but there was no boundary to catch it, add a <Suspense> component under your urql Provider.'
+    );
+  }
+  return null;
+};
+
 /** Provider for `@urql/next` during non-rsc interactions.
  *
  * @remarks
@@ -59,7 +68,15 @@ export function UrqlProvider({
     React.createElement(
       SSRContext.Provider,
       { value: ssr },
-      React.createElement(DataHydrationContextProvider, { nonce }, children)
+      React.createElement(
+        DataHydrationContextProvider,
+        { nonce },
+        React.createElement(
+          React.Suspense,
+          { fallback: React.createElement(SuspenseWarning) },
+          children
+        )
+      )
     )
   );
 }


### PR DESCRIPTION
Related to #3448 and #3408

## Summary

We have seen a few issues where folks forget their Suspense boundary which leads to infinite requests. We will shield from infinite requests by providing our own underneath the `urql` provider so the client doesn't get re-created and give the user a warning when we are not in production.
