### PR TITLE
feat(graphcache): track types in the data-structure

### DIFF
--- a/.changeset/tall-buttons-fetch.md
+++ b/.changeset/tall-buttons-fetch.md
@@ -2,4 +2,4 @@
 '@urql/exchange-graphcache': minor
 ---
 
-Support tracking a mapping of `typename` to a list of `entityKey` for that typename, this enables invalidating a whole type within the normalized cache.
+Track list of entity keys for a given type name. This enables enumerating and invalidating all entities of a given type within the normalized cache.

--- a/.changeset/tall-buttons-fetch.md
+++ b/.changeset/tall-buttons-fetch.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': minor
+---
+
+Support tracking a mapping of `typename` to a list of `entityKey` for that typename, this enables invalidating a whole type within the normalized cache.

--- a/docs/graphcache/cache-updates.md
+++ b/docs/graphcache/cache-updates.md
@@ -489,6 +489,25 @@ In this example we've attached an updater to a `Mutation.updateTodo` field. We r
 mutation by enumerating all `todos` listing fields using `cache.inspectFields` and targetedly
 invalidate only these fields, which causes all queries using these listing fields to be refetched.
 
+### Invalidating a type
+
+We can also invalidate all the entities of a given type, this could be handy in the case of a
+list update or when you aren't sure what entity is affected.
+
+This can be done by only passing the relevant `__typename` to the `invalidate` function.
+
+```js
+cacheExchange({
+  updates: {
+    Mutation: {
+      deleteTodo(_result, args, cache, _info) {
+        cache.invalidate('Todo');
+      },
+    },
+  },
+});
+```
+
 ## Optimistic updates
 
 If we know what result a mutation may return, why wait for the GraphQL API to fulfill our mutations?

--- a/exchanges/graphcache/src/operations/invalidate.ts
+++ b/exchanges/graphcache/src/operations/invalidate.ts
@@ -28,8 +28,8 @@ export const invalidateEntity = (
 export const invalidateType = (typename: string) => {
   const types = InMemoryData.getEntitiesForType(typename);
   if (types) {
-    for (let i = 0, l = types.size; i < l; i++) {
-      invalidateEntity(types[i]);
+    for (const entity of types.values()) {
+      invalidateEntity(entity);
     }
   }
 };

--- a/exchanges/graphcache/src/operations/invalidate.ts
+++ b/exchanges/graphcache/src/operations/invalidate.ts
@@ -27,9 +27,7 @@ export const invalidateEntity = (
 
 export const invalidateType = (typename: string) => {
   const types = InMemoryData.getEntitiesForType(typename);
-  if (types) {
-    for (const entity of types) {
-      invalidateEntity(entity);
-    }
+  for (const entity of types) {
+    invalidateEntity(entity);
   }
 };

--- a/exchanges/graphcache/src/operations/invalidate.ts
+++ b/exchanges/graphcache/src/operations/invalidate.ts
@@ -26,8 +26,10 @@ export const invalidateEntity = (
 };
 
 export const invalidateType = (typename: string) => {
-  const types = InMemoryData.getEntitiesForType(typename) || [];
-  for (let i = 0, l = types.length; i < l; i++) {
-    invalidateEntity(types[i]);
+  const types = InMemoryData.getEntitiesForType(typename);
+  if (types) {
+    for (let i = 0, l = types.size; i < l; i++) {
+      invalidateEntity(types[i]);
+    }
   }
 };

--- a/exchanges/graphcache/src/operations/invalidate.ts
+++ b/exchanges/graphcache/src/operations/invalidate.ts
@@ -28,7 +28,7 @@ export const invalidateEntity = (
 export const invalidateType = (typename: string) => {
   const types = InMemoryData.getEntitiesForType(typename);
   if (types) {
-    for (const entity of types.values()) {
+    for (const entity of types) {
       invalidateEntity(entity);
     }
   }

--- a/exchanges/graphcache/src/operations/invalidate.ts
+++ b/exchanges/graphcache/src/operations/invalidate.ts
@@ -24,3 +24,10 @@ export const invalidateEntity = (
     }
   }
 };
+
+export const invalidateType = (typename: string) => {
+  const types = InMemoryData.getEntitiesForType(typename) || [];
+  for (let i = 0, l = types.length; i < l; i++) {
+    invalidateEntity(types[i]);
+  }
+};

--- a/exchanges/graphcache/src/operations/write.ts
+++ b/exchanges/graphcache/src/operations/write.ts
@@ -232,6 +232,7 @@ const writeSelection = (
     return;
   } else if (!isRoot && entityKey) {
     InMemoryData.writeRecord(entityKey, '__typename', typename);
+    InMemoryData.writeType(typename, entityKey);
   }
 
   const updates = ctx.store.updates[typename];

--- a/exchanges/graphcache/src/store/data.test.ts
+++ b/exchanges/graphcache/src/store/data.test.ts
@@ -21,7 +21,9 @@ describe('garbage collection', () => {
     InMemoryData.gc();
 
     expect(InMemoryData.readLink('Query', 'todo')).toBe('Todo:1');
-    expect(InMemoryData.getEntitiesForType('Todo')).toEqual(new Set(['Todo:1']));
+    expect(InMemoryData.getEntitiesForType('Todo')).toEqual(
+      new Set(['Todo:1'])
+    );
 
     InMemoryData.writeLink('Query', 'todo', undefined);
     InMemoryData.gc();
@@ -49,7 +51,9 @@ describe('garbage collection', () => {
     expect(InMemoryData.readLink('Query', 'newTodo')).toBe('Todo:1');
     expect(InMemoryData.readLink('Query', 'todo')).toBe(undefined);
     expect(InMemoryData.readRecord('Todo:1', 'id')).toBe('1');
-    expect(InMemoryData.getEntitiesForType('Todo')).toEqual(new Set(['Todo:1']));
+    expect(InMemoryData.getEntitiesForType('Todo')).toEqual(
+      new Set(['Todo:1'])
+    );
 
     expect(InMemoryData.getCurrentDependencies()).toEqual(
       new Set(['Todo:1', 'Query.todo', 'Query.newTodo'])
@@ -110,8 +114,12 @@ describe('garbage collection', () => {
     InMemoryData.writeType('Author', 'Author:1');
 
     InMemoryData.writeLink('Query', 'todo', undefined);
-    expect(InMemoryData.getEntitiesForType('Todo')).toEqual(new Set(['Todo:1']));
-    expect(InMemoryData.getEntitiesForType('Author')).toEqual(new Set(['Author:1']));
+    expect(InMemoryData.getEntitiesForType('Todo')).toEqual(
+      new Set(['Todo:1'])
+    );
+    expect(InMemoryData.getEntitiesForType('Author')).toEqual(
+      new Set(['Author:1'])
+    );
     InMemoryData.gc();
 
     expect(InMemoryData.readRecord('Todo:1', 'id')).toBe(undefined);

--- a/exchanges/graphcache/src/store/data.test.ts
+++ b/exchanges/graphcache/src/store/data.test.ts
@@ -16,16 +16,19 @@ describe('garbage collection', () => {
     InMemoryData.writeRecord('Todo:2', '__typename', 'Todo');
     InMemoryData.writeRecord('Query', '__typename', 'Query');
     InMemoryData.writeLink('Query', 'todo', 'Todo:1');
+    InMemoryData.writeType('Todo', 'Todo:1');
 
     InMemoryData.gc();
 
     expect(InMemoryData.readLink('Query', 'todo')).toBe('Todo:1');
+    expect(InMemoryData.getEntitiesForType('Todo')).toEqual(['Todo:1']);
 
     InMemoryData.writeLink('Query', 'todo', undefined);
     InMemoryData.gc();
 
     expect(InMemoryData.readLink('Query', 'todo')).toBe(undefined);
     expect(InMemoryData.readRecord('Todo:1', 'id')).toBe(undefined);
+    expect(InMemoryData.getEntitiesForType('Todo')).toEqual([]);
 
     expect(InMemoryData.getCurrentDependencies()).toEqual(
       new Set(['Todo:1', 'Todo:2', 'Query.todo'])
@@ -39,12 +42,14 @@ describe('garbage collection', () => {
     InMemoryData.writeLink('Query', 'todo', 'Todo:1');
     InMemoryData.writeLink('Query', 'todo', undefined);
     InMemoryData.writeLink('Query', 'newTodo', 'Todo:1');
+    InMemoryData.writeType('Todo', 'Todo:1');
 
     InMemoryData.gc();
 
     expect(InMemoryData.readLink('Query', 'newTodo')).toBe('Todo:1');
     expect(InMemoryData.readLink('Query', 'todo')).toBe(undefined);
     expect(InMemoryData.readRecord('Todo:1', 'id')).toBe('1');
+    expect(InMemoryData.getEntitiesForType('Todo')).toEqual(['Todo:1']);
 
     expect(InMemoryData.getCurrentDependencies()).toEqual(
       new Set(['Todo:1', 'Query.todo', 'Query.newTodo'])
@@ -101,12 +106,18 @@ describe('garbage collection', () => {
     InMemoryData.writeRecord('Todo:1', '__typename', 'Todo');
     InMemoryData.writeRecord('Todo:1', 'id', '1');
     InMemoryData.writeLink('Query', 'todo', 'Todo:1');
+    InMemoryData.writeType('Todo', 'Todo:1');
+    InMemoryData.writeType('Author', 'Author:1');
 
     InMemoryData.writeLink('Query', 'todo', undefined);
+    expect(InMemoryData.getEntitiesForType('Todo')).toEqual(['Todo:1']);
+    expect(InMemoryData.getEntitiesForType('Author')).toEqual(['Author:1']);
     InMemoryData.gc();
 
     expect(InMemoryData.readRecord('Todo:1', 'id')).toBe(undefined);
     expect(InMemoryData.readRecord('Author:1', 'id')).toBe(undefined);
+    expect(InMemoryData.getEntitiesForType('Todo')).toEqual([]);
+    expect(InMemoryData.getEntitiesForType('Author')).toEqual([]);
 
     expect(InMemoryData.getCurrentDependencies()).toEqual(
       new Set(['Author:1', 'Todo:1', 'Query.todo'])

--- a/exchanges/graphcache/src/store/data.test.ts
+++ b/exchanges/graphcache/src/store/data.test.ts
@@ -21,14 +21,14 @@ describe('garbage collection', () => {
     InMemoryData.gc();
 
     expect(InMemoryData.readLink('Query', 'todo')).toBe('Todo:1');
-    expect(InMemoryData.getEntitiesForType('Todo')).toEqual(['Todo:1']);
+    expect(InMemoryData.getEntitiesForType('Todo')).toEqual(new Set(['Todo:1']));
 
     InMemoryData.writeLink('Query', 'todo', undefined);
     InMemoryData.gc();
 
     expect(InMemoryData.readLink('Query', 'todo')).toBe(undefined);
     expect(InMemoryData.readRecord('Todo:1', 'id')).toBe(undefined);
-    expect(InMemoryData.getEntitiesForType('Todo')).toEqual([]);
+    expect(InMemoryData.getEntitiesForType('Todo')).toEqual(new Set());
 
     expect(InMemoryData.getCurrentDependencies()).toEqual(
       new Set(['Todo:1', 'Todo:2', 'Query.todo'])
@@ -49,7 +49,7 @@ describe('garbage collection', () => {
     expect(InMemoryData.readLink('Query', 'newTodo')).toBe('Todo:1');
     expect(InMemoryData.readLink('Query', 'todo')).toBe(undefined);
     expect(InMemoryData.readRecord('Todo:1', 'id')).toBe('1');
-    expect(InMemoryData.getEntitiesForType('Todo')).toEqual(['Todo:1']);
+    expect(InMemoryData.getEntitiesForType('Todo')).toEqual(new Set(['Todo:1']));
 
     expect(InMemoryData.getCurrentDependencies()).toEqual(
       new Set(['Todo:1', 'Query.todo', 'Query.newTodo'])
@@ -110,14 +110,14 @@ describe('garbage collection', () => {
     InMemoryData.writeType('Author', 'Author:1');
 
     InMemoryData.writeLink('Query', 'todo', undefined);
-    expect(InMemoryData.getEntitiesForType('Todo')).toEqual(['Todo:1']);
-    expect(InMemoryData.getEntitiesForType('Author')).toEqual(['Author:1']);
+    expect(InMemoryData.getEntitiesForType('Todo')).toEqual(new Set(['Todo:1']));
+    expect(InMemoryData.getEntitiesForType('Author')).toEqual(new Set(['Author:1']));
     InMemoryData.gc();
 
     expect(InMemoryData.readRecord('Todo:1', 'id')).toBe(undefined);
     expect(InMemoryData.readRecord('Author:1', 'id')).toBe(undefined);
-    expect(InMemoryData.getEntitiesForType('Todo')).toEqual([]);
-    expect(InMemoryData.getEntitiesForType('Author')).toEqual([]);
+    expect(InMemoryData.getEntitiesForType('Todo')).toEqual(new Set());
+    expect(InMemoryData.getEntitiesForType('Author')).toEqual(new Set());
 
     expect(InMemoryData.getCurrentDependencies()).toEqual(
       new Set(['Author:1', 'Todo:1', 'Query.todo'])

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -47,6 +47,7 @@ export interface InMemoryData {
   records: NodeMap<EntityField>;
   /** A map of entity links which are connections from one entity to another (key-value entries per entity) */
   links: NodeMap<Link>;
+  /** A map of typename to a list of entity-keys belonging to said type */
   types: Map<string, string[]>;
   /** A set of Query operation keys that are in-flight and deferred/streamed */
   deferredKeys: Set<number>;

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -411,10 +411,13 @@ export const gc = () => {
     const rc = currentData!.refCount.get(entityKey) || 0;
     if (rc > 0) continue;
 
+    const record = currentData!.records.base.get(entityKey);
     // Delete the reference count, and delete the entity from the GC batch
     currentData!.refCount.delete(entityKey);
     currentData!.records.base.delete(entityKey);
-    const typename = entityKey.split(':')[0];
+
+    const typename = ((record && record.__typename) ||
+      entityKey.split(':')[0]) as string;
     const type = currentData!.types.get(typename);
     if (type) {
       const index = type.indexOf(entityKey);

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -236,6 +236,7 @@ export const getCurrentDependencies = (): Dependencies => {
   return currentDependencies;
 };
 
+const DEFAULT_EMPTY_SET = new Set<string>();
 export const make = (queryRootKey: string): InMemoryData => ({
   hydrating: false,
   defer: false,
@@ -463,8 +464,8 @@ export const readLink = (
   return getNode(currentData!.links, entityKey, fieldKey);
 };
 
-export const getEntitiesForType = (typename: string) =>
-  currentData!.types.get(typename);
+export const getEntitiesForType = (typename: string): Set<string> =>
+  currentData!.types.get(typename) || DEFAULT_EMPTY_SET;
 
 export const writeType = (typename: string, entityKey: string) => {
   const existingTypes = currentData!.types.get(typename);

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -405,12 +405,6 @@ export const gc = () => {
   for (const entityKey of currentData!.gc.keys()) {
     // Remove the current key from the GC batch
     currentData!.gc.delete(entityKey);
-    const typename = entityKey.split(':')[0];
-    const type = currentData!.types.get(typename);
-    if (type) {
-      const index = type.indexOf(entityKey);
-      if (index > -1) type.splice(index, 1);
-    }
 
     // Check first whether the entity has any references,
     // if so, we skip it from the GC run
@@ -420,6 +414,12 @@ export const gc = () => {
     // Delete the reference count, and delete the entity from the GC batch
     currentData!.refCount.delete(entityKey);
     currentData!.records.base.delete(entityKey);
+    const typename = entityKey.split(':')[0];
+    const type = currentData!.types.get(typename);
+    if (type) {
+      const index = type.indexOf(entityKey);
+      if (index > -1) type.splice(index, 1);
+    }
     const linkNode = currentData!.links.base.get(entityKey);
     if (linkNode) {
       currentData!.links.base.delete(entityKey);

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -417,13 +417,15 @@ export const gc = () => {
     currentData!.refCount.delete(entityKey);
     currentData!.records.base.delete(entityKey);
 
-    const typename = ((record && record.__typename) ||
-      entityKey.split(':')[0]) as string;
-    const type = currentData!.types.get(typename);
-    if (type) {
-      const index = type.indexOf(entityKey);
-      if (index > -1) type.splice(index, 1);
+    const typename = (record && record.__typename) as string | undefined;
+    if (typename) {
+      const type = currentData!.types.get(typename);
+      if (type) {
+        const index = type.indexOf(entityKey);
+        if (index > -1) type.splice(index, 1);
+      }
     }
+
     const linkNode = currentData!.links.base.get(entityKey);
     if (linkNode) {
       currentData!.links.base.delete(entityKey);

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -420,9 +420,7 @@ export const gc = () => {
     const typename = (record && record.__typename) as string | undefined;
     if (typename) {
       const type = currentData!.types.get(typename);
-      if (type && type.has(entityKey)) {
-        type.delete(entityKey);
-      }
+      if (type) type.delete(entityKey);
     }
 
     const linkNode = currentData!.links.base.get(entityKey);

--- a/exchanges/graphcache/src/store/store.test.ts
+++ b/exchanges/graphcache/src/store/store.test.ts
@@ -844,6 +844,15 @@ describe('Store with OptimisticMutationConfig', () => {
       expect(data).toBe(null);
     });
   });
+
+  describe('Invalidating a type', () => {
+    it('removes an entity from a list.', () => {
+      InMemoryData.initDataState('write', store.data, null);
+      store.invalidate('Todo');
+      const { data } = query(store, { query: Todos });
+      expect(data).toBe(null);
+    });
+  });
 });
 
 describe('Store with storage', () => {

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -171,13 +171,10 @@ export class Store<
   invalidate(entity: Entity, field?: string, args?: FieldArgs) {
     const entityKey = this.keyOfEntity(entity);
     const shouldInvalidateType =
-      entity &&
-      (typeof entity === 'string' || Object.keys(entity).length === 1) &&
-      !field &&
-      !args;
+      entity && typeof entity === 'string' && !field && !args;
 
     if (shouldInvalidateType) {
-      invalidateType(typeof entity === 'string' ? entity : entity.__typename);
+      invalidateType(entity);
     } else {
       invariant(
         entityKey,

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -170,7 +170,12 @@ export class Store<
 
   invalidate(entity: Entity, field?: string, args?: FieldArgs) {
     const entityKey = this.keyOfEntity(entity);
-    const shouldInvalidateType = entity && (typeof entity === 'string' || Object.keys(entity).length === 1) && !field && !args
+    const shouldInvalidateType =
+      entity &&
+      (typeof entity === 'string' || Object.keys(entity).length === 1) &&
+      !field &&
+      !args;
+
     if (shouldInvalidateType) {
       invalidateType(typeof entity === 'string' ? entity : entity.__typename);
     } else {

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -170,11 +170,8 @@ export class Store<
 
   invalidate(entity: Entity, field?: string, args?: FieldArgs) {
     const entityKey = this.keyOfEntity(entity);
-    if (
-      entity &&
-      (typeof entity === 'string' || Object.keys(entity).length === 1) &&
-      !entityKey
-    ) {
+    const shouldInvalidateType = entity && (typeof entity === 'string' || Object.keys(entity).length === 1) && !field && !args
+    if (shouldInvalidateType) {
       invalidateType(typeof entity === 'string' ? entity : entity.__typename);
     } else {
       invariant(


### PR DESCRIPTION
Related to #3470

## Summary

This starts tracking a mapping of `__typename` to a list of `entityKey`, this enables us to perform operations like `invalidate('Todo')` which would invalidate every `entityKey` of the `Todo` type.

We add non-root typenames when going through the `write` operation and we clean up entities in the list when we are going through `gc` runs.

In the future this can instruct us for operations where we can't derive an entity i.e. a create-mutation will invalidate all entities of its own type to ensure we don't run into stale values which leaves us with the scalar return case which won't automatically be handled.

The PR explicitly does not add the `updater` logic yet so we can see that the explicit API surface does not grow, we support more cases instead.

## Set of changes

- Add Map of `__typename` to a list of keys
- Add support for `invalidate('Type')` and `inavlidate({ __typename: 'Type' })`

## Questions

Should we support invalidating a full type with field and arguments i.e. `invalidate('Todo', 'author')` would go through every `Todo` key and explicitly invalidate the `Author` field.

## Follow-ups

- After this PR we can provide logic where we check the presence of the entity in cahce when there's no updater. When we can't find the entity we perform `invalidate({__typename})`