### PR TITLE
docs: fix typo and remove unused imports

### DIFF
--- a/docs/advanced/server-side-rendering.md
+++ b/docs/advanced/server-side-rendering.md
@@ -196,7 +196,6 @@ In a server component we will import from `@urql/next/rsc`
 ```ts
 // app/page.tsx
 import React from 'react';
-import Head from 'next/head';
 import { cacheExchange, createClient, fetchExchange, gql } from '@urql/core';
 import { registerUrql } from '@urql/next/rsc';
 
@@ -358,7 +357,6 @@ we wrap `_app.js` we won't have to wrap any individual page.
 ```js
 // pages/index.js
 import React from 'react';
-import Head from 'next/head';
 import { useQuery } from 'urql';
 import { withUrqlClient } from 'next-urql';
 

--- a/docs/advanced/server-side-rendering.md
+++ b/docs/advanced/server-side-rendering.md
@@ -257,7 +257,7 @@ export default function Layout({ children }: React.PropsWithChildren) {
 }
 ```
 
-It is important that we pas both a client as well as the `ssrExchange` to the `Provider`
+It is important that we pass both a client as well as the `ssrExchange` to the `Provider`
 this way we will be able to restore the data that Next streams to the client later on
 when we are hydrating.
 


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR, but please make sure to open an issue or discuss
  your changes first, if you’re looking to submit a larger PR.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

<!-- What's the motivation of this change? What does it solve? -->

I was following through [this guide](https://commerce.nearform.com/open-source/urql/docs/advanced/server-side-rendering/#nextjs) and found some minor typos and unused imports.

## Set of changes

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->

- Added missing letter on the word "pass"
```diff
- we pas both
+ we pass both
```

- Removed unused import `next/head` (since it's also deprecated in the app router)
```diff
// app/page.tsx
import React from 'react';
- import Head from 'next/head';
import { cacheExchange, createClient, fetchExchange, gql } from '@urql/core';
import { registerUrql } from '@urql/next/rsc';
```
```diff
// pages/index.js
import React from 'react';
- import Head from 'next/head';
import { useQuery } from 'urql';
import { withUrqlClient } from 'next-urql';
```
