### PR TITLE
fix(core): Fix JSON stringification in Vercel Edge runtime

### DIFF
--- a/.changeset/fifty-tables-happen.md
+++ b/.changeset/fifty-tables-happen.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Fix incorrect JSON stringification of objects from different JS contexts. This could lead to invalid variables being generated in the Vercel Edge runtime specifically.

--- a/packages/core/src/utils/variables.test.ts
+++ b/packages/core/src/utils/variables.test.ts
@@ -40,6 +40,26 @@ describe('stringifyVariables', () => {
     expect(stringifyVariables(Object.create(null))).toBe('{}');
   });
 
+  it('recovers if the root object is a dictionary (Object.create(null)) and nests a plain object', () => {
+    const root = Object.create(null);
+    root.data = { test: true };
+    expect(stringifyVariables(root)).toBe('{"data":{"test":true}}');
+  });
+
+  it('recovers if the root object contains a dictionary (Object.create(null))', () => {
+    const data = Object.create(null);
+    data.test = true;
+    const root = { data };
+    expect(stringifyVariables(root)).toBe('{"data":{"test":true}}');
+  });
+
+  it('replaces non-plain objects at the root with keyed replacements', () => {
+    expect(stringifyVariables(new (class Test {})())).toMatch(
+      /^{"__key":"\w+"}$/
+    );
+    expect(stringifyVariables(new Map())).toMatch(/^{"__key":"\w+"}$/);
+  });
+
   it('stringifies files correctly', () => {
     const file = new File([0] as any, 'test.js');
     const str = stringifyVariables(file);

--- a/packages/core/src/utils/variables.ts
+++ b/packages/core/src/utils/variables.ts
@@ -29,7 +29,7 @@ const stringify = (x: any): string => {
   if (
     !keys.length &&
     x.constructor &&
-    Object.getPrototypeOf(x).constructor.name === 'Object'
+    Object.getPrototypeOf(x).constructor.name !== 'Object'
   ) {
     const key = cache.get(x) || Math.random().toString(36).slice(2);
     cache.set(x, key);

--- a/packages/core/src/utils/variables.ts
+++ b/packages/core/src/utils/variables.ts
@@ -26,7 +26,7 @@ const stringify = (x: any): string => {
   }
 
   const keys = Object.keys(x).sort();
-  if (!keys.length && x.constructor && !(x.constructor instanceof Object)) {
+  if (!keys.length && x.constructor && x.constructor.name !== "Object") {
     const key = cache.get(x) || Math.random().toString(36).slice(2);
     cache.set(x, key);
     return stringify({ __key: key });

--- a/packages/core/src/utils/variables.ts
+++ b/packages/core/src/utils/variables.ts
@@ -26,7 +26,7 @@ const stringify = (x: any): string => {
   }
 
   const keys = Object.keys(x).sort();
-  if (!keys.length && x.constructor && x.constructor !== Object) {
+  if (!keys.length && x.constructor && !(x.constructor instanceof Object)) {
     const key = cache.get(x) || Math.random().toString(36).slice(2);
     cache.set(x, key);
     return stringify({ __key: key });

--- a/packages/core/src/utils/variables.ts
+++ b/packages/core/src/utils/variables.ts
@@ -26,7 +26,11 @@ const stringify = (x: any): string => {
   }
 
   const keys = Object.keys(x).sort();
-  if (!keys.length && x.constructor && x.constructor.name !== 'Object') {
+  if (
+    !keys.length &&
+    x.constructor &&
+    Object.getPrototypeOf(x).constructor.name === 'Object'
+  ) {
     const key = cache.get(x) || Math.random().toString(36).slice(2);
     cache.set(x, key);
     return stringify({ __key: key });

--- a/packages/core/src/utils/variables.ts
+++ b/packages/core/src/utils/variables.ts
@@ -26,7 +26,7 @@ const stringify = (x: any): string => {
   }
 
   const keys = Object.keys(x).sort();
-  if (!keys.length && x.constructor && x.constructor.name !== "Object") {
+  if (!keys.length && x.constructor && x.constructor.name !== 'Object') {
     const key = cache.get(x) || Math.random().toString(36).slice(2);
     cache.set(x, key);
     return stringify({ __key: key });

--- a/packages/core/src/utils/variables.ts
+++ b/packages/core/src/utils/variables.ts
@@ -29,7 +29,7 @@ const stringify = (x: any): string => {
   if (
     !keys.length &&
     x.constructor &&
-    Object.getPrototypeOf(x).constructor.name !== 'Object'
+    Object.getPrototypeOf(x).constructor !== Object.prototype.constructor
   ) {
     const key = cache.get(x) || Math.random().toString(36).slice(2);
     cache.set(x, key);


### PR DESCRIPTION
## Summary

In EdgeRuntime in Next.js, the constructor of an object does not match Object.
Therefore, it is necessary to determine if it inherits from Object.


## Set of changes

The following changes are made to the determination of the part that creates the keys of variables.

`x.constructor !== Object`
　　　↓
`!(x.constructor instanceof Object)`
