### PR TITLE
fix(core): Allow path-only URLs to be used with GET requests

### DIFF
--- a/.changeset/curvy-sheep-drive.md
+++ b/.changeset/curvy-sheep-drive.md
@@ -2,4 +2,4 @@
 '@urql/core': patch
 ---
 
-Allow URLs consisting of only a path (i.e. `/api/graphql`) to be passed to `fetch` when using GET requests
+Allow `url` to be a plain, non-URL pathname (i.e. `/api/graphql`) to be used with `preferGetMethod`

--- a/.changeset/curvy-sheep-drive.md
+++ b/.changeset/curvy-sheep-drive.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Allow URLs consisting of only a path (i.e. `/api/graphql`) to be passed to `fetch` when using GET requests

--- a/packages/core/src/internal/fetchOptions.test.ts
+++ b/packages/core/src/internal/fetchOptions.test.ts
@@ -52,6 +52,14 @@ describe('makeFetchURL', () => {
     );
   });
 
+  it('returns the URL by default when only a path is provided', () => {
+    const operation = makeOperation(queryOperation.kind, queryOperation, {
+      url: '/graphql',
+    });
+    const body = makeFetchBody(operation);
+    expect(makeFetchURL(operation, body)).toBe('/graphql');
+  });
+
   it('returns a query parameter URL when GET is preferred', () => {
     const operation = makeOperation(queryOperation.kind, queryOperation, {
       ...queryOperation.context,
@@ -61,6 +69,18 @@ describe('makeFetchURL', () => {
     const body = makeFetchBody(operation);
     expect(makeFetchURL(operation, body)).toMatchInlineSnapshot(
       '"http://localhost:3000/graphql?query=query+getUser%28%24name%3A+String%29+%7B%0A++user%28name%3A+%24name%29+%7B%0A++++id%0A++++firstName%0A++++lastName%0A++%7D%0A%7D&operationName=getUser&variables=%7B%22name%22%3A%22Clara%22%7D"'
+    );
+  });
+
+  it('returns a query parameter URL when GET is preferred and only a path is provided', () => {
+    const operation = makeOperation(queryOperation.kind, queryOperation, {
+      url: '/graphql',
+      preferGetMethod: true,
+    });
+
+    const body = makeFetchBody(operation);
+    expect(makeFetchURL(operation, body)).toMatchInlineSnapshot(
+      '"/graphql?query=query+getUser%28%24name%3A+String%29+%7B%0A++user%28name%3A+%24name%29+%7B%0A++++id%0A++++firstName%0A++++lastName%0A++%7D%0A%7D&operationName=getUser&variables=%7B%22name%22%3A%22Clara%22%7D"'
     );
   });
 


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR, but please make sure to open an issue or discuss
  your changes first, if you’re looking to submit a larger PR.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

<!-- What's the motivation of this change? What does it solve? -->

Changes query parameter handling to allow path-only URLs (i.e. `/api/graphql`) passed to `fetch` to be used with GET requests. This was previously broken as [`URL`](https://developer.mozilla.org/en-US/docs/Web/API/URL) would throw a `TypeError: Invalid URL` as it only works with fully formed URLs.

Extracting the unparsed query parameters is now done manually, so as to not depend on `URL`. Important to note is that the current method will not handle URLs with fragments (i.e. `/api/graphql#fragment`) in them, but it is easy to add if desired.
