### PR TITLE
Update urql.md with small typo fix

### DIFF
--- a/docs/api/urql.md
+++ b/docs/api/urql.md
@@ -69,7 +69,7 @@ This function will be called with the previous data (or `undefined`) and the new
 incoming from a subscription event, and may be used to "reduce" the data over time, altering the
 value of `result.data`.
 
-This hook returns a tuple of the shape `[result, executeQuery]`.
+This hook returns a tuple of the shape `[result, executeSubscription]`.
 
 - The `result` is an object with the shape of an [`OperationResult`](./core.md#operationresult).
 - The `executeSubscription` function optionally accepts


### PR DESCRIPTION
Updates the [docs](https://commerce.nearform.com/open-source/urql/docs/api/urql/#usesubscription) so these match:

![image](https://github.com/urql-graphql/urql/assets/2213636/9dc4d065-eab7-4770-91db-1e6fbf5f2b9f)
