### PR TITLE
fix(next): remove next warning, could interfere with useId

### DIFF
--- a/.changeset/funny-hornets-heal.md
+++ b/.changeset/funny-hornets-heal.md
@@ -1,5 +1,0 @@
----
-'@urql/next': patch
----
-
-Only apply Suspense boundary on the browser

--- a/.changeset/small-rings-drop.md
+++ b/.changeset/small-rings-drop.md
@@ -1,5 +1,0 @@
----
-'@urql/next': patch
----
-
-Show a warning when the `Suspense` boundary is missing under the UrqlProvider

--- a/packages/next-urql/src/Provider.ts
+++ b/packages/next-urql/src/Provider.ts
@@ -9,15 +9,6 @@ export const SSRContext = React.createContext<SSRExchange | undefined>(
   undefined
 );
 
-const SuspenseWarning = () => {
-  if (process.env.NODE_ENV !== 'production') {
-    console.warn(
-      'urql suspended but there was no boundary to catch it, add a <Suspense> component under your urql Provider.'
-    );
-  }
-  return null;
-};
-
 /** Provider for `@urql/next` during non-rsc interactions.
  *
  * @remarks
@@ -68,17 +59,7 @@ export function UrqlProvider({
     React.createElement(
       SSRContext.Provider,
       { value: ssr },
-      React.createElement(
-        DataHydrationContextProvider,
-        { nonce },
-        typeof window === 'undefined'
-          ? children
-          : React.createElement(
-              React.Suspense,
-              { fallback: React.createElement(SuspenseWarning) },
-              children
-            )
-      )
+      React.createElement(DataHydrationContextProvider, { nonce }, children)
     )
   );
 }


### PR DESCRIPTION
This introduces a new functional component which means that we can interfere with `useId`