### PR TITLE
feat(react): useFragment hook (BETA)

### DIFF
--- a/.changeset/olive-shrimps-leave.md
+++ b/.changeset/olive-shrimps-leave.md
@@ -1,0 +1,5 @@
+---
+'urql': minor
+---
+
+Add BETA `useFragment` hook, this hook will be able to `suspend` or indicate loading states when the data inside of said fragment is deferred.

--- a/examples/with-defer-stream-directives/src/App.jsx
+++ b/examples/with-defer-stream-directives/src/App.jsx
@@ -21,7 +21,9 @@ const client = new Client({
 function App() {
   return (
     <Provider value={client}>
-      <Songs />
+      <React.Suspense fallback={<p>Loading...</p>}>
+        <Songs />
+      </React.Suspense>
     </Provider>
   );
 }

--- a/examples/with-defer-stream-directives/src/App.jsx
+++ b/examples/with-defer-stream-directives/src/App.jsx
@@ -13,6 +13,7 @@ const cache = cacheExchange({
 });
 
 const client = new Client({
+  suspense: true,
   url: 'http://localhost:3004/graphql',
   exchanges: [cache, fetchExchange],
 });

--- a/examples/with-defer-stream-directives/src/Songs.jsx
+++ b/examples/with-defer-stream-directives/src/Songs.jsx
@@ -31,7 +31,6 @@ const Song = React.memo(function Song({ song }) {
 });
 
 const DeferredSong = ({ data }) => {
-  console.log(data, SecondVerseFragment)
   const result = useFragment({
     query: SecondVerseFragment,
     data,

--- a/examples/with-defer-stream-directives/src/Songs.jsx
+++ b/examples/with-defer-stream-directives/src/Songs.jsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { gql, useQuery } from 'urql';
+import React, { Suspense } from 'react';
+import { gql, useQuery, useFragment } from 'urql';
 
 const SecondVerseFragment = gql`
   fragment secondVerseFields on Song {
@@ -13,9 +13,6 @@ const SONGS_QUERY = gql`
       firstVerse
       ...secondVerseFields @defer
     }
-    alphabet @stream(initialCount: 3) {
-      char
-    }
   }
 
   ${SecondVerseFragment}
@@ -25,10 +22,22 @@ const Song = React.memo(function Song({ song }) {
   return (
     <section>
       <p>{song.firstVerse}</p>
+      <Suspense fallback={'Loading song 2...'}>
+        <DeferredSong data={song} />
+      </Suspense>
       <p>{song.secondVerse}</p>
     </section>
   );
 });
+
+const DeferredSong = ({ data }) => {
+  console.log(data, SecondVerseFragment)
+  const result = useFragment({
+    query: SecondVerseFragment,
+    data,
+  });
+  return <p>{result.secondVerse}</p>;
+};
 
 const LocationsList = () => {
   const [result] = useQuery({
@@ -42,9 +51,6 @@ const LocationsList = () => {
       {data && (
         <>
           <Song song={data.song} />
-          {data.alphabet.map(i => (
-            <div key={i.char}>{i.char}</div>
-          ))}
         </>
       )}
     </div>

--- a/examples/with-defer-stream-directives/src/Songs.jsx
+++ b/examples/with-defer-stream-directives/src/Songs.jsx
@@ -13,6 +13,9 @@ const SONGS_QUERY = gql`
       firstVerse
       ...secondVerseFields @defer
     }
+    alphabet @stream(initialCount: 3) {
+      char
+    }
   }
 
   ${SecondVerseFragment}
@@ -50,6 +53,9 @@ const LocationsList = () => {
       {data && (
         <>
           <Song song={data.song} />
+          {data.alphabet.map(i => (
+            <div key={i.char}>{i.char}</div>
+          ))}
         </>
       )}
     </div>

--- a/packages/react-urql/src/hooks/cache.ts
+++ b/packages/react-urql/src/hooks/cache.ts
@@ -1,7 +1,15 @@
 import { pipe, subscribe } from 'wonka';
 import type { Client, OperationResult } from '@urql/core';
 
-type CacheEntry = OperationResult | Promise<unknown> | undefined;
+export type FragmentPromise = Promise<unknown> & {
+  _resolve: () => void;
+  _resolved: boolean;
+};
+type CacheEntry =
+  | OperationResult
+  | Promise<unknown>
+  | FragmentPromise
+  | undefined;
 
 interface Cache {
   get(key: number): CacheEntry;

--- a/packages/react-urql/src/hooks/cache.ts
+++ b/packages/react-urql/src/hooks/cache.ts
@@ -3,12 +3,11 @@ import type { Client, OperationResult } from '@urql/core';
 
 export type FragmentPromise = Promise<unknown> & {
   _resolve: () => void;
-  _resolved: boolean;
 };
 
 type CacheEntry = OperationResult | Promise<unknown> | undefined;
 
-type FragmentCacheEntry = Promise<unknown> | undefined;
+type FragmentCacheEntry = FragmentPromise | undefined;
 
 interface Cache<Entry> {
   get(key: number): Entry;

--- a/packages/react-urql/src/hooks/index.ts
+++ b/packages/react-urql/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from './useMutation';
 export * from './useQuery';
+export * from './useFragment';
 export * from './useSubscription';

--- a/packages/react-urql/src/hooks/useFragment.test.ts
+++ b/packages/react-urql/src/hooks/useFragment.test.ts
@@ -53,6 +53,33 @@ describe('useFragment', () => {
     });
   });
 
+  it('should correctly take a different fragment to mask data', () => {
+    const { result } = renderHook(
+      () =>
+        useFragment({
+          query: `fragment x on X { foo bar } fragment TodoFields on Todo { id name __typename }`,
+          name: 'TodoFields',
+          data: {
+            __typename: 'Todo',
+            id: '1',
+            name: 'Learn urql',
+            completed: true,
+          },
+        }),
+      { initialProps: { query: mockQuery } }
+    );
+
+    const state = result.current;
+    expect(state).toEqual({
+      fetching: false,
+      data: {
+        __typename: 'Todo',
+        id: '1',
+        name: 'Learn urql',
+      },
+    });
+  });
+
   it('should correctly mask data w/ null attribute', () => {
     const { result } = renderHook(
       ({ query }) =>

--- a/packages/react-urql/src/hooks/useFragment.test.ts
+++ b/packages/react-urql/src/hooks/useFragment.test.ts
@@ -1,0 +1,303 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { vi, expect, it, describe, beforeAll } from 'vitest';
+
+import { useFragment } from './useFragment';
+
+vi.mock('../context', () => {
+  const mock = {};
+
+  return {
+    useClient: () => mock,
+  };
+});
+
+const mockQuery = `
+  fragment TodoFields on Todo {
+    id
+    name
+    __typename
+  }
+`;
+
+describe('useFragment', () => {
+  beforeAll(() => {
+    // TODO: Fix use of act()
+    vi.spyOn(global.console, 'error').mockImplementation(() => {
+      // do nothing
+    });
+  });
+
+  it('should correctly mask data', () => {
+    const { result } = renderHook(
+      ({ query }) =>
+        useFragment({
+          query,
+          data: {
+            __typename: 'Todo',
+            id: '1',
+            name: 'Learn urql',
+            completed: true,
+          },
+        }),
+      { initialProps: { query: mockQuery } }
+    );
+
+    const state = result.current;
+    expect(state).toEqual({
+      fetching: false,
+      data: {
+        __typename: 'Todo',
+        id: '1',
+        name: 'Learn urql',
+      },
+    });
+  });
+
+  it('should correctly mask data w/ null attribute', () => {
+    const { result } = renderHook(
+      ({ query }) =>
+        useFragment({
+          query,
+          data: { __typename: 'Todo', id: '1', name: null, completed: true },
+        }),
+      { initialProps: { query: mockQuery } }
+    );
+
+    const state = result.current;
+    expect(state).toEqual({
+      fetching: false,
+      data: {
+        __typename: 'Todo',
+        id: '1',
+        name: null,
+      },
+    });
+  });
+
+  it('should correctly indicate loading w/ undefined attribute', () => {
+    const { result } = renderHook(
+      ({ query }) =>
+        useFragment({
+          query,
+          data: {
+            __typename: 'Todo',
+            id: '1',
+            name: undefined,
+            completed: true,
+          },
+        }),
+      { initialProps: { query: mockQuery } }
+    );
+
+    const state = result.current;
+    expect(state).toEqual({
+      fetching: true,
+      data: {
+        __typename: 'Todo',
+        id: '1',
+      },
+    });
+  });
+
+  it('should correctly mask data w/ nested object', () => {
+    const { result } = renderHook(
+      ({ query }) =>
+        useFragment({
+          query,
+          data: {
+            __typename: 'Todo',
+            id: '1',
+            name: null,
+            completed: true,
+            author: {
+              id: '1',
+              name: 'Jovi',
+              __typename: 'Author',
+              awardWinner: true,
+            },
+          },
+        }),
+      {
+        initialProps: {
+          query: `
+        fragment TodoFields on Todo {
+          id
+          name
+          __typename
+          author { id name __typename }
+        }`,
+        },
+      }
+    );
+
+    const state = result.current;
+    expect(state).toEqual({
+      fetching: false,
+      data: {
+        __typename: 'Todo',
+        id: '1',
+        name: null,
+        author: {
+          __typename: 'Author',
+          id: '1',
+          name: 'Jovi',
+        },
+      },
+    });
+  });
+
+  it('should correctly mask data w/ nested selection that is null', () => {
+    const { result } = renderHook(
+      ({ query }) =>
+        useFragment({
+          query,
+          data: {
+            __typename: 'Todo',
+            id: '1',
+            name: null,
+            completed: true,
+            author: null,
+          },
+        }),
+      {
+        initialProps: {
+          query: `
+        fragment TodoFields on Todo {
+          id
+          name
+          __typename
+          author { id name __typename }
+        }`,
+        },
+      }
+    );
+
+    const state = result.current;
+    expect(state).toEqual({
+      fetching: false,
+      data: {
+        __typename: 'Todo',
+        id: '1',
+        name: null,
+        author: null,
+      },
+    });
+  });
+
+  it('should correctly mark loading w/ nested selection that is undefined', () => {
+    const { result } = renderHook(
+      ({ query }) =>
+        useFragment({
+          query,
+          data: {
+            __typename: 'Todo',
+            id: '1',
+            name: null,
+            completed: true,
+            author: undefined,
+          },
+        }),
+      {
+        initialProps: {
+          query: `
+        fragment TodoFields on Todo {
+          id
+          name
+          __typename
+          author { id name __typename }
+        }`,
+        },
+      }
+    );
+
+    const state = result.current;
+    expect(state).toEqual({
+      fetching: true,
+      data: {
+        __typename: 'Todo',
+        id: '1',
+        name: null,
+      },
+    });
+  });
+
+  it('should correctly mark resolved w/ deferred nested fragment-selection that is undefined', () => {
+    const { result } = renderHook(
+      ({ query }) =>
+        useFragment({
+          query,
+          data: {
+            __typename: 'Todo',
+            id: '1',
+            name: null,
+            completed: true,
+            author: undefined,
+          },
+        }),
+      {
+        initialProps: {
+          query: `
+        fragment TodoFields on Todo {
+          id
+          name
+          __typename
+          ...AuthorFields @defer
+        }
+
+        fragment AuthorFields on Todo { author { id name __typename } }
+        `,
+        },
+      }
+    );
+
+    const state = result.current;
+    expect(state).toEqual({
+      fetching: false,
+      data: {
+        __typename: 'Todo',
+        id: '1',
+        name: null,
+      },
+    });
+  });
+
+  it('should correctly mark resolved w/ nested fragment-selection that is undefined', () => {
+    const { result } = renderHook(
+      ({ query }) =>
+        useFragment({
+          query,
+          data: {
+            __typename: 'Todo',
+            id: '1',
+            name: null,
+            completed: true,
+            author: undefined,
+          },
+        }),
+      {
+        initialProps: {
+          query: `
+        fragment TodoFields on Todo {
+          id
+          name
+          __typename
+          ...AuthorFields
+        }
+
+        fragment AuthorFields on Todo { author { id name __typename }  }
+        `,
+        },
+      }
+    );
+
+    const state = result.current;
+    expect(state).toEqual({
+      fetching: true,
+      data: {
+        __typename: 'Todo',
+        id: '1',
+        name: null,
+      },
+    });
+  });
+});

--- a/packages/react-urql/src/hooks/useFragment.ts
+++ b/packages/react-urql/src/hooks/useFragment.ts
@@ -240,6 +240,21 @@ const maskFragment = <Data extends Record<string, any>>(
         }
       }
       maskedData[selection.name.value] = data[selection.name.value];
+    } else if (selection.kind === Kind.INLINE_FRAGMENT) {
+      if (
+        selection.typeCondition &&
+        selection.typeCondition.name.value !== data.__typename
+      ) {
+        return;
+      }
+
+      const result = maskFragment(data, selection.selectionSet);
+      if (!result.fulfilled) {
+        isDataComplete = false;
+      }
+      Object.assign(maskedData, result.data);
+    } else if (selection.kind === Kind.FRAGMENT_SPREAD) {
+      // TODO: do we want to support this?
     }
   });
 

--- a/packages/react-urql/src/hooks/useFragment.ts
+++ b/packages/react-urql/src/hooks/useFragment.ts
@@ -1,0 +1,237 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+
+import * as React from 'react';
+
+import type {
+  GraphQLRequestParams,
+  AnyVariables,
+  Client,
+  DocumentInput,
+  OperationContext,
+  RequestPolicy,
+  OperationResult,
+  Operation,
+  GraphQLRequest,
+} from '@urql/core';
+
+import { useClient } from '../context';
+import { useRequest } from './useRequest';
+import { getCacheForClient } from './cache';
+
+import {
+  deferDispatch,
+  initialState,
+  computeNextState,
+  hasDepsChanged,
+} from './state';
+import { FragmentDefinitionNode, Kind, SelectionSetNode } from 'graphql';
+
+/** Input arguments for the {@link useQuery} hook.
+ *
+ * @param query - The GraphQL query that `useQuery` executes.
+ */
+export type UseQueryArgs<Data = any> = {
+  context: Partial<OperationContext>;
+  query: GraphQLRequestParams<Data, AnyVariables>['query'];
+  data: Data;
+  name?: string;
+};
+
+/** State of the current query, your {@link useQuery} hook is executing.
+ *
+ * @remarks
+ * `UseQueryState` is returned (in a tuple) by {@link useQuery} and
+ * gives you the updating {@link OperationResult} of GraphQL queries.
+ *
+ * Even when the query and variables passed to {@link useQuery} change,
+ * this state preserves the prior state and sets the `fetching` flag to
+ * `true`.
+ * This allows you to display the previous state, while implementing
+ * a separate loading indicator separately.
+ */
+export interface UseFragmentState<Data = any> {
+  /** Indicates whether `useQuery` is waiting for a new result.
+   *
+   * @remarks
+   * When `useQuery` is passed a new query and/or variables, it will
+   * start executing the new query operation and `fetching` is set to
+   * `true` until a result arrives.
+   *
+   * Hint: This is subtly different than whether the query is actually
+   * fetching, and doesn’t indicate whether a query is being re-executed
+   * in the background. For this, see {@link UseQueryState.stale}.
+   */
+  fetching: boolean;
+  /** The {@link OperationResult.data} for the executed query. */
+  data?: Data;
+}
+
+/** Result tuple returned by the {@link useQuery} hook.
+ *
+ * @remarks
+ * Similarly to a `useState` hook’s return value,
+ * the first element is the {@link useQuery}’s result and state,
+ * a {@link UseQueryState} object,
+ * and the second is used to imperatively re-execute the query
+ * via a {@link UseQueryExecute} function.
+ */
+export type UseQueryResponse<Data = any> = UseFragmentState<Data>;
+
+const isSuspense = (client: Client, context?: Partial<OperationContext>) =>
+  context && context.suspense !== undefined
+    ? !!context.suspense
+    : client.suspense;
+
+/** Hook to mask a GraphQL Fragment given its data.
+ *
+ * @param args - a {@link UseQueryArgs} object, to pass a `fragment` and `data`.
+ * @returns a {@link UseQueryResponse} tuple of a {@link UseQueryState} result, and re-execute function.
+ *
+ * @remarks
+ * `useQuery` allows GraphQL queries to be defined and executed.
+ * Given {@link UseQueryArgs.query}, it executes the GraphQL query with the
+ * context’s {@link Client}.
+ *
+ * The returned result updates when the `Client` has new results
+ * for the query, and changes when your input `args` change.
+ *
+ * Additionally, if the `suspense` option is enabled on the `Client`,
+ * the `useQuery` hook will suspend instead of indicating that it’s
+ * waiting for a result via {@link UseQueryState.fetching}.
+ *
+ * @see {@link https://urql.dev/goto/urql/docs/basics/react-preact/#queries} for `useQuery` docs.
+ *
+ * @example
+ * ```ts
+ * import { gql, useQuery } from 'urql';
+ *
+ * const TodosQuery = gql`
+ *   query { todos { id, title } }
+ * `;
+ *
+ * const Todos = () => {
+ *   const [result, reexecuteQuery] = useQuery({
+ *     query: TodosQuery,
+ *     variables: {},
+ *   });
+ *   // ...
+ * };
+ * ```
+ */
+export function useFragment<Data = any>(
+  args: UseQueryArgs<Data>
+): UseQueryResponse<Data> {
+  const { query, data } = args;
+  const client = useClient();
+  const cache = getCacheForClient(client);
+  const suspense = isSuspense(client, args.context);
+  const request = useRequest(query, {});
+
+  const getSnapshot = React.useCallback(
+    (
+      request: GraphQLRequest<Data, AnyVariables>,
+      data: Data,
+      suspense: boolean
+    ): Partial<UseFragmentState<Data>> => {
+      const cached = cache.get(request.key);
+      if (!cached) {
+        const fragment = request.query.definitions.find(
+          x =>
+            x.kind === 'FragmentDefinition' &&
+            ((args.name && x.name.value === args.name) || !args.name)
+        );
+        const newResult = maskFragment(
+          data,
+          (fragment as FragmentDefinitionNode).selectionSet
+        );
+        if (newResult == null && suspense) {
+          const promise = new Promise(() => {});
+          cache.set(request.key, promise);
+          throw promise;
+        } else {
+          return { fetching: true, data: newResult.data };
+        }
+      } else if (suspense && cached != null && 'then' in cached) {
+        throw cached;
+      }
+
+      return (cached as OperationResult<Data>) || { fetching: true };
+    },
+    [cache, request]
+  );
+
+  const deps = [client, request, args.context, data] as const;
+
+  const [state, setState] = React.useState(
+    () =>
+      [
+        computeNextState(initialState, getSnapshot(request, data, suspense)),
+        deps,
+      ] as const
+  );
+
+  let currentResult = state[0];
+  if (hasDepsChanged(state[1], deps)) {
+    setState([
+      (currentResult = computeNextState(
+        state[0],
+        getSnapshot(request, data, suspense)
+      )),
+      deps,
+    ]);
+  }
+
+  return currentResult;
+}
+
+const maskFragment = (
+  data: Record<string, any>,
+  selectionSet: SelectionSetNode
+): { data: Record<string, any>; fulfilled: boolean } => {
+  const maskedData = {};
+  let isDataComplete = true;
+  selectionSet.selections.forEach(selection => {
+    if (selection.kind === Kind.FIELD) {
+      const fieldAlias = selection.alias
+        ? selection.alias.value
+        : selection.name.value;
+      if (selection.selectionSet) {
+        if (data[fieldAlias] === undefined) {
+          isDataComplete = false;
+        } else if (data[fieldAlias] === null) {
+          maskedData[fieldAlias] = null;
+        } else if (Array.isArray(data[fieldAlias])) {
+          maskedData[fieldAlias] = data[fieldAlias].map(item => {
+            const result = maskFragment(
+              item,
+              selection.selectionSet as SelectionSetNode
+            );
+            if (!result.fulfilled) {
+              isDataComplete = false;
+            }
+            return result.data;
+          });
+        } else {
+          const result = maskFragment(data[fieldAlias], selection.selectionSet);
+          if (!result.fulfilled) {
+            isDataComplete = false;
+          }
+          maskedData[fieldAlias] = result.data;
+        }
+      } else {
+        if (data[fieldAlias] === undefined) {
+          isDataComplete = false;
+        } else if (data[fieldAlias] === null) {
+          maskedData[fieldAlias] = null;
+        } else if (Array.isArray(data[fieldAlias])) {
+          maskedData[fieldAlias] = data[fieldAlias].map(item => item);
+        } else {
+          maskedData[fieldAlias] = data[fieldAlias];
+        }
+      }
+      maskedData[selection.name.value] = data[selection.name.value];
+    }
+  });
+
+  return { data: maskedData, fulfilled: isDataComplete };
+};

--- a/packages/react-urql/src/hooks/useFragment.ts
+++ b/packages/react-urql/src/hooks/useFragment.ts
@@ -22,13 +22,7 @@ import { getCacheForClient } from './cache';
 
 import { initialState, computeNextState, hasDepsChanged } from './state';
 
-/** Input arguments for the {@link useQuery} hook.
- *
- * @param query - The GraphQL query that `useQuery` executes.
- * @param query - The GraphQL query that `useQuery` executes.
- * @param query - The GraphQL query that `useQuery` executes.
- * @param query - The GraphQL query that `useQuery` executes.
- */
+/** Input arguments for the {@link useFragment} hook. */
 export type UseFragmentArgs<Data = any> = {
   /** Updates the {@link OperationContext} for the executed GraphQL query operation.
    *
@@ -91,7 +85,7 @@ const isSuspense = (client: Client, context?: Partial<OperationContext>) =>
     ? !!context.suspense
     : client.suspense;
 
-/** Hook to mask a GraphQL Fragment given its data.
+/** Hook to mask a GraphQL Fragment given its data. (BETA)
  *
  * @param args - a {@link UseFragmentArgs} object, to pass a `fragment` and `data`.
  * @returns a {@link UseFragmentState} result.

--- a/packages/react-urql/src/hooks/useFragment.ts
+++ b/packages/react-urql/src/hooks/useFragment.ts
@@ -124,8 +124,6 @@ export function useFragment<Data>(
   const client = useClient();
   const cache = getCacheForClient(client);
   const suspense = isSuspense(client, args.context);
-  // We use args.data here for the key to differentiate
-  // in cases where components in i.e. a list
   const request = useRequest(args.query, args.data as any);
 
   const fragments = React.useMemo(() => {
@@ -202,10 +200,8 @@ export function useFragment<Data>(
     [cache, request]
   );
 
-  // TODO: either we use request here or args.query and args.data
   const deps = [client, args.context, args.data, request.query] as const;
 
-  // In essence we could opt to not use state and always get snapshot
   const [state, setState] = React.useState(
     () => [getSnapshot(request, args.data, suspense), deps] as const
   );

--- a/packages/react-urql/src/hooks/useFragment.ts
+++ b/packages/react-urql/src/hooks/useFragment.ts
@@ -326,7 +326,7 @@ const isHeuristicFragmentMatch = (
             x.name.value === 'skip' ||
             x.name.value === 'defer'
         );
-      return Object.hasOwn(data, fieldAlias) && !couldBeExcluded;
+      return data[fieldAlias] !== undefined && !couldBeExcluded;
     } else if (selection.kind === Kind.INLINE_FRAGMENT) {
       return isHeuristicFragmentMatch(selection, data, fragments);
     } else if (selection.kind === Kind.FRAGMENT_SPREAD) {

--- a/packages/react-urql/src/hooks/useFragment.ts
+++ b/packages/react-urql/src/hooks/useFragment.ts
@@ -5,7 +5,6 @@ import type {
   FragmentDefinitionNode,
   InlineFragmentNode,
   SelectionSetNode,
-  DocumentNode,
 } from '@0no-co/graphql.web';
 import { Kind } from '@0no-co/graphql.web';
 
@@ -16,13 +15,13 @@ import type {
   OperationContext,
   GraphQLRequest,
 } from '@urql/core';
+import { createRequest } from '@urql/core';
 
 import { useClient } from '../context';
 import { useRequest } from './useRequest';
 import { getFragmentCacheForClient } from './cache';
 
 import { hasDepsChanged } from './state';
-import { keyDocument } from '@urql/core/utils';
 
 /** Input arguments for the {@link useFragment} hook. */
 export type UseFragmentArgs<Data = any> = {
@@ -125,14 +124,9 @@ export function useFragment<Data>(
   const cache = getFragmentCacheForClient(client);
   const suspense = isSuspense(client, args.context);
   const fragment = React.useMemo(() => {
-    let document: DocumentNode;
-    if (typeof args.query === 'string') {
-      document = keyDocument(args.query);
-    } else {
-      document = args.query;
-    }
+    const request = createRequest(args.query, {});
 
-    return document.definitions.find(
+    return request.query.definitions.find(
       x =>
         x.kind === Kind.FRAGMENT_DEFINITION &&
         ((args.name && x.name.value === args.name) || !args.name)

--- a/packages/react-urql/src/hooks/useFragment.ts
+++ b/packages/react-urql/src/hooks/useFragment.ts
@@ -57,7 +57,7 @@ export type UseFragmentArgs<Data = any> = {
    * masked fragment.
    */
   data: Data;
-  /** An optional name of the fragment to use. */
+  /** An optional name of the fragment to use from the passed Document. */
   name?: string;
 };
 

--- a/packages/react-urql/src/hooks/useFragment.ts
+++ b/packages/react-urql/src/hooks/useFragment.ts
@@ -293,7 +293,7 @@ const maskFragment = <Data>(
 
       const hasDefer =
         selection.directives &&
-        selection.directives.find(x => x.name.value === 'defer');
+        selection.directives.some(x => x.name.value === 'defer');
 
       if (!fragment || !isHeuristicFragmentMatch(fragment, data, fragments)) {
         return;

--- a/packages/react-urql/src/hooks/useFragment.ts
+++ b/packages/react-urql/src/hooks/useFragment.ts
@@ -279,19 +279,16 @@ const maskFragment = <Data>(
     } else if (selection.kind === Kind.FRAGMENT_SPREAD) {
       const fragment = fragments[selection.name.value];
 
-      if (
+      const hasDefer =
         selection.directives &&
-        selection.directives.find(x => x.name.value === 'defer')
-      ) {
-        return;
-      }
+        selection.directives.find(x => x.name.value === 'defer');
 
       if (!fragment || !isHeuristicFragmentMatch(fragment, data, fragments)) {
         return;
       }
 
       const result = maskFragment(data, fragment.selectionSet, fragments);
-      if (!result.fulfilled && !hasIncludeOrSkip) {
+      if (!result.fulfilled && !hasIncludeOrSkip && !hasDefer) {
         isDataComplete = false;
       }
       Object.assign(maskedData, result.data);


### PR DESCRIPTION
Resolves #1408

## Summary

This introduces a new hook to the React package that has two main purposes. On one hand it will mask over the data it gets from its parent component given a fragment, so in the following scenario:

```graphql
query GetTodo { todo { ...TodoFields completed } }
fragment TodoFields on Todo { id text }
```

When we'd pass the resulting data from `GetTodo.todo` into a component and leverage `useFragment` we wouldn't be able to get to the `completed` parameter.

The second goal is to establish a `loading` paradigm for `deferred` queries, this means that given the following document

```graphql
query {
  todo {
    id
    text
    author { ...AuthorFields @defer }
  }
}

fragment AuthorFields on Author {
  id
  name
}
```

When the initial payload comes in we can display the `id` and `text`, during that we display this query as `stale` however we can make this hook in deeper with React paradigms by leveraging `suspense` when the deferred boundary isn't complete and suspense is enabled we can suspend. Even without `suspense` this brings the benefit of not having to check `stale` and being able to render independently of the `result.stale` flag.

## Notes

The heuristic used to assess whether we are using is the presence of `undefined` basically `data` can only be `undefined` when it has not been queried or while it's being streamed in.

I opted for a slightly different approach to `useQuery`, in `useQuery` we are subscribed to the `request` and when the resolved query comes in we call `resolve` on the promise we threw to React. In this one I opted to purely base it on `props`, I tested this in this [demo](https://stackblitz.com/edit/vitejs-vite-bg9pmk?file=src%2FApp.tsx&terminal=dev).

I opted to create the request with our code we use for operations but replaced `variables` with `data` to ensure every entity gets its own cache entry.

A lacking piece at the moment would be directives, if a user leverages `@include()` with a variable then we'd need access to the parent variables to uphold our heuristic of when to set this to `loading`. To counter-act this we check whether the field is `undefined` and when it had one of these directives we accept the absence of the data.

In the future we'll need to find a way to `resolve()` the promise, this is currently impossible as we have no way of establishing a stable identifier across concurrent invocations of a fragment given unique sets of data. 

## Todo

- [x] support `gql.tada` `FragmentOf` dance for `data`
   - Decision: unwrap with `readFragment` before using `useFragment`
- [x] verify whether `TypedDocumentNode` types work correctly
- [x] handle nested fragments in the `FragmentDefinitionNode`
