### PR TITLE
fix invalidation through string key

### DIFF
--- a/.changeset/ninety-taxis-return.md
+++ b/.changeset/ninety-taxis-return.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix `invalidate` not applying when using a string to invalidate an entity

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -171,7 +171,11 @@ export class Store<
   invalidate(entity: Entity, field?: string, args?: FieldArgs) {
     const entityKey = this.keyOfEntity(entity);
     const shouldInvalidateType =
-      entity && typeof entity === 'string' && !field && !args;
+      entity &&
+      typeof entity === 'string' &&
+      !field &&
+      !args &&
+      !this.resolve(entity, '__typename');
 
     if (shouldInvalidateType) {
       invalidateType(entity);


### PR DESCRIPTION
Resolves #3543 

## Summary

When using a string-key like `Todo:1` it won't invalidate the entity, it will however try to invalidate the type which is also not present. This addresses that by checking whether it's an entity by checking whether `Todo:1.__typename` is part of the cache.
