### PR TITLE
fix(graphcache): Restore `stale` being set to `true` on blocked (but in-flight) operations

### DIFF
--- a/.changeset/giant-beans-act.md
+++ b/.changeset/giant-beans-act.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Set `stale: true` on cache results, even if a reexecution has been blocked by the loop protection, if the operation is already pending and in-flight.

--- a/exchanges/graphcache/e2e-tests/query.spec.tsx
+++ b/exchanges/graphcache/e2e-tests/query.spec.tsx
@@ -31,7 +31,8 @@ const schema = buildSchema(`
 `);
 
 const rootValue = {
-  movie: () => {
+  movie: async () => {
+    await new Promise(resolve => setTimeout(resolve, 50));
     return {
       id: 'foo',
       title: 'title',

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -32,6 +32,7 @@ import {
   noopDataState,
   hydrateData,
   reserveLayer,
+  hasLayer,
 } from './store/data';
 
 interface OperationResultWithMeta extends Partial<OperationResult> {
@@ -377,6 +378,13 @@ export const cacheExchange =
               (requestPolicy === 'cache-first' &&
                 res.outcome === 'partial' &&
                 !reexecutingOperations.has(res.operation.key)));
+          // Set stale to true anyway, even if the reexecute will be blocked, if the operation
+          // is in progress. We can be reasonably sure of that if a layer has been reserved for it.
+          const stale =
+            requestPolicy !== 'cache-only' &&
+            (shouldReexecute ||
+              (res.outcome === 'partial' &&
+                hasLayer(store.data, res.operation.key)));
 
           const result: OperationResult = {
             operation: addMetadata(res.operation, {
@@ -385,7 +393,7 @@ export const cacheExchange =
             data: res.data,
             error: res.error,
             extensions: res.extensions,
-            stale: shouldReexecute && !res.hasNext,
+            stale: stale && !res.hasNext,
             hasNext: shouldReexecute && res.hasNext,
           };
 

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -384,6 +384,7 @@ export const cacheExchange =
             requestPolicy !== 'cache-only' &&
             (shouldReexecute ||
               (res.outcome === 'partial' &&
+                reexecutingOperations.has(res.operation.key) &&
                 hasLayer(store.data, res.operation.key)));
 
           const result: OperationResult = {

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -528,6 +528,11 @@ export const reserveLayer = (
   data.commutativeKeys.add(layerKey);
 };
 
+/** Checks whether a given layer exists */
+export const hasLayer = (data: InMemoryData, layerKey: number) =>
+  data.commutativeKeys.has(layerKey) ||
+  data.optimisticOrder.indexOf(layerKey) > -1;
+
 /** Creates an optimistic layer of links and records */
 const createLayer = (data: InMemoryData, layerKey: number) => {
   if (data.optimisticOrder.indexOf(layerKey) === -1) {


### PR DESCRIPTION
> **Note:** I wasn't reasonably able to write tests for the looping protection yet that hit this particular case. Manual testing is needed!

## Summary

For partial cache results, `stale: false` was being set when the looping protection kicks in. In simple words, if an operation is triggered twice, once as part of an unrelated query updating, causing a partial result, then again, the second trigger will create a cache result with `stale: false`, even if the operation would be in flight.

This PR restores `stale: true` being set, if we reasonably believe the operation is still in flight.

## Set of changes

- Add separate `stale: true` override if operation is in flight
