### PR TITLE
fix(next): only inject `<Suspense` and warning during client-side rendering

### DIFF
--- a/.changeset/funny-hornets-heal.md
+++ b/.changeset/funny-hornets-heal.md
@@ -1,0 +1,5 @@
+---
+'@urql/next': patch
+---
+
+Only apply Suspense boundary on the browser

--- a/packages/next-urql/src/Provider.ts
+++ b/packages/next-urql/src/Provider.ts
@@ -71,11 +71,13 @@ export function UrqlProvider({
       React.createElement(
         DataHydrationContextProvider,
         { nonce },
-        React.createElement(
-          React.Suspense,
-          { fallback: React.createElement(SuspenseWarning) },
-          children
-        )
+        typeof window === 'undefined'
+          ? children
+          : React.createElement(
+              React.Suspense,
+              { fallback: React.createElement(SuspenseWarning) },
+              children
+            )
       )
     )
   );


### PR DESCRIPTION
## Summary

In response to a comment on https://github.com/urql-graphql/urql/pull/3449#discussion_r1418516774 this opts you into streaming automatically 😅 which is probably not what we want by default. This moves the defaulting to only in the browser

CC @SoraKumo001
