### PR TITLE
fix(graphcache): Fix `@defer` state carrying over to next operation

### DIFF
--- a/.changeset/serious-tables-ring.md
+++ b/.changeset/serious-tables-ring.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix `@defer` state leaking into following operations.

--- a/exchanges/graphcache/src/operations/shared.ts
+++ b/exchanges/graphcache/src/operations/shared.ts
@@ -64,6 +64,8 @@ export const makeContext = (
   entityKey: string,
   error: CombinedError | undefined
 ): Context => {
+  deferRef = false;
+
   const ctx: Context = {
     store,
     variables,


### PR DESCRIPTION
Related to #3167

## Summary

This fixes the `@defer` states becoming “sticky” and carrying over to subsequent
operations sometimes, causing incomplete results to be generated under certain conditions.

## Set of changes

- Forcefully reset `deferRef` when a new operation is started
