### PR TITLE
fix(graphcache): ignore current entity during invalidateType

### DIFF
--- a/.changeset/rich-suns-sit.md
+++ b/.changeset/rich-suns-sit.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+When invoking the automatic creation updater ignore the entity we are currently on in the mutation

--- a/exchanges/graphcache/src/cacheExchange.test.ts
+++ b/exchanges/graphcache/src/cacheExchange.test.ts
@@ -1927,6 +1927,12 @@ describe('mutation updates', () => {
     vi.runAllTimers();
     expect(response).toHaveBeenCalledTimes(3);
     expect(result).toHaveBeenCalledTimes(3);
+    expect(result.mock.calls[1][0].data).toEqual({
+      addAuthor: {
+        id: '2',
+        name: 'Author 2',
+      },
+    });
   });
 });
 

--- a/exchanges/graphcache/src/operations/invalidate.ts
+++ b/exchanges/graphcache/src/operations/invalidate.ts
@@ -25,9 +25,10 @@ export const invalidateEntity = (
   }
 };
 
-export const invalidateType = (typename: string) => {
+export const invalidateType = (typename: string, excludedEntity: string) => {
   const types = InMemoryData.getEntitiesForType(typename);
   for (const entity of types) {
+    if (entity === excludedEntity) continue;
     invalidateEntity(entity);
   }
 };

--- a/exchanges/graphcache/src/operations/invalidate.ts
+++ b/exchanges/graphcache/src/operations/invalidate.ts
@@ -25,10 +25,13 @@ export const invalidateEntity = (
   }
 };
 
-export const invalidateType = (typename: string, excludedEntity: string) => {
+export const invalidateType = (
+  typename: string,
+  excludedEntities: string[]
+) => {
   const types = InMemoryData.getEntitiesForType(typename);
   for (const entity of types) {
-    if (entity === excludedEntity) continue;
+    if (excludedEntities.includes(entity)) continue;
     invalidateEntity(entity);
   }
 };

--- a/exchanges/graphcache/src/operations/write.ts
+++ b/exchanges/graphcache/src/operations/write.ts
@@ -389,7 +389,7 @@ const writeSelection = (
             const resolved = InMemoryData.readRecord(key, '__typename');
             const count = InMemoryData!.getRefCount(key);
             if (resolved && !count) {
-              invalidateType(fieldValue[i].__typename);
+              invalidateType(fieldValue[i].__typename, key);
             }
           }
         }
@@ -399,7 +399,7 @@ const writeSelection = (
           const resolved = InMemoryData.readRecord(key, '__typename');
           const count = InMemoryData.getRefCount(key);
           if ((!resolved || !count) && fieldValue.__typename) {
-            invalidateType(fieldValue.__typename);
+            invalidateType(fieldValue.__typename, key);
           }
         }
       }

--- a/exchanges/graphcache/src/operations/write.ts
+++ b/exchanges/graphcache/src/operations/write.ts
@@ -383,13 +383,16 @@ const writeSelection = (
       // if we don't we'll assume this is a create mutation and invalidate
       // the found __typename.
       if (fieldValue && Array.isArray(fieldValue)) {
+        const excludedEntities: string[] = fieldValue.map(
+          entity => ctx.store.keyOfEntity(entity) || ''
+        );
         for (let i = 0, l = fieldValue.length; i < l; i++) {
-          const key = ctx.store.keyOfEntity(fieldValue[i]);
+          const key = excludedEntities[i];
           if (key && fieldValue[i].__typename) {
             const resolved = InMemoryData.readRecord(key, '__typename');
             const count = InMemoryData!.getRefCount(key);
             if (resolved && !count) {
-              invalidateType(fieldValue[i].__typename, key);
+              invalidateType(fieldValue[i].__typename, excludedEntities);
             }
           }
         }
@@ -399,7 +402,7 @@ const writeSelection = (
           const resolved = InMemoryData.readRecord(key, '__typename');
           const count = InMemoryData.getRefCount(key);
           if ((!resolved || !count) && fieldValue.__typename) {
-            invalidateType(fieldValue.__typename, key);
+            invalidateType(fieldValue.__typename, [key]);
           }
         }
       }

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -174,7 +174,7 @@ export class Store<
       !this.resolve(entity, '__typename');
 
     if (shouldInvalidateType) {
-      invalidateType(entity);
+      invalidateType(entity, []);
     } else {
       invariant(
         entityKey,


### PR DESCRIPTION
## Summary

After a conversation in Discord we discovered that an old "bug" is biting us with the new default functionality. The old bug goes as follows: when we invalidate in a mutation-updater and the invalidated entity belongs to the mutation response we effectively make the mutation response go to null due to us re-querying the data after our write, the re-querying happens so we respect `resolvers` for our mutation data.

This is an ad-hoc fix to reduce the impact of this change, we effectively exclude the entities we find in the mutation response so we can return a good response. In the future we might be able to establish a similar principle for custom invalidations/updates as well.
