### PR TITLE
chore(rn-storage): Update outdated React Native dependencies

### DIFF
--- a/.changeset/strange-drinks-sip.md
+++ b/.changeset/strange-drinks-sip.md
@@ -2,4 +2,4 @@
 '@urql/storage-rn': minor
 ---
 
-Bumped RN Netinfo and Async Storage to latest version and added Netinfo v11 to peer dependency array
+Bump peer-dependency of `@react-native-community/netinfo` to allow v11

--- a/.changeset/strange-drinks-sip.md
+++ b/.changeset/strange-drinks-sip.md
@@ -1,0 +1,5 @@
+---
+'@urql/storage-rn': minor
+---
+
+Bumped RN Netinfo and Async Storage to latest version and added Netinfo v11 to peer dependency array

--- a/packages/storage-rn/package.json
+++ b/packages/storage-rn/package.json
@@ -50,14 +50,14 @@
   },
   "peerDependencies": {
     "@urql/exchange-graphcache": ">=5.0.0",
-    "@react-native-async-storage/async-storage": "^1.15.5",
-    "@react-native-community/netinfo": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0"
+    "@react-native-async-storage/async-storage": "^1.21.0",
+    "@react-native-community/netinfo": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^11.0.0"
   },
   "devDependencies": {
     "@urql/core": "workspace:*",
     "@urql/exchange-graphcache": "workspace:*",
-    "@react-native-async-storage/async-storage": "^1.18.2",
-    "@react-native-community/netinfo": "^9.3.10"
+    "@react-native-async-storage/async-storage": "^1.21.0",
+    "@react-native-community/netinfo": "^11.2.1"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/storage-rn/package.json
+++ b/packages/storage-rn/package.json
@@ -50,7 +50,7 @@
   },
   "peerDependencies": {
     "@urql/exchange-graphcache": ">=5.0.0",
-    "@react-native-async-storage/async-storage": "^1.21.0",
+    "@react-native-async-storage/async-storage": "^1.15.5",
     "@react-native-community/netinfo": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^11.0.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -542,11 +542,11 @@ importers:
   packages/storage-rn:
     devDependencies:
       '@react-native-async-storage/async-storage':
-        specifier: ^1.18.2
-        version: 1.18.2
+        specifier: ^1.21.0
+        version: 1.21.0
       '@react-native-community/netinfo':
-        specifier: ^9.3.10
-        version: 9.3.10
+        specifier: ^11.2.1
+        version: 11.2.1
       '@urql/core':
         specifier: workspace:*
         version: link:../core
@@ -2692,10 +2692,10 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
       react-lifecycles-compat: 3.0.4
 
-  /@react-native-async-storage/async-storage@1.18.2:
-    resolution: {integrity: sha512-dM8AfdoeIxlh+zqgr0o5+vCTPQ0Ru1mrPzONZMsr7ufp5h+6WgNxQNza7t0r5qQ6b04AJqTlBNixTWZxqP649Q==}
+  /@react-native-async-storage/async-storage@1.21.0:
+    resolution: {integrity: sha512-JL0w36KuFHFCvnbOXRekqVAUplmOyT/OuCQkogo6X98MtpSaJOKEAeZnYO8JB0U/RIEixZaGI5px73YbRm/oag==}
     peerDependencies:
-      react-native: ^0.0.0-0 || 0.60 - 0.72 || 1000.0.0
+      react-native: ^0.0.0-0 || >=0.60 <1.0
     peerDependenciesMeta:
       react-native:
         optional: true
@@ -2703,8 +2703,8 @@ packages:
       merge-options: 3.0.4
     dev: true
 
-  /@react-native-community/netinfo@9.3.10:
-    resolution: {integrity: sha512-OwnqoJUp/4sa9e3ju+wQavAa8l0fiA3DheeLMKzKxtKeAe0CA7bNxWRM752JvRQ6A/igPnt1V0zSlu5owvQEuA==}
+  /@react-native-community/netinfo@11.2.1:
+    resolution: {integrity: sha512-n9kgmH7vLaU7Cdo8vGfJGGwhrlgppaOSq5zKj9I7H4k5iRM3aNtwURw83mgrc22Ip7nSye2afZV2xDiIyvHttQ==}
     peerDependencies:
       react-native: '>=0.59'
     peerDependenciesMeta:
@@ -3697,6 +3697,7 @@ packages:
 
   /anymatch@2.0.0(supports-color@6.1.0):
     resolution: {integrity: sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==}
+    requiresBuild: true
     dependencies:
       micromatch: 3.1.10(supports-color@6.1.0)
       normalize-path: 2.1.1
@@ -3905,6 +3906,7 @@ packages:
 
   /async-each@1.0.3:
     resolution: {integrity: sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==}
+    requiresBuild: true
 
   /async-limiter@1.0.1:
     resolution: {integrity: sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==}
@@ -7551,6 +7553,7 @@ packages:
 
   /glob-parent@3.1.0:
     resolution: {integrity: sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==}
+    requiresBuild: true
     dependencies:
       is-glob: 3.1.0
       path-dirname: 1.0.2
@@ -8410,6 +8413,7 @@ packages:
   /is-binary-path@1.0.1:
     resolution: {integrity: sha512-9fRVlXc0uCxEDj1nQzaWONSpbTfx0FmJfzHF7pwlI8DkWGoHBBea4Pg5Ky0ojwwxQmnSifgbKkI06Qv0Ljgj+Q==}
     engines: {node: '>=0.10.0'}
+    requiresBuild: true
     dependencies:
       binary-extensions: 1.13.1
 
@@ -12041,6 +12045,7 @@ packages:
   /readdirp@2.2.1(supports-color@6.1.0):
     resolution: {integrity: sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==}
     engines: {node: '>=0.10'}
+    requiresBuild: true
     dependencies:
       graceful-fs: 4.2.11
       micromatch: 3.1.10(supports-color@6.1.0)


### PR DESCRIPTION
Update outdated React Native peer reqs

## Summary

Currently @urql/storage-rn is breaking the update process to Expo version 50 due to the set peer dependencies in this package. In Expo 50 they bumped RN Netinfo to v11.

## Set of changes

- Updated React Native NetInfo package to version 11 and upped the peer reqs in package.json
- Updated React Native Async Storage to 1.21 and upped the peer reqs in package.json