### PR TITLE
feat(graphcache): only add dependency if we are changing the value

### DIFF
--- a/.changeset/nine-walls-behave.md
+++ b/.changeset/nine-walls-behave.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Only record dependencies that are changing data, this will reduce the amount of operations we re-invoke due to network-only/cache-and-network queries and mutations

--- a/exchanges/graphcache/src/cacheExchange.test.ts
+++ b/exchanges/graphcache/src/cacheExchange.test.ts
@@ -480,7 +480,7 @@ describe('data dependencies', () => {
     );
   });
 
-  it.only('does not notify related queries when a mutation update does not change the data', () => {
+  it('does not notify related queries when a mutation update does not change the data', () => {
     vi.useFakeTimers();
 
     const balanceFragment = gql`
@@ -639,12 +639,6 @@ describe('data dependencies', () => {
     expect(updates.Mutation.updateBalance).toHaveBeenCalledTimes(1);
 
     expect(reexec).toHaveBeenCalledTimes(0);
-    expect(reexec.mock.calls[0][0].key).toBe(1);
-
-    expect(result.mock.calls[2][0]).toHaveProperty(
-      'data.author.balance.amount',
-      100
-    );
   });
 
   it('does nothing when no related queries have changed', () => {
@@ -1613,14 +1607,15 @@ describe('optimistic updates', () => {
     vi.advanceTimersByTime(1);
     next(opMutationTwo);
 
+    // TODO: verify why this changed
     expect(response).toHaveBeenCalledTimes(1);
     expect(optimistic.concealAuthor).toHaveBeenCalledTimes(2);
-    expect(reexec).toHaveBeenCalledTimes(2);
+    expect(reexec).toHaveBeenCalledTimes(1);
     expect(result).toHaveBeenCalledTimes(0);
 
     vi.advanceTimersByTime(2);
     expect(response).toHaveBeenCalledTimes(2);
-    expect(result).toHaveBeenCalledTimes(0);
+    expect(result).toHaveBeenCalledTimes(1);
 
     vi.runAllTimers();
     expect(response).toHaveBeenCalledTimes(3);

--- a/exchanges/graphcache/src/cacheExchange.test.ts
+++ b/exchanges/graphcache/src/cacheExchange.test.ts
@@ -480,6 +480,173 @@ describe('data dependencies', () => {
     );
   });
 
+  it.only('does not notify related queries when a mutation update does not change the data', () => {
+    vi.useFakeTimers();
+
+    const balanceFragment = gql`
+      fragment BalanceFragment on Author {
+        id
+        balance {
+          amount
+        }
+      }
+    `;
+
+    const queryById = gql`
+      query ($id: ID!) {
+        author(id: $id) {
+          id
+          name
+          ...BalanceFragment
+        }
+      }
+
+      ${balanceFragment}
+    `;
+
+    const queryByIdDataA = {
+      __typename: 'Query',
+      author: {
+        __typename: 'Author',
+        id: '1',
+        name: 'Author 1',
+        balance: {
+          __typename: 'Balance',
+          amount: 100,
+        },
+      },
+    };
+
+    const queryByIdDataB = {
+      __typename: 'Query',
+      author: {
+        __typename: 'Author',
+        id: '2',
+        name: 'Author 2',
+        balance: {
+          __typename: 'Balance',
+          amount: 200,
+        },
+      },
+    };
+
+    const mutation = gql`
+      mutation ($userId: ID!, $amount: Int!) {
+        updateBalance(userId: $userId, amount: $amount) {
+          userId
+          balance {
+            amount
+          }
+        }
+      }
+    `;
+
+    const mutationData = {
+      __typename: 'Mutation',
+      updateBalance: {
+        __typename: 'UpdateBalanceResult',
+        userId: '1',
+        balance: {
+          __typename: 'Balance',
+          amount: 100,
+        },
+      },
+    };
+
+    const client = createClient({
+      url: 'http://0.0.0.0',
+      exchanges: [],
+    });
+    const { source: ops$, next } = makeSubject<Operation>();
+
+    const reexec = vi
+      .spyOn(client, 'reexecuteOperation')
+      .mockImplementation(next);
+
+    const opOne = client.createRequestOperation('query', {
+      key: 1,
+      query: queryById,
+      variables: { id: 1 },
+    });
+
+    const opTwo = client.createRequestOperation('query', {
+      key: 2,
+      query: queryById,
+      variables: { id: 2 },
+    });
+
+    const opMutation = client.createRequestOperation('mutation', {
+      key: 3,
+      query: mutation,
+      variables: { userId: '1', amount: 1000 },
+    });
+
+    const response = vi.fn((forwardOp: Operation): OperationResult => {
+      if (forwardOp.key === 1) {
+        return { ...queryResponse, operation: opOne, data: queryByIdDataA };
+      } else if (forwardOp.key === 2) {
+        return { ...queryResponse, operation: opTwo, data: queryByIdDataB };
+      } else if (forwardOp.key === 3) {
+        return {
+          ...queryResponse,
+          operation: opMutation,
+          data: mutationData,
+        };
+      }
+
+      return undefined as any;
+    });
+
+    const result = vi.fn();
+    const forward: ExchangeIO = ops$ =>
+      pipe(ops$, delay(1), map(response), share);
+
+    const updates = {
+      Mutation: {
+        updateBalance: vi.fn((result, _args, cache) => {
+          const {
+            updateBalance: { userId, balance },
+          } = result;
+          cache.writeFragment(balanceFragment, { id: userId, balance });
+        }),
+      },
+    };
+
+    const keys = {
+      Balance: () => null,
+    };
+
+    pipe(
+      cacheExchange({ updates, keys })({ forward, client, dispatchDebug })(
+        ops$
+      ),
+      tap(result),
+      publish
+    );
+
+    next(opTwo);
+    vi.runAllTimers();
+    expect(response).toHaveBeenCalledTimes(1);
+
+    next(opOne);
+    vi.runAllTimers();
+    expect(response).toHaveBeenCalledTimes(2);
+
+    next(opMutation);
+    vi.runAllTimers();
+
+    expect(response).toHaveBeenCalledTimes(3);
+    expect(updates.Mutation.updateBalance).toHaveBeenCalledTimes(1);
+
+    expect(reexec).toHaveBeenCalledTimes(0);
+    expect(reexec.mock.calls[0][0].key).toBe(1);
+
+    expect(result.mock.calls[2][0]).toHaveProperty(
+      'data.author.balance.amount',
+      100
+    );
+  });
+
   it('does nothing when no related queries have changed', () => {
     const queryUnrelated = gql`
       {

--- a/exchanges/graphcache/src/cacheExchange.test.ts
+++ b/exchanges/graphcache/src/cacheExchange.test.ts
@@ -1607,7 +1607,6 @@ describe('optimistic updates', () => {
     vi.advanceTimersByTime(1);
     next(opMutationTwo);
 
-    // TODO: verify why this changed
     expect(response).toHaveBeenCalledTimes(1);
     expect(optimistic.concealAuthor).toHaveBeenCalledTimes(2);
     expect(reexec).toHaveBeenCalledTimes(1);
@@ -1615,10 +1614,12 @@ describe('optimistic updates', () => {
 
     vi.advanceTimersByTime(2);
     expect(response).toHaveBeenCalledTimes(2);
+    expect(reexec).toHaveBeenCalledTimes(2);
     expect(result).toHaveBeenCalledTimes(1);
 
     vi.runAllTimers();
     expect(response).toHaveBeenCalledTimes(3);
+    expect(reexec).toHaveBeenCalledTimes(2);
     expect(result).toHaveBeenCalledTimes(2);
   });
 

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -273,7 +273,6 @@ export const cacheExchange =
           data,
           result.error
         ).dependencies;
-        console.log(writeDependencies)
         clearDataState();
         collectPendingOperations(pendingOperations, writeDependencies);
         const prevData =

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -273,6 +273,7 @@ export const cacheExchange =
           data,
           result.error
         ).dependencies;
+        console.log(writeDependencies)
         clearDataState();
         collectPendingOperations(pendingOperations, writeDependencies);
         const prevData =

--- a/exchanges/graphcache/src/operations/write.ts
+++ b/exchanges/graphcache/src/operations/write.ts
@@ -347,6 +347,7 @@ const writeSelection = (
           entityKey || typename,
           fieldKey
         );
+        console.log('[LINK]', existingLink, link, isEqualLinkOrScalar(existingLink, link))
         if (!isEqualLinkOrScalar(existingLink, link)) {
           InMemoryData.writeLink(entityKey || typename, fieldKey, link);
         }
@@ -361,6 +362,7 @@ const writeSelection = (
       const value = (
         fieldValue !== null || !getFieldError(ctx) ? fieldValue : undefined
       ) as EntityField;
+      console.log('[SCALAR]', existingRecord, value, isEqualLinkOrScalar(existingRecord, value))
       if (!isEqualLinkOrScalar(existingRecord, value)) {
         // This is a leaf node, so we're setting the field's value directly
         InMemoryData.writeRecord(entityKey || typename, fieldKey, value);
@@ -427,7 +429,7 @@ function isEqualLinkOrScalar(
   if (a !== b) return false;
   if (Array.isArray(a) && Array.isArray(b)) {
     if (a.length !== b.length) return false;
-    return a.every((el, index) => el === b[index]);
+    return !a.some((el, index) => el !== b[index]);
   }
 
   return true;

--- a/exchanges/graphcache/src/operations/write.ts
+++ b/exchanges/graphcache/src/operations/write.ts
@@ -232,8 +232,11 @@ const writeSelection = (
     );
     return;
   } else if (!isRoot && entityKey) {
-    InMemoryData.writeRecord(entityKey, '__typename', typename);
-    InMemoryData.writeType(typename, entityKey);
+    const existingTypename = InMemoryData.readRecord(entityKey, '__typename');
+    if (existingTypename !== typename) {
+      InMemoryData.writeRecord(entityKey, '__typename', typename);
+      InMemoryData.writeType(typename, entityKey);
+    }
   }
 
   const updates = ctx.store.updates[typename];
@@ -347,7 +350,6 @@ const writeSelection = (
           entityKey || typename,
           fieldKey
         );
-        console.log('[LINK]', existingLink, link, isEqualLinkOrScalar(existingLink, link))
         if (!isEqualLinkOrScalar(existingLink, link)) {
           InMemoryData.writeLink(entityKey || typename, fieldKey, link);
         }
@@ -362,7 +364,6 @@ const writeSelection = (
       const value = (
         fieldValue !== null || !getFieldError(ctx) ? fieldValue : undefined
       ) as EntityField;
-      console.log('[SCALAR]', existingRecord, value, isEqualLinkOrScalar(existingRecord, value))
       if (!isEqualLinkOrScalar(existingRecord, value)) {
         // This is a leaf node, so we're setting the field's value directly
         InMemoryData.writeRecord(entityKey || typename, fieldKey, value);

--- a/exchanges/graphcache/src/store/data.test.ts
+++ b/exchanges/graphcache/src/store/data.test.ts
@@ -98,6 +98,8 @@ describe('garbage collection', () => {
     InMemoryData.gc();
 
     expect(InMemoryData.readRecord('Todo:1', 'id')).toBe('1');
+    // TODO: is it a problem that this fails, we are reading from Todo
+    // but we are not updating anything
     expect(InMemoryData.getCurrentDependencies()).toEqual(
       new Set(['Query.todo', 'Todo:1'])
     );

--- a/exchanges/graphcache/src/store/data.test.ts
+++ b/exchanges/graphcache/src/store/data.test.ts
@@ -101,7 +101,7 @@ describe('garbage collection', () => {
     // TODO: is it a problem that this fails, we are reading from Todo
     // but we are not updating anything
     expect(InMemoryData.getCurrentDependencies()).toEqual(
-      new Set(['Query.todo', 'Todo:1'])
+      new Set(['Query.todo'])
     );
   });
 

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -633,8 +633,9 @@ const squashLayer = (layerKey: number) => {
     for (const entry of links.entries()) {
       const entityKey = entry[0];
       const keyMap = entry[1];
-      for (const fieldKey in keyMap)
+      for (const fieldKey in keyMap) {
         writeLink(entityKey, fieldKey, keyMap[fieldKey]);
+      }
     }
   }
 
@@ -643,8 +644,9 @@ const squashLayer = (layerKey: number) => {
     for (const entry of records.entries()) {
       const entityKey = entry[0];
       const keyMap = entry[1];
-      for (const fieldKey in keyMap)
+      for (const fieldKey in keyMap) {
         writeRecord(entityKey, fieldKey, keyMap[fieldKey]);
+      }
     }
   }
 

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -458,7 +458,9 @@ export const readRecord = (
   entityKey: string,
   fieldKey: string
 ): EntityField => {
-  updateDependencies(entityKey, fieldKey);
+  if (currentOperation === 'read') {
+    updateDependencies(entityKey, fieldKey);
+  }
   return getNode(currentData!.records, entityKey, fieldKey);
 };
 
@@ -467,7 +469,9 @@ export const readLink = (
   entityKey: string,
   fieldKey: string
 ): Link | undefined => {
-  updateDependencies(entityKey, fieldKey);
+  if (currentOperation === 'read') {
+    updateDependencies(entityKey, fieldKey);
+  }
   return getNode(currentData!.links, entityKey, fieldKey);
 };
 


### PR DESCRIPTION
## Summary

This is kind of an optimisation, say we have three operations that are all watching different fields of `Todo`, only one of these operations watches `Todo.completed`. When a mutation changes `Todo.completed` we should only invoke that one operation, this is slightly more performant. Not sure if worth it but it could also enable us to create a granular re-rendering mechanism with a first-class `fragment` citizen.
