### PR TITLE
fix: retry delay not persisting between calls

### DIFF
--- a/.changeset/witty-peas-love.md
+++ b/.changeset/witty-peas-love.md
@@ -1,0 +1,13 @@
+---
+'@urql/exchange-retry': patch
+---
+
+---
+
+## '@urql/exchange-retry': patch
+
+Fixed the delay amount not increasing as retry count increases. This was the result of
+the `retry.delay` value not being persisted in the operation context.
+
+This change also adds a unit test for the expected behaviour of the non-random delay
+increasing linearly as the retry count increases.

--- a/.changeset/witty-peas-love.md
+++ b/.changeset/witty-peas-love.md
@@ -4,10 +4,4 @@
 
 ---
 
-## '@urql/exchange-retry': patch
-
-Fixed the delay amount not increasing as retry count increases. This was the result of
-the `retry.delay` value not being persisted in the operation context.
-
-This change also adds a unit test for the expected behaviour of the non-random delay
-increasing linearly as the retry count increases.
+Fixed the delay amount not increasing as retry count increases.


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR, but please make sure to open an issue or discuss
  your changes first, if you’re looking to submit a larger PR.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

<!-- What's the motivation of this change? What does it solve? -->

Retry delays are not actually working as specified in the docs. Currently, retry delays are not persisted between retries, resulting in exponential backoff not actually increasing the delay amount as time goes on. The linear backoff also does not currently work.

I've added a unit test for this, as well as the change for the behavior to comply with what's actually stated in the docs.



## Set of changes

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->

- Made retry delays persist in the context, allowing backoffs to work
- Added unit test for retry delay
- Modified an existing unit test that was failing (I believe it might have been incorrect, but I'm not entirely sure, please verify! It seems like the retry value is meant to reset after a retry that was successful [so, a successful operation], but the unit test was checking the `retry` values after a failed/errored operation instead. However, the test was passing because the retry delays were never being carried across operations anyway.)