### PR TITLE
fix(core): add back cacheOutcome

### DIFF
--- a/.changeset/silly-pigs-return.md
+++ b/.changeset/silly-pigs-return.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Add back our cache-outcome on the document-cache, this was behind a development flag however in our normalized cache we always add it already

--- a/packages/core/src/exchanges/cache.ts
+++ b/packages/core/src/exchanges/cache.ts
@@ -86,14 +86,12 @@ export const cacheExchange: Exchange = ({ forward, client, dispatchDebug }) => {
             data: null,
           });
 
-        if (process.env.NODE_ENV !== 'production') {
-          result = {
-            ...result,
-            operation: addMetadata(operation, {
-              cacheOutcome: cachedResult ? 'hit' : 'miss',
-            }),
-          };
-        }
+        result = {
+          ...result,
+          operation: addMetadata(operation, {
+            cacheOutcome: cachedResult ? 'hit' : 'miss',
+          }),
+        };
 
         if (operation.context.requestPolicy === 'cache-and-network') {
           result.stale = true;


### PR DESCRIPTION
Resolves #3462 

## Summary

In the document cache we put the `cache-outcome` behind a dev-flag, which is inconsistent as we rely on it in other exchanges and it's not behind a flag in our normalized and ssr cache.
