### PR TITLE
fix(graphcache): Cascade `@defer`, `@_optional`, and `@_required` state only per nested fragment spread

### DIFF
--- a/.changeset/sixty-needles-exercise.md
+++ b/.changeset/sixty-needles-exercise.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Prevent `@defer` from being applied in child field selections. Previously, a child field (i.e. a nested field) under a `@defer`-ed fragment would also become optional, which was based on a prior version of the DeferStream spec which didn't require deferred fields to be delivered as a group.

--- a/exchanges/graphcache/src/cacheExchange.test.ts
+++ b/exchanges/graphcache/src/cacheExchange.test.ts
@@ -909,8 +909,10 @@ describe('directives', () => {
         todos {
           id
           text
-          ... on Todo @_optional {
-            completed
+          ... @_optional {
+            ... on Todo {
+              completed
+            }
           }
         }
       }

--- a/exchanges/graphcache/src/operations/query.ts
+++ b/exchanges/graphcache/src/operations/query.ts
@@ -145,7 +145,7 @@ const readRoot = (
   const iterate = makeSelectionIterator(
     entityKey,
     entityKey,
-    deferRef,
+    false,
     undefined,
     select,
     ctx
@@ -390,7 +390,7 @@ const readSelection = (
   const iterate = makeSelectionIterator(
     typename,
     entityKey,
-    deferRef,
+    false,
     undefined,
     select,
     ctx

--- a/exchanges/graphcache/src/operations/shared.ts
+++ b/exchanges/graphcache/src/operations/shared.ts
@@ -163,14 +163,33 @@ interface SelectionIterator {
   (): FormattedNode<FieldNode> | undefined;
 }
 
-export const makeSelectionIterator = (
-  typename: void | string,
+// NOTE: Outside of this file, we expect `_defer` to always be reset to `false`
+export function makeSelectionIterator(
+  typename: undefined | string,
   entityKey: string,
-  defer: boolean,
-  optional: boolean | undefined,
+  _defer: false,
+  _optional: undefined,
   selectionSet: FormattedNode<SelectionSet>,
   ctx: Context
-): SelectionIterator => {
+): SelectionIterator;
+// NOTE: Inside this file we expect the state to be recursively passed on
+export function makeSelectionIterator(
+  typename: undefined | string,
+  entityKey: string,
+  _defer: boolean,
+  _optional: undefined | boolean,
+  selectionSet: FormattedNode<SelectionSet>,
+  ctx: Context
+): SelectionIterator;
+
+export function makeSelectionIterator(
+  typename: undefined | string,
+  entityKey: string,
+  _defer: boolean,
+  _optional: boolean | undefined,
+  selectionSet: FormattedNode<SelectionSet>,
+  ctx: Context
+): SelectionIterator {
   let child: SelectionIterator | void;
   let index = 0;
 
@@ -178,8 +197,8 @@ export const makeSelectionIterator = (
     let node: FormattedNode<FieldNode> | undefined;
     while (child || index < selectionSet.length) {
       node = undefined;
-      deferRef = defer;
-      optionalRef = optional;
+      deferRef = _defer;
+      optionalRef = _optional;
       if (child) {
         if ((node = child())) {
           return node;
@@ -212,13 +231,11 @@ export const makeSelectionIterator = (
             if (isMatching) {
               if (process.env.NODE_ENV !== 'production')
                 pushDebugNode(typename, fragment);
-
-              const isFragmentOptional = isOptional(select);
               child = makeSelectionIterator(
                 typename,
                 entityKey,
-                defer || isDeferred(select, ctx.variables),
-                isFragmentOptional,
+                _defer || isDeferred(select, ctx.variables),
+                isOptional(select),
                 getSelectionSet(fragment),
                 ctx
               );
@@ -230,7 +247,7 @@ export const makeSelectionIterator = (
       }
     }
   };
-};
+}
 
 export const ensureData = (x: DataField): Data | NullArray<Data> | null =>
   x == null ? null : (x as Data | NullArray<Data>);

--- a/exchanges/graphcache/src/operations/shared.ts
+++ b/exchanges/graphcache/src/operations/shared.ts
@@ -71,8 +71,6 @@ export const makeContext = (
   entityKey: string,
   error: CombinedError | undefined
 ): Context => {
-  //deferRef = false;
-
   const ctx: Context = {
     store,
     variables,

--- a/exchanges/graphcache/src/operations/shared.ts
+++ b/exchanges/graphcache/src/operations/shared.ts
@@ -71,7 +71,7 @@ export const makeContext = (
   entityKey: string,
   error: CombinedError | undefined
 ): Context => {
-  deferRef = false;
+  //deferRef = false;
 
   const ctx: Context = {
     store,

--- a/exchanges/graphcache/src/operations/shared.ts
+++ b/exchanges/graphcache/src/operations/shared.ts
@@ -231,11 +231,14 @@ export function makeSelectionIterator(
             if (isMatching) {
               if (process.env.NODE_ENV !== 'production')
                 pushDebugNode(typename, fragment);
+              const isFragmentOptional = isOptional(select);
               child = makeSelectionIterator(
                 typename,
                 entityKey,
                 _defer || isDeferred(select, ctx.variables),
-                isOptional(select),
+                isFragmentOptional !== undefined
+                  ? isFragmentOptional
+                  : _optional,
                 getSelectionSet(fragment),
                 ctx
               );

--- a/exchanges/graphcache/src/operations/write.ts
+++ b/exchanges/graphcache/src/operations/write.ts
@@ -239,7 +239,7 @@ const writeSelection = (
   const iterate = makeSelectionIterator(
     typename,
     entityKey || typename,
-    deferRef,
+    false,
     undefined,
     select,
     ctx


### PR DESCRIPTION
## Summary

This fixes `@_optional` to work when the selection contains a sub-selection fragment spread. Previously, other fragment spreads inside an `@_optional` spread would become non-optional/non-required again, since the value of `deferRef` would be reset with another `isOptional()` check.

This also applies the same principle to `@defer`. Previously, `@defer` would cascade to all child selection fields. This meant that any field nested inside a `@defer`-ed fragment would be able to be deferred and be completely optional, even if it's direct parent wasn't a deferred fragment spread.

## Set of changes

- Remove `deferRef` reset from `makeContext`
- Reset `deferRef` with every new child field and only cascade it across fragment spreads
- Cascade `optionalRef` across fragment spreads (but also not new child fields)
- Add overload signature to annotate what the preferred call signature of `makeSelectionIterator` is to prevent future mistakes
