### PR TITLE
feat(svelte): add first class reexecute to svelte

### DIFF
--- a/.changeset/seven-toys-applaud.md
+++ b/.changeset/seven-toys-applaud.md
@@ -1,0 +1,5 @@
+---
+'@urql/svelte': minor
+---
+
+Add back the `reexecute` function

--- a/docs/basics/svelte.md
+++ b/docs/basics/svelte.md
@@ -362,9 +362,7 @@ Sometimes we'll need to arbitrarly reexecute a query to check for new data on th
   });
 
   function refresh() {
-    queryStore({
-      client,
-      query,
+    todos.reexecute({
       requestPolicy: 'network-only'
     });
   }

--- a/examples/with-svelte/package.json
+++ b/examples/with-svelte/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "scripts": {
-    "start": "vite",
+    "start": "vite --force",
     "build": "vite build",
     "serve": "vite preview"
   },

--- a/examples/with-svelte/package.json
+++ b/examples/with-svelte/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "scripts": {
-    "start": "vite --force",
+    "start": "vite",
     "build": "vite build",
     "serve": "vite preview"
   },

--- a/examples/with-svelte/src/PokemonList.svelte
+++ b/examples/with-svelte/src/PokemonList.svelte
@@ -19,6 +19,10 @@
   function nextPage() {
     skip = skip + 10;
   }
+
+  function reexcute() {
+    pokemons.reexecute({ requestPolicy: 'network-only' })
+  }
 </script>
 
 <div>
@@ -34,4 +38,5 @@
     </ul>
   {/if}
   <button on:click={nextPage}>Next Page</button>
+  <button on:click={reexcute}>Reexec</button>
 </div>

--- a/packages/svelte-urql/src/queryStore.ts
+++ b/packages/svelte-urql/src/queryStore.ts
@@ -152,12 +152,12 @@ export function queryStore<
             return never as any;
           }
 
-          return concat<Partial<OperationResultState<Data, Variables>>>([
-            fromValue({ fetching: true, stale: false }),
-            pipe(
-              fromStore(operation$),
-              switchMap(operation => {
-                return pipe(
+          return pipe(
+            fromStore(operation$),
+            switchMap(operation => {
+              return concat<Partial<OperationResultState<Data, Variables>>>([
+                fromValue({ fetching: true, stale: false }),
+                pipe(
                   args.client.executeRequestOperation(operation),
                   map(({ stale, data, error, extensions, operation }) => ({
                     fetching: false,
@@ -167,11 +167,11 @@ export function queryStore<
                     operation,
                     extensions,
                   }))
-                );
-              })
-            ),
-            fromValue({ fetching: false }),
-          ]);
+                ),
+                fromValue({ fetching: false }),
+              ]);
+            })
+          );
         }
       ),
       scan(

--- a/packages/svelte-urql/src/queryStore.ts
+++ b/packages/svelte-urql/src/queryStore.ts
@@ -194,6 +194,7 @@ export function queryStore<
       request,
       newContext
     );
+    isPaused$.set(false);
     operation$.set(operation);
   };
 


### PR DESCRIPTION
Resolves #3221

## Summary

This adds back a way to reexecute queries arbitrarily in svelte's query-store. It has been a while since I touched `wonka` and it was a learning experience all over again 😅 love the types though, they really go so far in helping out in figuring all of this out