### PR TITLE
fix(graphcache): Mutable links on InMemoryData store

### DIFF
--- a/.changeset/wicked-kids-joke.md
+++ b/.changeset/wicked-kids-joke.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix `store.resolve()` returning the exact link array that’s used by the cache. This can lead to subtle bugs when a user mutates the result returned by `cache.resolve()`, since this directly mutates what’s in the cache at that layer.

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -159,7 +159,10 @@ export class Store<
       const fieldKey = keyOfField(field, args);
       fieldValue = InMemoryData.readRecord(entityKey, fieldKey);
       if (fieldValue === undefined)
-        fieldValue = InMemoryData.readLink(entityKey, fieldKey);
+        fieldValue = ensureLink(
+          this,
+          InMemoryData.readLink(entityKey, fieldKey)
+        );
     }
     return fieldValue;
   }

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -153,18 +153,15 @@ export class Store<
     field: string,
     args?: FieldArgs
   ): DataField | undefined {
-    let fieldValue: DataField | undefined = null;
     const entityKey = this.keyOfEntity(entity);
     if (entityKey) {
       const fieldKey = keyOfField(field, args);
-      fieldValue = InMemoryData.readRecord(entityKey, fieldKey);
-      if (fieldValue === undefined)
-        fieldValue = ensureLink(
-          this,
-          InMemoryData.readLink(entityKey, fieldKey)
-        );
+      const fieldValue = InMemoryData.readRecord(entityKey, fieldKey);
+      if (fieldValue !== undefined) return fieldValue;
+      let fieldLink = InMemoryData.readLink(entityKey, fieldKey);
+      if (fieldLink !== undefined) fieldLink = ensureLink(this, fieldLink);
+      return fieldLink;
     }
-    return fieldValue;
   }
 
   resolveFieldByKey(entity: Entity, field: string, args?: FieldArgs) {


### PR DESCRIPTION
See related PR: https://github.com/urql-graphql/urql/pull/3503

## Summary

When `cache.resolve` returns a list of entity links, i.e. an array link, a user may be tempted to mutate this list before writing it back to the store.

This can have unforeseen consequences if:
- `cache.link` then doesn't write to the same layer
- `cache.link` isn't called at all
- the array is completely changed and then read back in an unrelated operation

This is because, unlike `cache.link`, `cache.resolve` doesn't make a copy of links before returning them. This means that mutating a link array leads to direct modifications to the internal caching layer.

## Set of changes

- Call `ensureLink` before returning the links via `cache.resolve` to copy them
