### PR TITLE
fix(client): eager unblocking of in-flight operations

### DIFF
--- a/.changeset/tiny-pots-allow.md
+++ b/.changeset/tiny-pots-allow.md
@@ -1,0 +1,8 @@
+---
+'@urql/core': patch
+---
+
+Fix issue where a reexecute on an in-flight operation would lead to multiple network-requests.
+This issue was observable when using graphcache on pages where we'd have multiple queries that are inter-dependent, i.e.
+they shared entities that had queries running in parallel, one of them completing would result in
+graphcache calling `reexecute` while the other ones were still in-flight leading to duplicate network requests.

--- a/.changeset/tiny-pots-allow.md
+++ b/.changeset/tiny-pots-allow.md
@@ -3,6 +3,4 @@
 ---
 
 Fix issue where a reexecute on an in-flight operation would lead to multiple network-requests.
-This issue was observable when using graphcache on pages where we'd have multiple queries that are inter-dependent, i.e.
-they shared entities that had queries running in parallel, one of them completing would result in
-graphcache calling `reexecute` while the other ones were still in-flight leading to duplicate network requests.
+For example, this issue presents itself when Graphcache is concurrently updating multiple, inter-dependent queries with shared entities. One query completing while others are still in-flight may lead to duplicate operations being issued.

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -701,7 +701,8 @@ describe('deduplication behavior', () => {
     expect(onOperation).toHaveBeenCalledTimes(2);
   });
 
-  it('unblocks operations on call to reexecuteOperation', async () => {
+  // TODO: I think this test is wrong
+  it.skip('unblocks operations on call to reexecuteOperation', async () => {
     const onOperation = vi.fn();
     const onResult = vi.fn();
 

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -21,7 +21,6 @@ import {
   take,
   fromPromise,
   fromValue,
-  switchMap,
   mergeMap,
 } from 'wonka';
 
@@ -749,6 +748,7 @@ describe('deduplication behavior', () => {
     expect(onResult).toHaveBeenCalledTimes(1);
   });
 
+  // See https://github.com/urql-graphql/urql/issues/3254
   it('unblocks stale operations', async () => {
     const onOperation = vi.fn();
     const onResult = vi.fn();
@@ -788,6 +788,7 @@ describe('deduplication behavior', () => {
     expect(onResult).toHaveBeenCalledTimes(2);
   });
 
+  // See https://github.com/urql-graphql/urql/issues/3565
   it('blocks reexecuting operations that are in-flight', async () => {
     const onOperation = vi.fn();
     const onResult = vi.fn();

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -25,7 +25,11 @@ import { gql } from './gql';
 import { Exchange, Operation, OperationResult } from './types';
 import { makeOperation } from './utils';
 import { Client, createClient } from './client';
-import { queryOperation, subscriptionOperation } from './test-utils';
+import {
+  mutationOperation,
+  queryOperation,
+  subscriptionOperation,
+} from './test-utils';
 
 const url = 'https://hostname.com';
 
@@ -701,8 +705,7 @@ describe('deduplication behavior', () => {
     expect(onOperation).toHaveBeenCalledTimes(2);
   });
 
-  // TODO: I think this test is wrong
-  it.skip('unblocks operations on call to reexecuteOperation', async () => {
+  it('unblocks mutation operations on call to reexecuteOperation', async () => {
     const onOperation = vi.fn();
     const onResult = vi.fn();
 
@@ -725,8 +728,8 @@ describe('deduplication behavior', () => {
       exchanges: [exchange],
     });
 
-    const operation = makeOperation('query', queryOperation, {
-      ...queryOperation.context,
+    const operation = makeOperation('mutation', mutationOperation, {
+      ...mutationOperation.context,
       requestPolicy: 'cache-first',
     });
 

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -643,12 +643,17 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
         // Store replay result
         onPush(result => {
           if (result.stale) {
-            // If the current result has queued up an operation of the same
-            // key, then `stale` refers to it
-            for (const operation of queue) {
-              if (operation.key === result.operation.key) {
-                dispatched.delete(operation.key);
-                break;
+            if (!result.hasNext) {
+              // we are dealing with an optimistic mutation or a partial result
+              dispatched.delete(operation.key);
+            } else {
+              // If the current result has queued up an operation of the same
+              // key, then `stale` refers to it
+              for (const operation of queue) {
+                if (operation.key === result.operation.key) {
+                  dispatched.delete(operation.key);
+                  break;
+                }
               }
             }
           } else if (!result.hasNext) {
@@ -697,13 +702,21 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
       // operation's exchange results
       if (operation.kind === 'teardown') {
         dispatchOperation(operation);
-      } else if (operation.kind === 'mutation' || active.has(operation.key)) {
+      } else if (operation.kind === 'mutation') {
+        queue.push(operation);
+        Promise.resolve().then(dispatchOperation);
+      } else if (active.has(operation.key)) {
         let queued = false;
         for (let i = 0; i < queue.length; i++)
           queued = queued || queue[i].key === operation.key;
-        if (!queued) dispatched.delete(operation.key);
-        queue.push(operation);
-        Promise.resolve().then(dispatchOperation);
+
+        if (!queued && (!dispatched.has(operation.key) || operation.context.requestPolicy === 'network-only')) {
+          queue.push(operation);
+          Promise.resolve().then(dispatchOperation);
+        } else {
+          dispatched.delete(operation.key);
+          Promise.resolve().then(dispatchOperation);
+        }
       }
     },
 

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -713,7 +713,7 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
         if (
           !queued &&
           (!dispatched.has(operation.key) ||
-            operation.context.requestPolicy === 'network-only')
+            operation.context.requestPolicy !== 'network-only')
         ) {
           queue.push(operation);
           Promise.resolve().then(dispatchOperation);

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -710,7 +710,11 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
         for (let i = 0; i < queue.length; i++)
           queued = queued || queue[i].key === operation.key;
 
-        if (!queued && (!dispatched.has(operation.key) || operation.context.requestPolicy === 'network-only')) {
+        if (
+          !queued &&
+          (!dispatched.has(operation.key) ||
+            operation.context.requestPolicy === 'network-only')
+        ) {
           queue.push(operation);
           Promise.resolve().then(dispatchOperation);
         } else {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -707,8 +707,12 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
         Promise.resolve().then(dispatchOperation);
       } else if (active.has(operation.key)) {
         let queued = false;
-        for (let i = 0; i < queue.length; i++)
-          queued = queued || queue[i].key === operation.key;
+        for (let i = 0; i < queue.length; i++) {
+          if (queue[i].key === operation.key) {
+            queue[i] = operation;
+            queued = true;
+          }
+        }
 
         if (
           !queued &&

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -713,7 +713,7 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
         if (
           !queued &&
           (!dispatched.has(operation.key) ||
-            operation.context.requestPolicy !== 'network-only')
+            operation.context.requestPolicy === 'network-only')
         ) {
           queue.push(operation);
           Promise.resolve().then(dispatchOperation);


### PR DESCRIPTION
Resolves #3565

## Summary

In the initial issue we were faced with the following issue, imagine a query that returns a list with values `[Todo:1, Todo:2]` we use this list to return components that in turn has its own query to fetch the details of this `Todo`. Both this list and the details have a shared parent field let's name it `Query.author`, this is important for graph-cache to re-dispatch operations.

This diagram of this looks like the following

```
Operation List
Completed Operation List
Operation Todo:1
Operation Todo:2
Completed Operation Todo:1
Operation Todo:2
Completed Operation Todo:2
Completed Operation Todo:2
```

Notice that we re-dispatch `Todo:2` even though it is already in-flight, this is problematic as in the cache it has not resolved to a response yet and hence we send off multiple network requests. This issue becomes more and more apparent given more queries being in-flight. The lines causing this issue can be found [here](https://github.com/urql-graphql/urql/blob/main/packages/core/src/client.ts#L701-L706) since there is no operation queued we will always remove the operation from our in-flight operations.

The solution here is to change this logic to only remove `dispatched` on a queued operation that either is already in `dispatched` or is `network-only`.

> I did notice that https://github.com/urql-graphql/urql/pull/3564 already makes this issue less severe due to dispatching less operations from graphcache.

The above fix however re-introduces the issue we faced in https://github.com/urql-graphql/urql/issues/3254 this due to our optimistic mutation re-triggering the operation and resulting in `stale` and then our real data re-triggering the query but it already having been dispatched. This because we have similar logic in the [`onPush`](https://github.com/urql-graphql/urql/blob/main/packages/core/src/client.ts#L645-L653) part of our `operation`. When it's stale we'll check the queue whether there is an operation in there, however there won't be as we are dealing with an optimistic mutation re-trigger, to fix this I added a check whether the stale result has a next payload coming, if not it gets deleted form dispatched either way.

I think the above `stale` flag fix is the root cause that needed to be addressed in #3254 but I am not a 100% sure as I got a bit overloaded while leveraging `console.log` in all of these reproductions 😅 
