### PR TITLE
feat(graphcache): default updater when none found

### DIFF
--- a/.changeset/honest-queens-approve.md
+++ b/.changeset/honest-queens-approve.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': minor
+---
+
+Add a default updater for mutation fields who are lacking an updater and where the returned entity is not present in the cache

--- a/.changeset/honest-queens-approve.md
+++ b/.changeset/honest-queens-approve.md
@@ -1,5 +1,5 @@
 ---
-'@urql/exchange-graphcache': minor
+'@urql/exchange-graphcache': major
 ---
 
 Add a default updater for mutation fields who are lacking an updater and where the returned entity is not present in the cache

--- a/exchanges/graphcache/src/cacheExchange.test.ts
+++ b/exchanges/graphcache/src/cacheExchange.test.ts
@@ -3116,7 +3116,7 @@ describe('commutativity', () => {
     expect(data).toHaveProperty('node.name', 'mutation');
   });
 
-  it('applies optimistic updates on top of commutative queries until mutation resolves', () => {
+  it.only('applies optimistic updates on top of commutative queries until mutation resolves', () => {
     let data: any;
     const client = createClient({
       url: 'http://0.0.0.0',

--- a/exchanges/graphcache/src/cacheExchange.test.ts
+++ b/exchanges/graphcache/src/cacheExchange.test.ts
@@ -3116,7 +3116,7 @@ describe('commutativity', () => {
     expect(data).toHaveProperty('node.name', 'mutation');
   });
 
-  it.only('applies optimistic updates on top of commutative queries until mutation resolves', () => {
+  it('applies optimistic updates on top of commutative queries until mutation resolves', () => {
     let data: any;
     const client = createClient({
       url: 'http://0.0.0.0',

--- a/exchanges/graphcache/src/operations/write.ts
+++ b/exchanges/graphcache/src/operations/write.ts
@@ -394,7 +394,7 @@ const writeSelection = (
         const key = ctx.store.keyOfEntity(fieldValue as any);
         if (key) {
           const resolved = InMemoryData.readRecord(key, '__typename');
-          const count = InMemoryData!.getRefCount(key);
+          const count = InMemoryData.getRefCount(key);
           if (resolved && !count) {
             invalidateType(fieldValue.__typename);
           }

--- a/exchanges/graphcache/src/operations/write.ts
+++ b/exchanges/graphcache/src/operations/write.ts
@@ -46,6 +46,7 @@ import {
   getFieldError,
   deferRef,
 } from './shared';
+import { invalidateEntity } from './invalidate';
 
 export interface WriteResult {
   data: null | Data;
@@ -373,6 +374,26 @@ const writeSelection = (
 
       data[fieldName] = fieldValue;
       updater(data, fieldArgs || {}, ctx.store, ctx);
+    } else if (typename === ctx.store.rootFields['mutation']) {
+      // If we're on a mutation that doesn't have an updater, we'll see
+      // whether we can find the entity returned by the mutation in the cache.
+      // if we don't we'll assume this is a create mutation and invalidate
+      // the found __typename.
+      if (fieldValue && Array.isArray(fieldValue)) {
+        for (let i = 0, l = fieldValue.length; i < l; i++) {
+          const key = ctx.store.keyOfEntity(fieldValue[i]);
+          if (key && fieldValue[i].__typename) {
+            const resolved = InMemoryData.readRecord(key, '__typename');
+            if (!resolved) invalidateEntity(fieldValue[i].__typename);
+          }
+        }
+      } else if (fieldValue && typeof fieldValue === 'object') {
+        const key = ctx.store.keyOfEntity(fieldValue as any);
+        if (key) {
+          const resolved = InMemoryData.readRecord(key, '__typename');
+          if (!resolved) invalidateEntity(fieldValue.__typeaname);
+        }
+      }
     }
 
     // After processing the field, remove the current alias from the path again

--- a/exchanges/graphcache/src/operations/write.ts
+++ b/exchanges/graphcache/src/operations/write.ts
@@ -46,7 +46,7 @@ import {
   getFieldError,
   deferRef,
 } from './shared';
-import { invalidateEntity } from './invalidate';
+import { invalidateType } from './invalidate';
 
 export interface WriteResult {
   data: null | Data;
@@ -384,14 +384,20 @@ const writeSelection = (
           const key = ctx.store.keyOfEntity(fieldValue[i]);
           if (key && fieldValue[i].__typename) {
             const resolved = InMemoryData.readRecord(key, '__typename');
-            if (!resolved) invalidateEntity(fieldValue[i].__typename);
+            const count = InMemoryData!.getRefCount(key);
+            if (resolved && !count) {
+              invalidateType(fieldValue[i].__typename);
+            }
           }
         }
       } else if (fieldValue && typeof fieldValue === 'object') {
         const key = ctx.store.keyOfEntity(fieldValue as any);
         if (key) {
           const resolved = InMemoryData.readRecord(key, '__typename');
-          if (!resolved) invalidateEntity(fieldValue.__typeaname);
+          const count = InMemoryData!.getRefCount(key);
+          if (resolved && !count) {
+            invalidateType(fieldValue.__typename);
+          }
         }
       }
     }

--- a/exchanges/graphcache/src/operations/write.ts
+++ b/exchanges/graphcache/src/operations/write.ts
@@ -374,7 +374,10 @@ const writeSelection = (
 
       data[fieldName] = fieldValue;
       updater(data, fieldArgs || {}, ctx.store, ctx);
-    } else if (typename === ctx.store.rootFields['mutation']) {
+    } else if (
+      typename === ctx.store.rootFields['mutation'] &&
+      !ctx.optimistic
+    ) {
       // If we're on a mutation that doesn't have an updater, we'll see
       // whether we can find the entity returned by the mutation in the cache.
       // if we don't we'll assume this is a create mutation and invalidate
@@ -395,7 +398,7 @@ const writeSelection = (
         if (key) {
           const resolved = InMemoryData.readRecord(key, '__typename');
           const count = InMemoryData.getRefCount(key);
-          if (resolved && !count) {
+          if ((!resolved || !count) && fieldValue.__typename) {
             invalidateType(fieldValue.__typename);
           }
         }

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -345,7 +345,7 @@ export function getRefCount(entityKey: string): number {
 /** Adjusts the reference count of an entity on a refCount dict by "by" and updates the gc */
 const updateRCForEntity = (entityKey: string, by: number): void => {
   // Retrieve the reference count and adjust it by "by"
-  const count = currentData!.refCount.get(entityKey) || 0;
+  const count = getRefCount(entityKey);
   const newCount = count + by > 0 ? count + by : 0;
   currentData!.refCount.set(entityKey, newCount);
   // Add it to the garbage collection batch if it needs to be deleted or remove it
@@ -414,7 +414,7 @@ export const gc = () => {
 
     // Check first whether the entity has any references,
     // if so, we skip it from the GC run
-    const rc = currentData!.refCount.get(entityKey) || 0;
+    const rc = getRefCount(entityKey);
     if (rc > 0) continue;
 
     const record = currentData!.records.base.get(entityKey);

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -338,6 +338,10 @@ const getNode = <T>(
   return node !== undefined ? node[fieldKey] : undefined;
 };
 
+export function getRefCount(entityKey: string): number {
+  return currentData!.refCount.get(entityKey) || 0;
+}
+
 /** Adjusts the reference count of an entity on a refCount dict by "by" and updates the gc */
 const updateRCForEntity = (entityKey: string, by: number): void => {
   // Retrieve the reference count and adjust it by "by"


### PR DESCRIPTION
Resolves #3470

## Summary

This adds a default updater when the response contains an entity that has no links to yet, this implies the creation of a new entity. When this creation has no associated updater we'll invalidate the `type`, this ensures that lists are invalidated. This gets us to an easier adoption path and allows for optimising where the user wants to.

The remaining issue here would be cases where the user returns a scalar or when an updater shifts the ordering of a list.

This brings the default graphcache a bit closer to document caching in terms of mutation reactions.
