### PR TITLE
fix(request-policy): avoid relying on cache internals to assert misses

### DIFF
--- a/.changeset/plenty-elephants-lay.md
+++ b/.changeset/plenty-elephants-lay.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-request-policy': minor
+---
+
+Change the request-policy exchange not to rely on OperationMeta set by the cache exchanges

--- a/exchanges/request-policy/src/requestPolicyExchange.ts
+++ b/exchanges/request-policy/src/requestPolicyExchange.ts
@@ -92,6 +92,9 @@ export const requestPolicyExchange =
       // lower than the current time we see this as a miss.
       const lastDispatched = dispatched.get(result.operation.key) || 0;
       if (incomingTime !== lastDispatched) {
+        // We only delete in the case of a miss to ensure that cache-and-network
+        // is properly taken care of
+        dispatched.delete(result.operation.key);
         operations.set(result.operation.key, new Date().getTime());
       }
     };

--- a/exchanges/request-policy/src/requestPolicyExchange.ts
+++ b/exchanges/request-policy/src/requestPolicyExchange.ts
@@ -58,6 +58,7 @@ export const requestPolicyExchange =
     const operations = new Map();
     const TTL = (options || {}).ttl || defaultTTL;
     const dispatched = new Map<number, number>();
+    let counter = 0;
 
     const processIncomingOperation = (operation: Operation): Operation => {
       if (
@@ -70,7 +71,10 @@ export const requestPolicyExchange =
 
       const currentTime = new Date().getTime();
       // When an operation passes by we track the current time
-      dispatched.set(operation.key, currentTime);
+      dispatched.set(operation.key, counter);
+      queueMicrotask(() => {
+        counter = (counter + 1) | 0;
+      });
       const lastOccurrence = operations.get(operation.key) || 0;
       if (
         currentTime - lastOccurrence > TTL &&
@@ -86,12 +90,11 @@ export const requestPolicyExchange =
     };
 
     const processIncomingResults = (result: OperationResult): void => {
-      const incomingTime = new Date().getTime();
       // When we get a result for the operation we check whether it resolved
-      // synchronously by checking when it was last dispatched and if it's
-      // lower than the current time we see this as a miss.
+      // synchronously by checking whether the counter is different from the
+      // dispatched counter.
       const lastDispatched = dispatched.get(result.operation.key) || 0;
-      if (incomingTime !== lastDispatched) {
+      if (counter !== lastDispatched) {
         // We only delete in the case of a miss to ensure that cache-and-network
         // is properly taken care of
         dispatched.delete(result.operation.key);


### PR DESCRIPTION
Resolves #3508

## Summary

This PR removes the logic of asserting the cacheState of a given operation and moves us to asserting whether the operation was resolved synchronously. When we are dealing with a synchronously resolved operation we can see this as a cache-hit, when it's higher than the last dispatched we can see this as a cache miss.

```
## Operation with cache-first
cache-first --> request-policy (time 1) --> cache-miss --> fetch --> request-policy (time x > 1)
## Operation with cache-and-network
cache-and-network--> request-policy (time 1) --> cache-hit --> request-policy (time = 1) --> fetch --> request-policy (time x > 1)
```
