### PR TITLE
docs(graphcache): remove mutative operations

### DIFF
--- a/docs/graphcache/cache-updates.md
+++ b/docs/graphcache/cache-updates.md
@@ -260,8 +260,10 @@ cacheExchange({
         `;
 
         cache.updateQuery({ query: TodoList }, data => {
-          data.todos.push(result.createTodo);
-          return data;
+          return {
+            ...data,
+            todos: [...data.todos, result.createTodo],
+          };
         });
       },
     },
@@ -299,8 +301,7 @@ cacheExchange({
       createTodo(result, _args, cache, _info) {
         const todos = cache.resolve('Query', 'todos');
         if (Array.isArray(todos)) {
-          todos.push(result.createTodo);
-          cache.link('Query', 'todos', todos);
+          cache.link('Query', 'todos', [...todos, result.createTodo]);
         }
       },
     },

--- a/examples/with-graphcache-updates/src/client.js
+++ b/examples/with-graphcache-updates/src/client.js
@@ -29,8 +29,13 @@ const cache = cacheExchange({
               variables: { first: lastField.arguments.first },
             },
             data => {
-              data.links.nodes.push(result.createLink.node);
-              return data;
+              return {
+                ...data,
+                links: {
+                  ...data.links,
+                  nodes: [...data.links.nodes, result.createLink.node],
+                },
+              };
             }
           );
         }


### PR DESCRIPTION
It's confusing that we use mutative operations in our updaters when that can alter the base-layer when we i.e. are working with optimistic layers.