### PR TITLE
feat(persisted-exchange): add support for persisted subscriptions

### DIFF
--- a/.changeset/eight-garlics-move.md
+++ b/.changeset/eight-garlics-move.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-persisted': minor
+---
+
+Add option to enable persisted-operations for subscriptions

--- a/exchanges/persisted/src/persistedExchange.ts
+++ b/exchanges/persisted/src/persistedExchange.ts
@@ -89,6 +89,16 @@ export interface PersistedExchangeOptions {
    * their GraphQL APIs.
    */
   enableForMutation?: boolean;
+  /** Enables persisted queries to be used for subscriptions.
+   *
+   * @remarks
+   * When enabled, the `persistedExchange` will also use the persisted queries
+   * logic for subscription operations.
+   *
+   * This is disabled by default, but often used on APIs that obfuscate
+   * their GraphQL APIs.
+   */
+  enableForSubscriptions?: boolean;
 }
 
 /** Exchange factory that adds support for Persisted Queries.
@@ -131,12 +141,13 @@ export const persistedExchange =
     const enforcePersistedQueries = !!options.enforcePersistedQueries;
     const hashFn = options.generateHash || hash;
     const enableForMutation = !!options.enableForMutation;
+    const enableForSubscriptions = !!options.enableForSubscriptions;
     let supportsPersistedQueries = true;
 
     const operationFilter = (operation: Operation) =>
       supportsPersistedQueries &&
       !operation.context.persistAttempt &&
-      ((enableForMutation && operation.kind === 'mutation') ||
+      ((enableForMutation && operation.kind === 'mutation') || (enableForSubscriptions && operation.kind === 'subscription') ||
         operation.kind === 'query');
 
     const getPersistedOperation = async (operation: Operation) => {

--- a/exchanges/persisted/src/persistedExchange.ts
+++ b/exchanges/persisted/src/persistedExchange.ts
@@ -147,7 +147,8 @@ export const persistedExchange =
     const operationFilter = (operation: Operation) =>
       supportsPersistedQueries &&
       !operation.context.persistAttempt &&
-      ((enableForMutation && operation.kind === 'mutation') || (enableForSubscriptions && operation.kind === 'subscription') ||
+      ((enableForMutation && operation.kind === 'mutation') ||
+        (enableForSubscriptions && operation.kind === 'subscription') ||
         operation.kind === 'query');
 
     const getPersistedOperation = async (operation: Operation) => {


### PR DESCRIPTION
## Summary

This PR adds a new option to the `persistedExchange` where we allow passing in `enableForSubscriptions` which enables persisted operations for subscriptions.