### PR TITLE
feat(populate): alias fields with arguments

### DIFF
--- a/.changeset/smart-keys-invite.md
+++ b/.changeset/smart-keys-invite.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-populate': minor
+---
+
+Give fields with arguments an alias so that when there are duplicates they don't overwrite one another

--- a/exchanges/populate/src/populateExchange.test.ts
+++ b/exchanges/populate/src/populateExchange.test.ts
@@ -271,7 +271,64 @@ describe('on query -> mutation', () => {
             __typename
             id
             text
-            createdAt(timezone: \\"GMT+1\\")
+            createdAt_0: createdAt(timezone: \\"GMT+1\\")
+          }
+        }"
+      `);
+    });
+  });
+});
+
+describe('on query -> mutation', () => {
+  const queryOp = makeOperation(
+    'query',
+    {
+      key: 1234,
+      variables: undefined,
+      query: gql`
+        query {
+          todos {
+            id
+            text
+            gmt: createdAt(timezone: "GMT+1")
+            utc: createdAt(timezone: "UTC")
+          }
+        }
+      `,
+    },
+    context
+  );
+
+  const mutationOp = makeOperation(
+    'mutation',
+    {
+      key: 5678,
+      variables: undefined,
+      query: gql`
+        mutation MyMutation {
+          addTodo @populate
+        }
+      `,
+    },
+    context
+  );
+
+  describe('mutation query', () => {
+    it('matches snapshot', async () => {
+      const response = pipe<Operation, any, Operation[]>(
+        fromArray([queryOp, mutationOp]),
+        populateExchange({ schema })(exchangeArgs),
+        toArray
+      );
+
+      expect(print(response[1].query)).toMatchInlineSnapshot(`
+        "mutation MyMutation {
+          addTodo {
+            __typename
+            id
+            text
+            createdAt_0: createdAt(timezone: \\"GMT+1\\")
+            createdAt_1: createdAt(timezone: \\"UTC\\")
           }
         }"
       `);
@@ -821,15 +878,15 @@ describe('nested fragment', () => {
     );
 
     expect(print(response[1].query)).toMatchInlineSnapshot(`
-    "mutation MyMutation {
-      updateTodo {
-        ... on Todo {
-          __typename
-          id
+      "mutation MyMutation {
+        updateTodo {
+          ... on Todo {
+            __typename
+            id
+          }
         }
-      }
-    }"
-  `);
+      }"
+    `);
   });
 });
 

--- a/exchanges/populate/src/populateExchange.test.ts
+++ b/exchanges/populate/src/populateExchange.test.ts
@@ -271,7 +271,7 @@ describe('on query -> mutation', () => {
             __typename
             id
             text
-            createdAt_0: createdAt(timezone: \\"GMT+1\\")
+            createdAt(timezone: \\"GMT+1\\")
           }
         }"
       `);
@@ -327,7 +327,7 @@ describe('on query -> mutation', () => {
             __typename
             id
             text
-            createdAt_0: createdAt(timezone: \\"GMT+1\\")
+            createdAt(timezone: \\"GMT+1\\")
             createdAt_1: createdAt(timezone: \\"UTC\\")
           }
         }"

--- a/exchanges/populate/src/populateExchange.ts
+++ b/exchanges/populate/src/populateExchange.ts
@@ -135,7 +135,7 @@ export const populateExchange =
         return op;
       }
 
-      let fieldCounter = 0;
+      const fieldCounter = {};
       const document = traverse(op.query, node => {
         if (node.kind === Kind.FIELD) {
           if (!node.directives) return;
@@ -264,17 +264,24 @@ export const populateExchange =
                   const field: FieldNode = {
                     kind: Kind.FIELD,
                     arguments: args,
-                    alias: args.length
-                      ? {
-                          kind: Kind.NAME,
-                          value: value.fieldName + '_' + fieldCounter++,
-                        }
-                      : undefined,
+                    alias:
+                      args.length && fieldCounter[value.fieldName]
+                        ? {
+                            kind: Kind.NAME,
+                            value:
+                              value.fieldName +
+                              '_' +
+                              fieldCounter[value.fieldName]++,
+                          }
+                        : undefined,
                     name: {
                       kind: Kind.NAME,
                       value: value.fieldName,
                     },
                   };
+                  if (args.length) {
+                    fieldCounter[value.fieldName] = 1;
+                  }
 
                   typeSelections.push(field);
                 } else if (

--- a/exchanges/populate/src/populateExchange.ts
+++ b/exchanges/populate/src/populateExchange.ts
@@ -264,24 +264,21 @@ export const populateExchange =
                   const field: FieldNode = {
                     kind: Kind.FIELD,
                     arguments: args,
-                    alias:
-                      args.length && fieldCounter[value.fieldName]
-                        ? {
-                            kind: Kind.NAME,
-                            value:
-                              value.fieldName +
-                              '_' +
-                              fieldCounter[value.fieldName]++,
-                          }
-                        : undefined,
+                    alias: fieldCounter[typeName + value.fieldName]
+                      ? {
+                          kind: Kind.NAME,
+                          value:
+                            value.fieldName +
+                            '_' +
+                            fieldCounter[typeName + value.fieldName]++,
+                        }
+                      : undefined,
                     name: {
                       kind: Kind.NAME,
                       value: value.fieldName,
                     },
                   };
-                  if (args.length) {
-                    fieldCounter[value.fieldName] = 1;
-                  }
+                  fieldCounter[typeName + value.fieldName] = 1;
 
                   typeSelections.push(field);
                 } else if (

--- a/exchanges/populate/src/populateExchange.ts
+++ b/exchanges/populate/src/populateExchange.ts
@@ -135,6 +135,7 @@ export const populateExchange =
         return op;
       }
 
+      let fieldCounter = 0;
       const document = traverse(op.query, node => {
         if (node.kind === Kind.FIELD) {
           if (!node.directives) return;
@@ -259,9 +260,16 @@ export const populateExchange =
                         } as ArgumentNode;
                       })
                     : [];
+
                   const field: FieldNode = {
                     kind: Kind.FIELD,
                     arguments: args,
+                    alias: args.length
+                      ? {
+                          kind: Kind.NAME,
+                          value: value.fieldName + '_' + fieldCounter++,
+                        }
+                      : undefined,
                     name: {
                       kind: Kind.NAME,
                       value: value.fieldName,


### PR DESCRIPTION
Relates to https://github.com/urql-graphql/urql/issues/964

## Summary

This adds aliasing to fields that we have seen before with arguments, this checks whether we've seen a certain type + field before and if so it will be aliased. This however can become problematic in the case of interfaces, we might need to either always alias (breaking change), or check for `possible-types` who have queried this before... Not sure whether we want to solve this off the bat but just spitballing idea's