### PR TITLE
feat(core): Support Apollo Federation subscriptions multipart payloads

### DIFF
--- a/.changeset/small-cheetahs-jam.md
+++ b/.changeset/small-cheetahs-jam.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': minor
+---
+
+Support the [Apollo federation spec](https://www.apollographql.com/docs/router/executing-operations/subscription-multipart-protocol/) for dispatching subscriptions

--- a/.changeset/small-cheetahs-jam.md
+++ b/.changeset/small-cheetahs-jam.md
@@ -2,4 +2,4 @@
 '@urql/core': minor
 ---
 
-Support the [Apollo federation spec](https://www.apollographql.com/docs/router/executing-operations/subscription-multipart-protocol/) for dispatching subscriptions
+Support [Apollo Federation's format](https://www.apollographql.com/docs/router/executing-operations/subscription-multipart-protocol/) for subscription results in `multipart/mixed` responses (result properties essentially are namespaced on a `payload` key)

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -223,7 +223,7 @@ export interface ExecutionResult {
    * @see {@link https://github.com/graphql/graphql-wg/blob/main/rfcs/DeferStream.md#payload-format} for the DeferStream spec
    */
   hasNext?: boolean;
-  payload?: ExecutionResult;
+  payload?: Omit<ExecutionResult, 'payload'>;
 }
 
 /** A source of {@link OperationResult | OperationResults}, convertable to a promise, subscribable, or Wonka Source.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -223,6 +223,7 @@ export interface ExecutionResult {
    * @see {@link https://github.com/graphql/graphql-wg/blob/main/rfcs/DeferStream.md#payload-format} for the DeferStream spec
    */
   hasNext?: boolean;
+  payload?: ExecutionResult;
 }
 
 /** A source of {@link OperationResult | OperationResults}, convertable to a promise, subscribable, or Wonka Source.

--- a/packages/core/src/utils/result.ts
+++ b/packages/core/src/utils/result.ts
@@ -153,7 +153,7 @@ export const mergeResultPatch = (
     withData.data = (nextResult.payload || nextResult).data || prevResult.data;
     errors =
       (nextResult.errors as any[]) ||
-      (nextResult.payload && nextResult.payload.errors) || 
+      (nextResult.payload && nextResult.payload.errors) ||
       errors;
   }
 

--- a/packages/core/src/utils/result.ts
+++ b/packages/core/src/utils/result.ts
@@ -92,8 +92,12 @@ export const mergeResultPatch = (
   pending?: ExecutionResult['pending']
 ): OperationResult => {
   let errors = prevResult.error ? prevResult.error.graphQLErrors : [];
-  let hasExtensions = !!prevResult.extensions || !!nextResult.extensions;
-  const extensions = { ...prevResult.extensions, ...nextResult.extensions };
+  let hasExtensions =
+    !!prevResult.extensions || !!(nextResult.payload || nextResult).extensions;
+  const extensions = {
+    ...prevResult.extensions,
+    ...(nextResult.payload || nextResult).extensions,
+  };
 
   let incremental = nextResult.incremental;
 
@@ -146,7 +150,7 @@ export const mergeResultPatch = (
       }
     }
   } else {
-    withData.data = nextResult.data || prevResult.data;
+    withData.data = (nextResult.payload || nextResult).data || prevResult.data;
     errors = (nextResult.errors as any[]) || errors;
   }
 

--- a/packages/core/src/utils/result.ts
+++ b/packages/core/src/utils/result.ts
@@ -152,10 +152,9 @@ export const mergeResultPatch = (
   } else {
     withData.data = (nextResult.payload || nextResult).data || prevResult.data;
     errors =
-      [
-        ...((nextResult.errors || []) as any[]),
-        ...((nextResult.payload && nextResult.payload.errors) || []),
-      ] || errors;
+      (nextResult.errors as any[]) ||
+      (nextResult.payload && nextResult.payload.errors) || 
+      errors;
   }
 
   return {

--- a/packages/core/src/utils/result.ts
+++ b/packages/core/src/utils/result.ts
@@ -151,7 +151,11 @@ export const mergeResultPatch = (
     }
   } else {
     withData.data = (nextResult.payload || nextResult).data || prevResult.data;
-    errors = (nextResult.errors as any[]) || errors;
+    errors =
+      [
+        ...((nextResult.errors || []) as any[]),
+        ...((nextResult.payload && nextResult.payload.errors) || []),
+      ] || errors;
   }
 
   return {


### PR DESCRIPTION
## Summary

A missing feature for `multipart/mixed` was pointed out where we were missing support for the apollo subscriptions spec which adds a `payload` property
