### PR TITLE
fix(core): support Headers being passed in fetchOptions

### DIFF
--- a/.changeset/fluffy-poets-protect.md
+++ b/.changeset/fluffy-poets-protect.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Correctly support the `Headers` class being used in `fetchOptions`

--- a/packages/core/src/internal/fetchOptions.test.ts
+++ b/packages/core/src/internal/fetchOptions.test.ts
@@ -107,6 +107,30 @@ describe('makeFetchOptions', () => {
     `);
   });
 
+  it('handles the Headers object', () => {
+    const headers = new Headers();
+    headers.append('x-test', 'true');
+    const operation = makeOperation(queryOperation.kind, queryOperation, {
+      ...queryOperation.context,
+      fetchOptions: {
+        headers,
+      },
+    });
+    const body = makeFetchBody(operation);
+
+    expect(makeFetchOptions(operation, body)).toMatchInlineSnapshot(`
+      {
+        "body": "{\\"operationName\\":\\"getUser\\",\\"query\\":\\"query getUser($name: String) {\\\\n  user(name: $name) {\\\\n    id\\\\n    firstName\\\\n    lastName\\\\n  }\\\\n}\\",\\"variables\\":{\\"name\\":\\"Clara\\"}}",
+        "headers": {
+          "accept": "application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed",
+          "content-type": "application/json",
+          "x-test": "true",
+        },
+        "method": "POST",
+      }
+    `);
+  });
+
   it('creates a GET request when preferred for query operations', () => {
     const operation = makeOperation(queryOperation.kind, queryOperation, {
       ...queryOperation.context,

--- a/packages/core/src/internal/fetchOptions.test.ts
+++ b/packages/core/src/internal/fetchOptions.test.ts
@@ -131,6 +131,28 @@ describe('makeFetchOptions', () => {
     `);
   });
 
+  it('handles an Array headers init', () => {
+    const operation = makeOperation(queryOperation.kind, queryOperation, {
+      ...queryOperation.context,
+      fetchOptions: {
+        headers: [['x-test', 'true']],
+      },
+    });
+    const body = makeFetchBody(operation);
+
+    expect(makeFetchOptions(operation, body)).toMatchInlineSnapshot(`
+      {
+        "body": "{\\"operationName\\":\\"getUser\\",\\"query\\":\\"query getUser($name: String) {\\\\n  user(name: $name) {\\\\n    id\\\\n    firstName\\\\n    lastName\\\\n  }\\\\n}\\",\\"variables\\":{\\"name\\":\\"Clara\\"}}",
+        "headers": {
+          "accept": "application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed",
+          "content-type": "application/json",
+          "x-test": "true",
+        },
+        "method": "POST",
+      }
+    `);
+  });
+
   it('creates a GET request when preferred for query operations', () => {
     const operation = makeOperation(queryOperation.kind, queryOperation, {
       ...queryOperation.context,

--- a/packages/core/src/internal/fetchOptions.ts
+++ b/packages/core/src/internal/fetchOptions.ts
@@ -134,7 +134,11 @@ export const makeFetchOptions = (
       (extraOptions.headers as Headers | [[string, string]]).forEach(
         (value, key) => {
           if (Array.isArray(value)) {
-            headers[value[0]] = value[1];
+            if (headers[value[0]]) {
+              headers[value[0]] = `${headers[value[0]]},${value[1]}`;
+            } else {
+              headers[value[0]] = value[1];
+            }
           } else {
             headers[key] = value;
           }

--- a/packages/core/src/internal/fetchOptions.ts
+++ b/packages/core/src/internal/fetchOptions.ts
@@ -102,6 +102,9 @@ const serializeBody = (
   }
 };
 
+const isHeaders = (headers: HeadersInit): headers is Headers =>
+  'has' in headers && !Object.keys(headers).length;
+
 /** Creates a `RequestInit` object for a given `Operation`.
  *
  * @param operation - An {@link Operation} for which to make the request.
@@ -130,8 +133,12 @@ export const makeFetchOptions = (
       ? operation.context.fetchOptions()
       : operation.context.fetchOptions) || {};
   if (extraOptions.headers) {
-    if (extraOptions.headers.forEach) {
-      (extraOptions.headers as Headers | [[string, string]]).forEach(
+    if (isHeaders(extraOptions.headers)) {
+      extraOptions.headers.forEach((value, key) => {
+        headers[key] = value;
+      });
+    } else if (Array.isArray(extraOptions.headers)) {
+      (extraOptions.headers as Array<[string, string]>).forEach(
         (value, key) => {
           if (Array.isArray(value)) {
             if (headers[value[0]]) {

--- a/packages/core/src/internal/fetchOptions.ts
+++ b/packages/core/src/internal/fetchOptions.ts
@@ -129,9 +129,18 @@ export const makeFetchOptions = (
     (typeof operation.context.fetchOptions === 'function'
       ? operation.context.fetchOptions()
       : operation.context.fetchOptions) || {};
-  if (extraOptions.headers)
-    for (const key in extraOptions.headers)
-      headers[key.toLowerCase()] = extraOptions.headers[key];
+  if (extraOptions.headers) {
+    if (extraOptions.headers.forEach) {
+      (extraOptions.headers as Headers).forEach((value, key) => {
+        headers[key] = value;
+      });
+    } else {
+      for (const key in extraOptions.headers) {
+        headers[key.toLowerCase()] = extraOptions.headers[key];
+      }
+    }
+  }
+
   const serializedBody = serializeBody(operation, body);
   if (typeof serializedBody === 'string' && !headers['content-type'])
     headers['content-type'] = 'application/json';

--- a/packages/core/src/internal/fetchOptions.ts
+++ b/packages/core/src/internal/fetchOptions.ts
@@ -131,9 +131,15 @@ export const makeFetchOptions = (
       : operation.context.fetchOptions) || {};
   if (extraOptions.headers) {
     if (extraOptions.headers.forEach) {
-      (extraOptions.headers as Headers).forEach((value, key) => {
-        headers[key] = value;
-      });
+      (extraOptions.headers as Headers | [[string, string]]).forEach(
+        (value, key) => {
+          if (Array.isArray(value)) {
+            headers[value[0]] = value[1];
+          } else {
+            headers[key] = value;
+          }
+        }
+      );
     } else {
       for (const key in extraOptions.headers) {
         headers[key.toLowerCase()] = extraOptions.headers[key];


### PR DESCRIPTION
Resolves #3504 

## Summary

This aims to solve the problem of supporting `Headers` I opted not to do do a `instanceof` check for this to support node versions that don't have this by default. The downside of doing the `forEach` check is that we also get the `[[string, string]]` `HeadersInit` in there which is a tad harder to support