### PR TITLE
chore: Upgrade `@0no-co/graphql.web` to 1.0.5

### DIFF
--- a/.changeset/silly-vans-do.md
+++ b/.changeset/silly-vans-do.md
@@ -1,0 +1,6 @@
+---
+'@urql/exchange-graphcache': patch
+'@urql/core': patch
+---
+
+Upgrade `@0no-co/graphql.web` to `1.0.5`

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ you can take it from getting started with your first GraphQL project all the way
   <tr>
    <td align="center"><a href="https://bigcommerce.com/"><img src="https://avatars.githubusercontent.com/u/186342?s=200&v=4" width="150" alt="BigCommerce"/><br />BigCommerce</a></td>
    <td align="center"><a href="https://wundergraph.com/"><img src="https://avatars.githubusercontent.com/u/64281914?s=200&v=4" width="150" alt="WunderGraph"/><br />WunderGraph</a></td>
+   <td align="center"><a href="https://the-guild.dev/"><img src="https://avatars.githubusercontent.com/u/42573040?s=200&v=4" width="150" alt="The Guild "/><br />The Guild</a></td>
   </tr>
 </table>
 <table>

--- a/exchanges/graphcache/package.json
+++ b/exchanges/graphcache/package.json
@@ -63,7 +63,7 @@
     "prepublishOnly": "run-s clean build"
   },
   "dependencies": {
-    "@0no-co/graphql.web": "^1.0.1",
+    "@0no-co/graphql.web": "^1.0.5",
     "@urql/core": ">=4.3.0",
     "wonka": "^6.3.2"
   },

--- a/exchanges/graphcache/src/operations/shared.test.ts
+++ b/exchanges/graphcache/src/operations/shared.test.ts
@@ -47,8 +47,8 @@ describe('makeSelectionIterator', () => {
       [
         {
           "alias": undefined,
-          "arguments": [],
-          "directives": [],
+          "arguments": undefined,
+          "directives": undefined,
           "kind": "Field",
           "name": {
             "kind": "Name",
@@ -58,8 +58,8 @@ describe('makeSelectionIterator', () => {
         },
         {
           "alias": undefined,
-          "arguments": [],
-          "directives": [],
+          "arguments": undefined,
+          "directives": undefined,
           "kind": "Field",
           "name": {
             "kind": "Name",
@@ -69,8 +69,8 @@ describe('makeSelectionIterator', () => {
         },
         {
           "alias": undefined,
-          "arguments": [],
-          "directives": [],
+          "arguments": undefined,
+          "directives": undefined,
           "kind": "Field",
           "name": {
             "kind": "Name",
@@ -138,8 +138,8 @@ describe('makeSelectionIterator', () => {
       [
         {
           "alias": undefined,
-          "arguments": [],
-          "directives": [],
+          "arguments": undefined,
+          "directives": undefined,
           "kind": "Field",
           "name": {
             "kind": "Name",
@@ -149,8 +149,8 @@ describe('makeSelectionIterator', () => {
         },
         {
           "alias": undefined,
-          "arguments": [],
-          "directives": [],
+          "arguments": undefined,
+          "directives": undefined,
           "kind": "Field",
           "name": {
             "kind": "Name",
@@ -160,8 +160,8 @@ describe('makeSelectionIterator', () => {
         },
         {
           "alias": undefined,
-          "arguments": [],
-          "directives": [],
+          "arguments": undefined,
+          "directives": undefined,
           "kind": "Field",
           "name": {
             "kind": "Name",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     }
   },
   "devDependencies": {
-    "@0no-co/graphql.web": "^1.0.1",
+    "@0no-co/graphql.web": "^1.0.5",
     "@actions/artifact": "^1.1.1",
     "@actions/core": "^1.10.0",
     "@babel/core": "^7.21.5",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,7 +54,7 @@
     "prepublishOnly": "run-s clean build"
   },
   "dependencies": {
-    "@0no-co/graphql.web": "^1.0.1",
+    "@0no-co/graphql.web": "^1.0.5",
     "wonka": "^6.3.2"
   },
   "publishConfig": {

--- a/packages/core/src/exchanges/__snapshots__/fetch.test.ts.snap
+++ b/packages/core/src/exchanges/__snapshots__/fetch.test.ts.snap
@@ -20,7 +20,7 @@ exports[`on error > returns error data 1`] = `
       "__key": -2395444236,
       "definitions": [
         {
-          "directives": [],
+          "directives": undefined,
           "kind": "OperationDefinition",
           "name": {
             "kind": "Name",
@@ -48,7 +48,7 @@ exports[`on error > returns error data 1`] = `
                     },
                   },
                 ],
-                "directives": [],
+                "directives": undefined,
                 "kind": "Field",
                 "name": {
                   "kind": "Name",
@@ -59,8 +59,8 @@ exports[`on error > returns error data 1`] = `
                   "selections": [
                     {
                       "alias": undefined,
-                      "arguments": [],
-                      "directives": [],
+                      "arguments": undefined,
+                      "directives": undefined,
                       "kind": "Field",
                       "name": {
                         "kind": "Name",
@@ -70,8 +70,8 @@ exports[`on error > returns error data 1`] = `
                     },
                     {
                       "alias": undefined,
-                      "arguments": [],
-                      "directives": [],
+                      "arguments": undefined,
+                      "directives": undefined,
                       "kind": "Field",
                       "name": {
                         "kind": "Name",
@@ -81,8 +81,8 @@ exports[`on error > returns error data 1`] = `
                     },
                     {
                       "alias": undefined,
-                      "arguments": [],
-                      "directives": [],
+                      "arguments": undefined,
+                      "directives": undefined,
                       "kind": "Field",
                       "name": {
                         "kind": "Name",
@@ -98,7 +98,7 @@ exports[`on error > returns error data 1`] = `
           "variableDefinitions": [
             {
               "defaultValue": undefined,
-              "directives": [],
+              "directives": undefined,
               "kind": "VariableDefinition",
               "type": {
                 "kind": "NamedType",
@@ -176,7 +176,7 @@ exports[`on error > returns error data with status 400 and manual redirect mode 
       "__key": -2395444236,
       "definitions": [
         {
-          "directives": [],
+          "directives": undefined,
           "kind": "OperationDefinition",
           "name": {
             "kind": "Name",
@@ -204,7 +204,7 @@ exports[`on error > returns error data with status 400 and manual redirect mode 
                     },
                   },
                 ],
-                "directives": [],
+                "directives": undefined,
                 "kind": "Field",
                 "name": {
                   "kind": "Name",
@@ -215,8 +215,8 @@ exports[`on error > returns error data with status 400 and manual redirect mode 
                   "selections": [
                     {
                       "alias": undefined,
-                      "arguments": [],
-                      "directives": [],
+                      "arguments": undefined,
+                      "directives": undefined,
                       "kind": "Field",
                       "name": {
                         "kind": "Name",
@@ -226,8 +226,8 @@ exports[`on error > returns error data with status 400 and manual redirect mode 
                     },
                     {
                       "alias": undefined,
-                      "arguments": [],
-                      "directives": [],
+                      "arguments": undefined,
+                      "directives": undefined,
                       "kind": "Field",
                       "name": {
                         "kind": "Name",
@@ -237,8 +237,8 @@ exports[`on error > returns error data with status 400 and manual redirect mode 
                     },
                     {
                       "alias": undefined,
-                      "arguments": [],
-                      "directives": [],
+                      "arguments": undefined,
+                      "directives": undefined,
                       "kind": "Field",
                       "name": {
                         "kind": "Name",
@@ -254,7 +254,7 @@ exports[`on error > returns error data with status 400 and manual redirect mode 
           "variableDefinitions": [
             {
               "defaultValue": undefined,
-              "directives": [],
+              "directives": undefined,
               "kind": "VariableDefinition",
               "type": {
                 "kind": "NamedType",
@@ -334,7 +334,7 @@ exports[`on success > returns response data 1`] = `
       "__key": -2395444236,
       "definitions": [
         {
-          "directives": [],
+          "directives": undefined,
           "kind": "OperationDefinition",
           "name": {
             "kind": "Name",
@@ -362,7 +362,7 @@ exports[`on success > returns response data 1`] = `
                     },
                   },
                 ],
-                "directives": [],
+                "directives": undefined,
                 "kind": "Field",
                 "name": {
                   "kind": "Name",
@@ -373,8 +373,8 @@ exports[`on success > returns response data 1`] = `
                   "selections": [
                     {
                       "alias": undefined,
-                      "arguments": [],
-                      "directives": [],
+                      "arguments": undefined,
+                      "directives": undefined,
                       "kind": "Field",
                       "name": {
                         "kind": "Name",
@@ -384,8 +384,8 @@ exports[`on success > returns response data 1`] = `
                     },
                     {
                       "alias": undefined,
-                      "arguments": [],
-                      "directives": [],
+                      "arguments": undefined,
+                      "directives": undefined,
                       "kind": "Field",
                       "name": {
                         "kind": "Name",
@@ -395,8 +395,8 @@ exports[`on success > returns response data 1`] = `
                     },
                     {
                       "alias": undefined,
-                      "arguments": [],
-                      "directives": [],
+                      "arguments": undefined,
+                      "directives": undefined,
                       "kind": "Field",
                       "name": {
                         "kind": "Name",
@@ -412,7 +412,7 @@ exports[`on success > returns response data 1`] = `
           "variableDefinitions": [
             {
               "defaultValue": undefined,
-              "directives": [],
+              "directives": undefined,
               "kind": "VariableDefinition",
               "type": {
                 "kind": "NamedType",

--- a/packages/core/src/exchanges/__snapshots__/subscription.test.ts.snap
+++ b/packages/core/src/exchanges/__snapshots__/subscription.test.ts.snap
@@ -20,7 +20,7 @@ exports[`should return response data from forwardSubscription observable 1`] = `
       "__key": 7623921801,
       "definitions": [
         {
-          "directives": [],
+          "directives": undefined,
           "kind": "OperationDefinition",
           "name": {
             "kind": "Name",
@@ -48,7 +48,7 @@ exports[`should return response data from forwardSubscription observable 1`] = `
                     },
                   },
                 ],
-                "directives": [],
+                "directives": undefined,
                 "kind": "Field",
                 "name": {
                   "kind": "Name",
@@ -59,8 +59,8 @@ exports[`should return response data from forwardSubscription observable 1`] = `
                   "selections": [
                     {
                       "alias": undefined,
-                      "arguments": [],
-                      "directives": [],
+                      "arguments": undefined,
+                      "directives": undefined,
                       "kind": "Field",
                       "name": {
                         "kind": "Name",
@@ -76,7 +76,7 @@ exports[`should return response data from forwardSubscription observable 1`] = `
           "variableDefinitions": [
             {
               "defaultValue": undefined,
-              "directives": [],
+              "directives": undefined,
               "kind": "VariableDefinition",
               "type": {
                 "kind": "NamedType",

--- a/packages/core/src/internal/__snapshots__/fetchSource.test.ts.snap
+++ b/packages/core/src/internal/__snapshots__/fetchSource.test.ts.snap
@@ -20,7 +20,7 @@ exports[`on error > ignores the error when a result is available 1`] = `
       "__key": -2395444236,
       "definitions": [
         {
-          "directives": [],
+          "directives": undefined,
           "kind": "OperationDefinition",
           "name": {
             "kind": "Name",
@@ -48,7 +48,7 @@ exports[`on error > ignores the error when a result is available 1`] = `
                     },
                   },
                 ],
-                "directives": [],
+                "directives": undefined,
                 "kind": "Field",
                 "name": {
                   "kind": "Name",
@@ -59,8 +59,8 @@ exports[`on error > ignores the error when a result is available 1`] = `
                   "selections": [
                     {
                       "alias": undefined,
-                      "arguments": [],
-                      "directives": [],
+                      "arguments": undefined,
+                      "directives": undefined,
                       "kind": "Field",
                       "name": {
                         "kind": "Name",
@@ -70,8 +70,8 @@ exports[`on error > ignores the error when a result is available 1`] = `
                     },
                     {
                       "alias": undefined,
-                      "arguments": [],
-                      "directives": [],
+                      "arguments": undefined,
+                      "directives": undefined,
                       "kind": "Field",
                       "name": {
                         "kind": "Name",
@@ -81,8 +81,8 @@ exports[`on error > ignores the error when a result is available 1`] = `
                     },
                     {
                       "alias": undefined,
-                      "arguments": [],
-                      "directives": [],
+                      "arguments": undefined,
+                      "directives": undefined,
                       "kind": "Field",
                       "name": {
                         "kind": "Name",
@@ -98,7 +98,7 @@ exports[`on error > ignores the error when a result is available 1`] = `
           "variableDefinitions": [
             {
               "defaultValue": undefined,
-              "directives": [],
+              "directives": undefined,
               "kind": "VariableDefinition",
               "type": {
                 "kind": "NamedType",
@@ -166,7 +166,7 @@ exports[`on error > returns error data 1`] = `
       "__key": -2395444236,
       "definitions": [
         {
-          "directives": [],
+          "directives": undefined,
           "kind": "OperationDefinition",
           "name": {
             "kind": "Name",
@@ -194,7 +194,7 @@ exports[`on error > returns error data 1`] = `
                     },
                   },
                 ],
-                "directives": [],
+                "directives": undefined,
                 "kind": "Field",
                 "name": {
                   "kind": "Name",
@@ -205,8 +205,8 @@ exports[`on error > returns error data 1`] = `
                   "selections": [
                     {
                       "alias": undefined,
-                      "arguments": [],
-                      "directives": [],
+                      "arguments": undefined,
+                      "directives": undefined,
                       "kind": "Field",
                       "name": {
                         "kind": "Name",
@@ -216,8 +216,8 @@ exports[`on error > returns error data 1`] = `
                     },
                     {
                       "alias": undefined,
-                      "arguments": [],
-                      "directives": [],
+                      "arguments": undefined,
+                      "directives": undefined,
                       "kind": "Field",
                       "name": {
                         "kind": "Name",
@@ -227,8 +227,8 @@ exports[`on error > returns error data 1`] = `
                     },
                     {
                       "alias": undefined,
-                      "arguments": [],
-                      "directives": [],
+                      "arguments": undefined,
+                      "directives": undefined,
                       "kind": "Field",
                       "name": {
                         "kind": "Name",
@@ -244,7 +244,7 @@ exports[`on error > returns error data 1`] = `
           "variableDefinitions": [
             {
               "defaultValue": undefined,
-              "directives": [],
+              "directives": undefined,
               "kind": "VariableDefinition",
               "type": {
                 "kind": "NamedType",
@@ -312,7 +312,7 @@ exports[`on error > returns error data with status 400 and manual redirect mode 
       "__key": -2395444236,
       "definitions": [
         {
-          "directives": [],
+          "directives": undefined,
           "kind": "OperationDefinition",
           "name": {
             "kind": "Name",
@@ -340,7 +340,7 @@ exports[`on error > returns error data with status 400 and manual redirect mode 
                     },
                   },
                 ],
-                "directives": [],
+                "directives": undefined,
                 "kind": "Field",
                 "name": {
                   "kind": "Name",
@@ -351,8 +351,8 @@ exports[`on error > returns error data with status 400 and manual redirect mode 
                   "selections": [
                     {
                       "alias": undefined,
-                      "arguments": [],
-                      "directives": [],
+                      "arguments": undefined,
+                      "directives": undefined,
                       "kind": "Field",
                       "name": {
                         "kind": "Name",
@@ -362,8 +362,8 @@ exports[`on error > returns error data with status 400 and manual redirect mode 
                     },
                     {
                       "alias": undefined,
-                      "arguments": [],
-                      "directives": [],
+                      "arguments": undefined,
+                      "directives": undefined,
                       "kind": "Field",
                       "name": {
                         "kind": "Name",
@@ -373,8 +373,8 @@ exports[`on error > returns error data with status 400 and manual redirect mode 
                     },
                     {
                       "alias": undefined,
-                      "arguments": [],
-                      "directives": [],
+                      "arguments": undefined,
+                      "directives": undefined,
                       "kind": "Field",
                       "name": {
                         "kind": "Name",
@@ -390,7 +390,7 @@ exports[`on error > returns error data with status 400 and manual redirect mode 
           "variableDefinitions": [
             {
               "defaultValue": undefined,
-              "directives": [],
+              "directives": undefined,
               "kind": "VariableDefinition",
               "type": {
                 "kind": "NamedType",
@@ -458,7 +458,7 @@ exports[`on error with non spec-compliant body > handles network errors 1`] = `
       "__key": -2395444236,
       "definitions": [
         {
-          "directives": [],
+          "directives": undefined,
           "kind": "OperationDefinition",
           "name": {
             "kind": "Name",
@@ -486,7 +486,7 @@ exports[`on error with non spec-compliant body > handles network errors 1`] = `
                     },
                   },
                 ],
-                "directives": [],
+                "directives": undefined,
                 "kind": "Field",
                 "name": {
                   "kind": "Name",
@@ -497,8 +497,8 @@ exports[`on error with non spec-compliant body > handles network errors 1`] = `
                   "selections": [
                     {
                       "alias": undefined,
-                      "arguments": [],
-                      "directives": [],
+                      "arguments": undefined,
+                      "directives": undefined,
                       "kind": "Field",
                       "name": {
                         "kind": "Name",
@@ -508,8 +508,8 @@ exports[`on error with non spec-compliant body > handles network errors 1`] = `
                     },
                     {
                       "alias": undefined,
-                      "arguments": [],
-                      "directives": [],
+                      "arguments": undefined,
+                      "directives": undefined,
                       "kind": "Field",
                       "name": {
                         "kind": "Name",
@@ -519,8 +519,8 @@ exports[`on error with non spec-compliant body > handles network errors 1`] = `
                     },
                     {
                       "alias": undefined,
-                      "arguments": [],
-                      "directives": [],
+                      "arguments": undefined,
+                      "directives": undefined,
                       "kind": "Field",
                       "name": {
                         "kind": "Name",
@@ -536,7 +536,7 @@ exports[`on error with non spec-compliant body > handles network errors 1`] = `
           "variableDefinitions": [
             {
               "defaultValue": undefined,
-              "directives": [],
+              "directives": undefined,
               "kind": "VariableDefinition",
               "type": {
                 "kind": "NamedType",
@@ -608,7 +608,7 @@ exports[`on success > returns response data 1`] = `
       "__key": -2395444236,
       "definitions": [
         {
-          "directives": [],
+          "directives": undefined,
           "kind": "OperationDefinition",
           "name": {
             "kind": "Name",
@@ -636,7 +636,7 @@ exports[`on success > returns response data 1`] = `
                     },
                   },
                 ],
-                "directives": [],
+                "directives": undefined,
                 "kind": "Field",
                 "name": {
                   "kind": "Name",
@@ -647,8 +647,8 @@ exports[`on success > returns response data 1`] = `
                   "selections": [
                     {
                       "alias": undefined,
-                      "arguments": [],
-                      "directives": [],
+                      "arguments": undefined,
+                      "directives": undefined,
                       "kind": "Field",
                       "name": {
                         "kind": "Name",
@@ -658,8 +658,8 @@ exports[`on success > returns response data 1`] = `
                     },
                     {
                       "alias": undefined,
-                      "arguments": [],
-                      "directives": [],
+                      "arguments": undefined,
+                      "directives": undefined,
                       "kind": "Field",
                       "name": {
                         "kind": "Name",
@@ -669,8 +669,8 @@ exports[`on success > returns response data 1`] = `
                     },
                     {
                       "alias": undefined,
-                      "arguments": [],
-                      "directives": [],
+                      "arguments": undefined,
+                      "directives": undefined,
                       "kind": "Field",
                       "name": {
                         "kind": "Name",
@@ -686,7 +686,7 @@ exports[`on success > returns response data 1`] = `
           "variableDefinitions": [
             {
               "defaultValue": undefined,
-              "directives": [],
+              "directives": undefined,
               "kind": "VariableDefinition",
               "type": {
                 "kind": "NamedType",
@@ -790,7 +790,7 @@ exports[`on success > uses the mock fetch if given 1`] = `
       "__key": -2395444236,
       "definitions": [
         {
-          "directives": [],
+          "directives": undefined,
           "kind": "OperationDefinition",
           "name": {
             "kind": "Name",
@@ -818,7 +818,7 @@ exports[`on success > uses the mock fetch if given 1`] = `
                     },
                   },
                 ],
-                "directives": [],
+                "directives": undefined,
                 "kind": "Field",
                 "name": {
                   "kind": "Name",
@@ -829,8 +829,8 @@ exports[`on success > uses the mock fetch if given 1`] = `
                   "selections": [
                     {
                       "alias": undefined,
-                      "arguments": [],
-                      "directives": [],
+                      "arguments": undefined,
+                      "directives": undefined,
                       "kind": "Field",
                       "name": {
                         "kind": "Name",
@@ -840,8 +840,8 @@ exports[`on success > uses the mock fetch if given 1`] = `
                     },
                     {
                       "alias": undefined,
-                      "arguments": [],
-                      "directives": [],
+                      "arguments": undefined,
+                      "directives": undefined,
                       "kind": "Field",
                       "name": {
                         "kind": "Name",
@@ -851,8 +851,8 @@ exports[`on success > uses the mock fetch if given 1`] = `
                     },
                     {
                       "alias": undefined,
-                      "arguments": [],
-                      "directives": [],
+                      "arguments": undefined,
+                      "directives": undefined,
                       "kind": "Field",
                       "name": {
                         "kind": "Name",
@@ -868,7 +868,7 @@ exports[`on success > uses the mock fetch if given 1`] = `
           "variableDefinitions": [
             {
               "defaultValue": undefined,
-              "directives": [],
+              "directives": undefined,
               "kind": "VariableDefinition",
               "type": {
                 "kind": "NamedType",

--- a/packages/core/src/utils/formatDocument.test.ts
+++ b/packages/core/src/utils/formatDocument.test.ts
@@ -129,7 +129,7 @@ describe('formatDocument', () => {
       {
         test: {
           kind: Kind.DIRECTIVE,
-          arguments: [],
+          arguments: undefined,
           name: {
             kind: Kind.NAME,
             value: '_test',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,8 +26,8 @@ importers:
         version: 3.3.1
     devDependencies:
       '@0no-co/graphql.web':
-        specifier: ^1.0.1
-        version: 1.0.1(graphql@16.6.0)
+        specifier: ^1.0.5
+        version: 1.0.5(graphql@16.6.0)
       '@actions/artifact':
         specifier: ^1.1.1
         version: 1.1.1
@@ -221,8 +221,8 @@ importers:
   exchanges/graphcache:
     dependencies:
       '@0no-co/graphql.web':
-        specifier: ^1.0.1
-        version: 1.0.1(graphql@16.6.0)
+        specifier: ^1.0.5
+        version: 1.0.5(graphql@16.6.0)
       '@urql/core':
         specifier: '>=4.3.0'
         version: link:../../packages/core
@@ -326,8 +326,8 @@ importers:
   packages/core:
     dependencies:
       '@0no-co/graphql.web':
-        specifier: ^1.0.1
-        version: 1.0.1(graphql@16.6.0)
+        specifier: ^1.0.5
+        version: 1.0.5(graphql@16.6.0)
       wonka:
         specifier: ^6.3.2
         version: 6.3.2
@@ -591,8 +591,8 @@ importers:
 
 packages:
 
-  /@0no-co/graphql.web@1.0.1(graphql@16.6.0):
-    resolution: {integrity: sha512-6Yaxyv6rOwRkLIvFaL0NrLDgfNqC/Ng9QOPmTmlqW4mORXMEKmh5NYGkIvvt5Yw8fZesnMAqkj8cIqTj8f40cQ==}
+  /@0no-co/graphql.web@1.0.5(graphql@16.6.0):
+    resolution: {integrity: sha512-/ODdeNNFksS9hUvpjWFldMEpq0OqCFEIV3NVM0eU8HLUYU0Szf+2iKvr63kkbGchQwk2/1IxPF1PfoCabVkgLw==}
     peerDependencies:
       graphql: ^16.6.0
     peerDependenciesMeta:
@@ -661,7 +661,7 @@ packages:
       source-map: 0.5.7
     optionalDependencies:
       '@nicolo-ribaudo/chokidar-2': 2.1.8-no-fsevents
-      chokidar: 3.5.3
+      chokidar: 3.6.0
     transitivePeerDependencies:
       - supports-color
 
@@ -671,6 +671,13 @@ packages:
     dependencies:
       '@babel/highlight': 7.22.5
 
+  /@babel/code-frame@7.24.2:
+    resolution: {integrity: sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/highlight': 7.24.2
+      picocolors: 1.0.0
+
   /@babel/compat-data@7.21.5:
     resolution: {integrity: sha512-M+XAiQ7GzQ3FDPf0KOLkugzptnIypt0X0ma0wmlTKPR3IchgNFdx2JXxZdvd18JY5s7QkaFD/qyX0dsMpog/Ug==}
     engines: {node: '>=6.9.0'}
@@ -679,7 +686,7 @@ packages:
     resolution: {integrity: sha512-gTXYh3M5wb7FRXQy+FErKFAv90BnlOuNn1QkCK2lREoPAjrQCO49+HVSrFoe5uakFAF5eenS75KbO2vQiLrTMQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.22.5
+      '@babel/code-frame': 7.24.2
       '@babel/generator': 7.21.5
       '@babel/helper-module-transforms': 7.21.5
       '@babel/helpers': 7.21.5
@@ -905,6 +912,17 @@ packages:
     resolution: {integrity: sha512-5pTUx3hAJaZIdW99sJ6ZUUgWq/Y+Hja7TowEnLNMm1VivRgZQL3vpBY3qUACVsvw+yQU6+YgfBVmcbLaZtrA1w==}
     engines: {node: '>=6.9.0'}
 
+  /@babel/helper-string-parser@7.24.1:
+    resolution: {integrity: sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==}
+    engines: {node: '>=6.9.0'}
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@babel/helper-validator-identifier@7.22.20:
+    resolution: {integrity: sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==}
+    engines: {node: '>=6.9.0'}
+
   /@babel/helper-validator-identifier@7.22.5:
     resolution: {integrity: sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==}
     engines: {node: '>=6.9.0'}
@@ -941,12 +959,31 @@ packages:
       chalk: 2.4.2
       js-tokens: 4.0.0
 
+  /@babel/highlight@7.24.2:
+    resolution: {integrity: sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-validator-identifier': 7.22.20
+      chalk: 2.4.2
+      js-tokens: 4.0.0
+      picocolors: 1.0.0
+
   /@babel/parser@7.22.4:
     resolution: {integrity: sha512-VLLsx06XkEYqBtE5YGPwfSGwfrjnyPP5oiGty3S8pQLFDFLaS8VwWSIxkTXpcvr5zeYLE6+MBNl2npl/YnfofA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
       '@babel/types': 7.22.4
+
+  /@babel/parser@7.24.1:
+    resolution: {integrity: sha512-Zo9c7N3xdOIQrNip7Lc9wvRPzlRtovHVE4lkz8WEDr7uYh/GMQhSiIgFxGIArRHYdJE5kxtZjAf8rT0xhdLCzg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    requiresBuild: true
+    dependencies:
+      '@babel/types': 7.24.0
+    dev: true
+    optional: true
 
   /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.13.12(@babel/core@7.21.5):
     resolution: {integrity: sha512-d0u3zWKcoZf379fOeJdr1a5WPDny4aOFZ6hlfKivgK0LY7ZxNfoaHL2fWwdGtHyVvra38FC+HVYkO+byfSA8AQ==}
@@ -1407,7 +1444,7 @@ packages:
       '@babel/helper-hoist-variables': 7.18.6
       '@babel/helper-module-transforms': 7.21.5
       '@babel/helper-plugin-utils': 7.21.5
-      '@babel/helper-validator-identifier': 7.22.5
+      '@babel/helper-validator-identifier': 7.22.20
       babel-plugin-dynamic-import-node: 2.3.3
     transitivePeerDependencies:
       - supports-color
@@ -1786,6 +1823,17 @@ packages:
       '@babel/helper-string-parser': 7.21.5
       '@babel/helper-validator-identifier': 7.22.5
       to-fast-properties: 2.0.0
+
+  /@babel/types@7.24.0:
+    resolution: {integrity: sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==}
+    engines: {node: '>=6.9.0'}
+    requiresBuild: true
+    dependencies:
+      '@babel/helper-string-parser': 7.24.1
+      '@babel/helper-validator-identifier': 7.22.20
+      to-fast-properties: 2.0.0
+    dev: true
+    optional: true
 
   /@changesets/apply-release-plan@6.1.4:
     resolution: {integrity: sha512-FMpKF1fRlJyCZVYHr3CbinpZZ+6MwvOtWUuO8uo+svcATEoc1zRDcj23pAurJ2TZ/uVz1wFHH6K3NlACy0PLew==}
@@ -2830,7 +2878,7 @@ packages:
     resolution: {integrity: sha512-GObDVMaI4ARrZEXaRy4moolNAxWPKvEYNV/fa6Uc2eAzR/t4otS6A7EhrntPBIQLeehL9DbVhscvvv7gd6hWqA==}
     engines: {node: '>=10'}
     dependencies:
-      '@babel/code-frame': 7.22.5
+      '@babel/code-frame': 7.24.2
       '@babel/runtime': 7.22.5
       '@types/aria-query': 4.2.1
       aria-query: 4.2.2
@@ -3055,8 +3103,8 @@ packages:
       '@types/yargs-parser': 20.2.0
     dev: true
 
-  /@types/yauzl@2.10.0:
-    resolution: {integrity: sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==}
+  /@types/yauzl@2.10.3:
+    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
     requiresBuild: true
     dependencies:
       '@types/node': 18.16.3
@@ -3243,14 +3291,15 @@ packages:
       source-map: 0.6.1
     dev: true
 
-  /@vue/compiler-core@3.3.4:
-    resolution: {integrity: sha512-cquyDNvZ6jTbf/+x+AgM2Arrp6G4Dzbb0R64jiG804HRMfRiFXWI6kqUVqZ6ZR0bQhIoQjB4+2bhNtVwndW15g==}
+  /@vue/compiler-core@3.4.21:
+    resolution: {integrity: sha512-MjXawxZf2SbZszLPYxaFCjxfibYrzr3eYbKxwpLR9EQN+oaziSu3qKVbwBERj1IFIB8OLUewxB5m/BFzi613og==}
     requiresBuild: true
     dependencies:
-      '@babel/parser': 7.22.4
-      '@vue/shared': 3.3.4
+      '@babel/parser': 7.24.1
+      '@vue/shared': 3.4.21
+      entities: 4.5.0
       estree-walker: 2.0.2
-      source-map-js: 1.0.2
+      source-map-js: 1.2.0
     dev: true
     optional: true
 
@@ -3261,11 +3310,11 @@ packages:
       '@vue/shared': 3.2.47
     dev: true
 
-  /@vue/compiler-dom@3.3.4:
-    resolution: {integrity: sha512-wyM+OjOVpuUukIq6p5+nwHYtj9cFroz9cwkfmP9O1nzH68BenTTv0u7/ndggT8cIQlnBeOo6sUT/gvHcIkLA5w==}
+  /@vue/compiler-dom@3.4.21:
+    resolution: {integrity: sha512-IZC6FKowtT1sl0CR5DpXSiEB5ayw75oT2bma1BEhV7RRR1+cfwLrxc2Z8Zq/RGFzJ8w5r9QtCOvTjQgdn0IKmA==}
     dependencies:
-      '@vue/compiler-core': 3.3.4
-      '@vue/shared': 3.3.4
+      '@vue/compiler-core': 3.4.21
+      '@vue/shared': 3.4.21
     dev: true
     optional: true
 
@@ -3291,12 +3340,12 @@ packages:
       '@vue/shared': 3.2.47
     dev: true
 
-  /@vue/compiler-ssr@3.3.4:
-    resolution: {integrity: sha512-m0v6oKpup2nMSehwA6Uuu+j+wEwcy7QmwMkVNVfrV9P2qE5KshC6RwOCq8fjGS/Eak/uNb8AaWekfiXxbBB6gQ==}
+  /@vue/compiler-ssr@3.4.21:
+    resolution: {integrity: sha512-M5+9nI2lPpAsgXOGQobnIueVqc9sisBFexh5yMIMRAPYLa7+5wEJs8iqOZc1WAa9WQbx9GR2twgznU8LTIiZ4Q==}
     requiresBuild: true
     dependencies:
-      '@vue/compiler-dom': 3.3.4
-      '@vue/shared': 3.3.4
+      '@vue/compiler-dom': 3.4.21
+      '@vue/shared': 3.4.21
     dev: true
     optional: true
 
@@ -3341,13 +3390,13 @@ packages:
       vue: 3.2.47
     dev: true
 
-  /@vue/server-renderer@3.3.4(vue@3.2.47):
-    resolution: {integrity: sha512-Q6jDDzR23ViIb67v+vM1Dqntu+HUexQcsWKhhQa4ARVzxOY2HbC7QRW/ggkDBd5BU+uM1sV6XOAP0b216o34JQ==}
+  /@vue/server-renderer@3.4.21(vue@3.2.47):
+    resolution: {integrity: sha512-aV1gXyKSN6Rz+6kZ6kr5+Ll14YzmIbeuWe7ryJl5muJ4uwSwY/aStXTixx76TwkZFJLm1aAlA/HSWEJ4EyiMkg==}
     peerDependencies:
-      vue: 3.3.4
+      vue: 3.4.21
     dependencies:
-      '@vue/compiler-ssr': 3.3.4
-      '@vue/shared': 3.3.4
+      '@vue/compiler-ssr': 3.4.21
+      '@vue/shared': 3.4.21
       vue: 3.2.47
     dev: true
     optional: true
@@ -3356,8 +3405,8 @@ packages:
     resolution: {integrity: sha512-BHGyyGN3Q97EZx0taMQ+OLNuZcW3d37ZEVmEAyeoA9ERdGvm9Irc/0Fua8SNyOtV1w6BS4q25wbMzJujO9HIfQ==}
     dev: true
 
-  /@vue/shared@3.3.4:
-    resolution: {integrity: sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==}
+  /@vue/shared@3.4.21:
+    resolution: {integrity: sha512-PuJe7vDIi6VYSinuEbUIQgMIRZGgM8e4R+G+/dQTk0X1NEdvgvvgv7m+rfmDH1gZzyA1OjjoWskvHlfRNfQf3g==}
     requiresBuild: true
     dev: true
     optional: true
@@ -3370,8 +3419,8 @@ packages:
       js-beautify: 1.14.6
       vue: 3.2.47
     optionalDependencies:
-      '@vue/compiler-dom': 3.3.4
-      '@vue/server-renderer': 3.3.4(vue@3.2.47)
+      '@vue/compiler-dom': 3.4.21
+      '@vue/server-renderer': 3.4.21(vue@3.2.47)
     dev: true
 
   /@webassemblyjs/ast@1.9.0:
@@ -4744,7 +4793,23 @@ packages:
       normalize-path: 3.0.0
       readdirp: 3.6.0
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
+
+  /chokidar@3.6.0:
+    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
+    engines: {node: '>= 8.10.0'}
+    requiresBuild: true
+    dependencies:
+      anymatch: 3.1.2
+      braces: 3.0.2
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.3
+    optional: true
 
   /chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
@@ -6218,6 +6283,13 @@ packages:
     engines: {node: '>=0.12'}
     dev: true
 
+  /entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
@@ -6975,7 +7047,7 @@ packages:
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
-      '@types/yauzl': 2.10.0
+      '@types/yauzl': 2.10.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7392,8 +7464,8 @@ packages:
       nan: 2.14.2
     optional: true
 
-  /fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+  /fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
@@ -10733,7 +10805,7 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/code-frame': 7.22.5
+      '@babel/code-frame': 7.24.2
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -12442,7 +12514,7 @@ packages:
       rollup: 3.21.1
       typescript: 5.1.6
     optionalDependencies:
-      '@babel/code-frame': 7.22.5
+      '@babel/code-frame': 7.24.2
     dev: true
 
   /rollup-plugin-visualizer@5.9.0(rollup@3.21.1):
@@ -12467,7 +12539,7 @@ packages:
     engines: {node: '>=10.0.0'}
     hasBin: true
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /rollup@3.21.1:
@@ -12475,7 +12547,7 @@ packages:
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /rrweb-cssom@0.6.0:
@@ -13015,6 +13087,13 @@ packages:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
     engines: {node: '>=0.10.0'}
     dev: true
+
+  /source-map-js@1.2.0:
+    resolution: {integrity: sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==}
+    engines: {node: '>=0.10.0'}
+    requiresBuild: true
+    dev: true
+    optional: true
 
   /source-map-resolve@0.5.3:
     resolution: {integrity: sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==}
@@ -14532,7 +14611,7 @@ packages:
       rollup: 2.79.1
       terser: 5.17.1
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /vitest@0.30.1(jsdom@21.1.1)(terser@5.17.1):
@@ -14646,7 +14725,7 @@ packages:
       graceful-fs: 4.2.11
       neo-async: 2.6.2
     optionalDependencies:
-      chokidar: 3.5.3
+      chokidar: 3.6.0
       watchpack-chokidar2: 2.0.1
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
This won't need to be backported, but brings `main` to a new minimum requirement for the next major.

## Set of changes

- Upgrade `@0no-co/graphql.web` to 1.0.5
- Update tests
