### PR TITLE
chore(workspace): automatically publish urql-core to JSR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Unit Tests
         run: pnpm run test
 
+      - name: Check for slow types
+        run: pnpm jsr:dryrun
+
   react-e2e:
     name: React E2E
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - jsr-support
 jobs:
   release:
     name: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-      - jsr-support
+
 jobs:
   release:
     name: Release

--- a/exchanges/auth/jsr.json
+++ b/exchanges/auth/jsr.json
@@ -1,0 +1,6 @@
+{
+  "name": "@urql/exchange-auth",
+  "version": "2.1.6",
+  "exports": ".",
+  "exclude": ["node_modules", "cypress"]
+}

--- a/exchanges/auth/jsr.json
+++ b/exchanges/auth/jsr.json
@@ -1,6 +1,8 @@
 {
   "name": "@urql/exchange-auth",
   "version": "2.1.6",
-  "exports": ".",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "exclude": ["node_modules", "cypress"]
 }

--- a/exchanges/auth/jsr.json
+++ b/exchanges/auth/jsr.json
@@ -4,5 +4,12 @@
   "exports": {
     ".": "./src/index.ts"
   },
-  "exclude": ["node_modules", "cypress"]
+  "exclude": [
+    "node_modules",
+    "cypress",
+    "**/*.test.*",
+    "**/*.spec.*",
+    "**/*.test.*.snap",
+    "**/*.spec.*.snap"
+  ]
 }

--- a/exchanges/context/jsr.json
+++ b/exchanges/context/jsr.json
@@ -1,0 +1,6 @@
+{
+  "name": "@urql/exchange-context",
+  "version": "0.2.1",
+  "exports": ".",
+  "exclude": ["node_modules", "cypress"]
+}

--- a/exchanges/context/jsr.json
+++ b/exchanges/context/jsr.json
@@ -4,5 +4,12 @@
   "exports": {
     ".": "./src/index.ts"
   },
-  "exclude": ["node_modules", "cypress"]
+  "exclude": [
+    "node_modules",
+    "cypress",
+    "**/*.test.*",
+    "**/*.spec.*",
+    "**/*.test.*.snap",
+    "**/*.spec.*.snap"
+  ]
 }

--- a/exchanges/context/jsr.json
+++ b/exchanges/context/jsr.json
@@ -1,6 +1,8 @@
 {
   "name": "@urql/exchange-context",
   "version": "0.2.1",
-  "exports": ".",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "exclude": ["node_modules", "cypress"]
 }

--- a/exchanges/execute/jsr.json
+++ b/exchanges/execute/jsr.json
@@ -4,5 +4,12 @@
   "exports": {
     ".": "./src/index.ts"
   },
-  "exclude": ["node_modules", "cypress"]
+  "exclude": [
+    "node_modules",
+    "cypress",
+    "**/*.test.*",
+    "**/*.spec.*",
+    "**/*.test.*.snap",
+    "**/*.spec.*.snap"
+  ]
 }

--- a/exchanges/execute/jsr.json
+++ b/exchanges/execute/jsr.json
@@ -1,0 +1,6 @@
+{
+  "name": "@urql/exchange-execute",
+  "version": "2.2.2",
+  "exports": ".",
+  "exclude": ["node_modules", "cypress"]
+}

--- a/exchanges/execute/jsr.json
+++ b/exchanges/execute/jsr.json
@@ -1,6 +1,8 @@
 {
   "name": "@urql/exchange-execute",
   "version": "2.2.2",
-  "exports": ".",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "exclude": ["node_modules", "cypress"]
 }

--- a/exchanges/graphcache/jsr.json
+++ b/exchanges/graphcache/jsr.json
@@ -1,8 +1,8 @@
 {
   "name": "@urql/exchange-graphcache",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "exports": {
-    "0": ".",
+    ".": "./src/index.ts",
     "./extras": "./src/extras/index.ts",
     "./default-storage": "./src/default-storage/index.ts"
   },

--- a/exchanges/graphcache/jsr.json
+++ b/exchanges/graphcache/jsr.json
@@ -6,5 +6,12 @@
     "./extras": "./src/extras/index.ts",
     "./default-storage": "./src/default-storage/index.ts"
   },
-  "exclude": ["node_modules", "cypress"]
+  "exclude": [
+    "node_modules",
+    "cypress",
+    "**/*.test.*",
+    "**/*.spec.*",
+    "**/*.test.*.snap",
+    "**/*.spec.*.snap"
+  ]
 }

--- a/exchanges/graphcache/jsr.json
+++ b/exchanges/graphcache/jsr.json
@@ -1,0 +1,10 @@
+{
+  "name": "@urql/exchange-graphcache",
+  "version": "7.0.1",
+  "exports": {
+    "0": ".",
+    "./extras": "./src/extras/index.ts",
+    "./default-storage": "./src/default-storage/index.ts"
+  },
+  "exclude": ["node_modules", "cypress"]
+}

--- a/exchanges/persisted/jsr.json
+++ b/exchanges/persisted/jsr.json
@@ -1,0 +1,6 @@
+{
+  "name": "@urql/exchange-persisted",
+  "version": "4.2.0",
+  "exports": ".",
+  "exclude": ["node_modules", "cypress"]
+}

--- a/exchanges/persisted/jsr.json
+++ b/exchanges/persisted/jsr.json
@@ -4,5 +4,12 @@
   "exports": {
     ".": "./src/index.ts"
   },
-  "exclude": ["node_modules", "cypress"]
+  "exclude": [
+    "node_modules",
+    "cypress",
+    "**/*.test.*",
+    "**/*.spec.*",
+    "**/*.test.*.snap",
+    "**/*.spec.*.snap"
+  ]
 }

--- a/exchanges/persisted/jsr.json
+++ b/exchanges/persisted/jsr.json
@@ -1,6 +1,8 @@
 {
   "name": "@urql/exchange-persisted",
   "version": "4.2.0",
-  "exports": ".",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "exclude": ["node_modules", "cypress"]
 }

--- a/exchanges/populate/jsr.json
+++ b/exchanges/populate/jsr.json
@@ -4,5 +4,12 @@
   "exports": {
     ".": "./src/index.ts"
   },
-  "exclude": ["node_modules", "cypress"]
+  "exclude": [
+    "node_modules",
+    "cypress",
+    "**/*.test.*",
+    "**/*.spec.*",
+    "**/*.test.*.snap",
+    "**/*.spec.*.snap"
+  ]
 }

--- a/exchanges/populate/jsr.json
+++ b/exchanges/populate/jsr.json
@@ -1,0 +1,6 @@
+{
+  "name": "@urql/exchange-populate",
+  "version": "1.1.2",
+  "exports": ".",
+  "exclude": ["node_modules", "cypress"]
+}

--- a/exchanges/populate/jsr.json
+++ b/exchanges/populate/jsr.json
@@ -1,6 +1,8 @@
 {
   "name": "@urql/exchange-populate",
   "version": "1.1.2",
-  "exports": ".",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "exclude": ["node_modules", "cypress"]
 }

--- a/exchanges/refocus/jsr.json
+++ b/exchanges/refocus/jsr.json
@@ -1,6 +1,8 @@
 {
   "name": "@urql/exchange-refocus",
   "version": "1.0.2",
-  "exports": ".",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "exclude": ["node_modules", "cypress"]
 }

--- a/exchanges/refocus/jsr.json
+++ b/exchanges/refocus/jsr.json
@@ -1,0 +1,6 @@
+{
+  "name": "@urql/exchange-refocus",
+  "version": "1.0.2",
+  "exports": ".",
+  "exclude": ["node_modules", "cypress"]
+}

--- a/exchanges/refocus/jsr.json
+++ b/exchanges/refocus/jsr.json
@@ -4,5 +4,12 @@
   "exports": {
     ".": "./src/index.ts"
   },
-  "exclude": ["node_modules", "cypress"]
+  "exclude": [
+    "node_modules",
+    "cypress",
+    "**/*.test.*",
+    "**/*.spec.*",
+    "**/*.test.*.snap",
+    "**/*.spec.*.snap"
+  ]
 }

--- a/exchanges/request-policy/jsr.json
+++ b/exchanges/request-policy/jsr.json
@@ -1,6 +1,8 @@
 {
   "name": "@urql/exchange-request-policy",
   "version": "1.1.0",
-  "exports": ".",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "exclude": ["node_modules", "cypress"]
 }

--- a/exchanges/request-policy/jsr.json
+++ b/exchanges/request-policy/jsr.json
@@ -1,0 +1,6 @@
+{
+  "name": "@urql/exchange-request-policy",
+  "version": "1.1.0",
+  "exports": ".",
+  "exclude": ["node_modules", "cypress"]
+}

--- a/exchanges/request-policy/jsr.json
+++ b/exchanges/request-policy/jsr.json
@@ -4,5 +4,12 @@
   "exports": {
     ".": "./src/index.ts"
   },
-  "exclude": ["node_modules", "cypress"]
+  "exclude": [
+    "node_modules",
+    "cypress",
+    "**/*.test.*",
+    "**/*.spec.*",
+    "**/*.test.*.snap",
+    "**/*.spec.*.snap"
+  ]
 }

--- a/exchanges/retry/jsr.json
+++ b/exchanges/retry/jsr.json
@@ -4,5 +4,12 @@
   "exports": {
     ".": "./src/index.ts"
   },
-  "exclude": ["node_modules", "cypress"]
+  "exclude": [
+    "node_modules",
+    "cypress",
+    "**/*.test.*",
+    "**/*.spec.*",
+    "**/*.test.*.snap",
+    "**/*.spec.*.snap"
+  ]
 }

--- a/exchanges/retry/jsr.json
+++ b/exchanges/retry/jsr.json
@@ -1,0 +1,6 @@
+{
+  "name": "@urql/exchange-retry",
+  "version": "1.2.1",
+  "exports": ".",
+  "exclude": ["node_modules", "cypress"]
+}

--- a/exchanges/retry/jsr.json
+++ b/exchanges/retry/jsr.json
@@ -1,6 +1,8 @@
 {
   "name": "@urql/exchange-retry",
   "version": "1.2.1",
-  "exports": ".",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "exclude": ["node_modules", "cypress"]
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "pack": "node ./scripts/actions/pack-all.mjs",
     "changeset:version": "node ./scripts/changesets/version.mjs && node ./scripts/changesets/jsr.mjs",
     "changeset:publish": "changeset publish && pnpm jsr",
-    "jsr": "pnpm --filter @urql/core jsr"
+    "jsr": "pnpm --filter @urql/core jsr",
+    "jsr:dryrun": "pnpm --filter @urql/core jsr --dry-run"
   },
   "eslintConfig": {
     "root": true,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "node ./scripts/actions/build-all.mjs",
     "postinstall": "node ./scripts/prepare/postinstall.js",
     "pack": "node ./scripts/actions/pack-all.mjs",
-    "changeset:version": "node ./scripts/changesets/version.mjs && node ./scripts/changesets/jsr.mjs",
+    "changeset:version": "node ./scripts/changesets/version.mjs",
     "changeset:publish": "changeset publish && pnpm jsr",
     "jsr": "pnpm --filter @urql/core jsr",
     "jsr:dryrun": "pnpm --filter @urql/core jsr --dry-run"

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "build": "node ./scripts/actions/build-all.mjs",
     "postinstall": "node ./scripts/prepare/postinstall.js",
     "pack": "node ./scripts/actions/pack-all.mjs",
-    "changeset:version": "node ./scripts/changesets/version.mjs",
-    "changeset:publish": "changeset publish",
+    "changeset:version": "node ./scripts/changesets/version.mjs && node ./scripts/changesets/jsr.mjs",
+    "changeset:publish": "changeset publish && pnpm jsr",
     "jsr": "pnpm --filter @urql/core jsr"
   },
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "postinstall": "node ./scripts/prepare/postinstall.js",
     "pack": "node ./scripts/actions/pack-all.mjs",
     "changeset:version": "node ./scripts/changesets/version.mjs",
-    "changeset:publish": "changeset publish"
+    "changeset:publish": "changeset publish",
+    "jsr": "pnpm --filter @urql/core jsr"
   },
   "eslintConfig": {
     "root": true,
@@ -88,6 +89,7 @@
     "husky-v4": "^4.3.8",
     "invariant": "^2.2.4",
     "jsdom": "^21.1.1",
+    "jsr": "^0.12.4",
     "lint-staged": "^13.2.2",
     "npm-packlist": "^7.0.4",
     "npm-run-all": "^4.1.5",

--- a/packages/core/jsr.json
+++ b/packages/core/jsr.json
@@ -5,5 +5,12 @@
     ".": "./src/index.ts",
     "./internal": "./src/internal/index.ts"
   },
-  "exclude": ["node_modules", "cypress"]
+  "exclude": [
+    "node_modules",
+    "cypress",
+    "**/*.test.*",
+    "**/*.spec.*",
+    "**/*.test.*.snap",
+    "**/*.spec.*.snap"
+  ]
 }

--- a/packages/core/jsr.json
+++ b/packages/core/jsr.json
@@ -1,8 +1,8 @@
 {
   "name": "@urql/core",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "exports": {
-    "0": ".",
+    ".": "./src/index.ts",
     "./internal": "./src/internal/index.ts"
   },
   "exclude": ["node_modules", "cypress"]

--- a/packages/core/jsr.json
+++ b/packages/core/jsr.json
@@ -1,0 +1,9 @@
+{
+  "name": "@urql/core",
+  "version": "5.0.1",
+  "exports": {
+    "0": ".",
+    "./internal": "./src/internal/index.ts"
+  },
+  "exclude": ["node_modules", "cypress"]
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,7 +51,8 @@
     "lint": "eslint --ext=js,jsx,ts,tsx .",
     "build": "rollup -c ../../scripts/rollup/config.mjs",
     "prepare": "node ../../scripts/prepare/index.js",
-    "prepublishOnly": "run-s clean build"
+    "prepublishOnly": "run-s clean build",
+    "jsr": "jsr publish --dry-run"
   },
   "dependencies": {
     "@0no-co/graphql.web": "^1.0.5",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,7 +52,7 @@
     "build": "rollup -c ../../scripts/rollup/config.mjs",
     "prepare": "node ../../scripts/prepare/index.js",
     "prepublishOnly": "run-s clean build",
-    "jsr": "jsr publish --dry-run"
+    "jsr": "jsr publish"
   },
   "dependencies": {
     "@0no-co/graphql.web": "^1.0.5",

--- a/packages/core/src/utils/error.ts
+++ b/packages/core/src/utils/error.ts
@@ -114,7 +114,7 @@ export class CombinedError extends Error {
     this.response = input.response;
   }
 
-  toString() {
+  toString(): string {
     return this.message;
   }
 }

--- a/packages/core/src/utils/formatDocument.ts
+++ b/packages/core/src/utils/formatDocument.ts
@@ -74,7 +74,10 @@ const formatNode = <
   return node as FormattedNode<T>;
 };
 
-const formattedDocs = new Map<number, KeyedDocumentNode>();
+const formattedDocs: Map<number, KeyedDocumentNode> = new Map<
+  number,
+  KeyedDocumentNode
+>();
 
 /** Formats a GraphQL document to add `__typename` fields and process client-side directives.
  *

--- a/packages/core/src/utils/request.ts
+++ b/packages/core/src/utils/request.ts
@@ -23,15 +23,21 @@ const SOURCE_NAME = 'gql';
 const GRAPHQL_STRING_RE = /("{3}[\s\S]*"{3}|"(?:\\.|[^"])*")/g;
 const REPLACE_CHAR_RE = /(?:#[^\n\r]+)?(?:[\r\n]+|$)/g;
 
-const replaceOutsideStrings = (str: string, idx: number) =>
+const replaceOutsideStrings = (str: string, idx: number): string =>
   idx % 2 === 0 ? str.replace(REPLACE_CHAR_RE, '\n') : str;
 
 /** Sanitizes a GraphQL document string by replacing comments and redundant newlines in it. */
 const sanitizeDocument = (node: string): string =>
   node.split(GRAPHQL_STRING_RE).map(replaceOutsideStrings).join('').trim();
 
-const prints = new Map<DocumentNode | DefinitionNode, string>();
-const docs = new Map<HashValue, KeyedDocumentNode>();
+const prints: Map<DocumentNode | DefinitionNode, string> = new Map<
+  DocumentNode | DefinitionNode,
+  string
+>();
+const docs: Map<HashValue, KeyedDocumentNode> = new Map<
+  HashValue,
+  KeyedDocumentNode
+>();
 
 /** A cached printing function for GraphQL documents.
  *

--- a/packages/core/src/utils/result.ts
+++ b/packages/core/src/utils/result.ts
@@ -51,7 +51,7 @@ export const makeResult = (
   };
 };
 
-const deepMerge = (target: any, source: any) => {
+const deepMerge = (target: any, source: any): any => {
   if (typeof target === 'object' && target != null) {
     if (
       !target.constructor ||

--- a/packages/core/src/utils/variables.ts
+++ b/packages/core/src/utils/variables.ts
@@ -1,7 +1,7 @@
 export type FileMap = Map<string, File | Blob>;
 
-const seen = new Set();
-const cache = new WeakMap();
+const seen: Set<any> = new Set();
+const cache: WeakMap<any, any> = new WeakMap();
 
 const stringify = (x: any): string => {
   if (x === null || seen.has(x)) {

--- a/packages/introspection/jsr.json
+++ b/packages/introspection/jsr.json
@@ -1,6 +1,8 @@
 {
   "name": "@urql/introspection",
   "version": "1.0.3",
-  "exports": ".",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "exclude": ["node_modules", "cypress"]
 }

--- a/packages/introspection/jsr.json
+++ b/packages/introspection/jsr.json
@@ -4,5 +4,12 @@
   "exports": {
     ".": "./src/index.ts"
   },
-  "exclude": ["node_modules", "cypress"]
+  "exclude": [
+    "node_modules",
+    "cypress",
+    "**/*.test.*",
+    "**/*.spec.*",
+    "**/*.test.*.snap",
+    "**/*.spec.*.snap"
+  ]
 }

--- a/packages/introspection/jsr.json
+++ b/packages/introspection/jsr.json
@@ -1,0 +1,6 @@
+{
+  "name": "@urql/introspection",
+  "version": "1.0.3",
+  "exports": ".",
+  "exclude": ["node_modules", "cypress"]
+}

--- a/packages/next-urql/jsr.json
+++ b/packages/next-urql/jsr.json
@@ -1,0 +1,9 @@
+{
+  "name": "@urql/next",
+  "version": "1.1.1",
+  "exports": {
+    "0": ".",
+    "./rsc": "./src/rsc.ts"
+  },
+  "exclude": ["node_modules", "cypress"]
+}

--- a/packages/next-urql/jsr.json
+++ b/packages/next-urql/jsr.json
@@ -2,7 +2,7 @@
   "name": "@urql/next",
   "version": "1.1.1",
   "exports": {
-    "0": ".",
+    ".": "./src/index.ts",
     "./rsc": "./src/rsc.ts"
   },
   "exclude": ["node_modules", "cypress"]

--- a/packages/next-urql/jsr.json
+++ b/packages/next-urql/jsr.json
@@ -5,5 +5,12 @@
     ".": "./src/index.ts",
     "./rsc": "./src/rsc.ts"
   },
-  "exclude": ["node_modules", "cypress"]
+  "exclude": [
+    "node_modules",
+    "cypress",
+    "**/*.test.*",
+    "**/*.spec.*",
+    "**/*.test.*.snap",
+    "**/*.spec.*.snap"
+  ]
 }

--- a/packages/preact-urql/jsr.json
+++ b/packages/preact-urql/jsr.json
@@ -1,6 +1,8 @@
 {
   "name": "@urql/preact",
   "version": "4.0.5",
-  "exports": ".",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "exclude": ["node_modules", "cypress"]
 }

--- a/packages/preact-urql/jsr.json
+++ b/packages/preact-urql/jsr.json
@@ -4,5 +4,12 @@
   "exports": {
     ".": "./src/index.ts"
   },
-  "exclude": ["node_modules", "cypress"]
+  "exclude": [
+    "node_modules",
+    "cypress",
+    "**/*.test.*",
+    "**/*.spec.*",
+    "**/*.test.*.snap",
+    "**/*.spec.*.snap"
+  ]
 }

--- a/packages/preact-urql/jsr.json
+++ b/packages/preact-urql/jsr.json
@@ -1,0 +1,6 @@
+{
+  "name": "@urql/preact",
+  "version": "4.0.5",
+  "exports": ".",
+  "exclude": ["node_modules", "cypress"]
+}

--- a/packages/react-urql/jsr.json
+++ b/packages/react-urql/jsr.json
@@ -2,5 +2,12 @@
   "name": "urql",
   "version": "4.0.7",
   "exports": "src/index.ts",
-  "exclude": ["node_modules", "cypress"]
+  "exclude": [
+    "node_modules",
+    "cypress",
+    "**/*.test.*",
+    "**/*.spec.*",
+    "**/*.test.*.snap",
+    "**/*.spec.*.snap"
+  ]
 }

--- a/packages/react-urql/jsr.json
+++ b/packages/react-urql/jsr.json
@@ -1,0 +1,6 @@
+{
+  "name": "urql",
+  "version": "4.0.7",
+  "exports": "src/index.ts",
+  "exclude": ["node_modules", "cypress"]
+}

--- a/packages/storage-rn/jsr.json
+++ b/packages/storage-rn/jsr.json
@@ -1,6 +1,8 @@
 {
   "name": "@urql/storage-rn",
   "version": "1.1.0",
-  "exports": ".",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "exclude": ["node_modules", "cypress"]
 }

--- a/packages/storage-rn/jsr.json
+++ b/packages/storage-rn/jsr.json
@@ -4,5 +4,12 @@
   "exports": {
     ".": "./src/index.ts"
   },
-  "exclude": ["node_modules", "cypress"]
+  "exclude": [
+    "node_modules",
+    "cypress",
+    "**/*.test.*",
+    "**/*.spec.*",
+    "**/*.test.*.snap",
+    "**/*.spec.*.snap"
+  ]
 }

--- a/packages/storage-rn/jsr.json
+++ b/packages/storage-rn/jsr.json
@@ -1,0 +1,6 @@
+{
+  "name": "@urql/storage-rn",
+  "version": "1.1.0",
+  "exports": ".",
+  "exclude": ["node_modules", "cypress"]
+}

--- a/packages/svelte-urql/jsr.json
+++ b/packages/svelte-urql/jsr.json
@@ -1,6 +1,8 @@
 {
   "name": "@urql/svelte",
   "version": "4.1.1",
-  "exports": ".",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "exclude": ["node_modules", "cypress"]
 }

--- a/packages/svelte-urql/jsr.json
+++ b/packages/svelte-urql/jsr.json
@@ -4,5 +4,12 @@
   "exports": {
     ".": "./src/index.ts"
   },
-  "exclude": ["node_modules", "cypress"]
+  "exclude": [
+    "node_modules",
+    "cypress",
+    "**/*.test.*",
+    "**/*.spec.*",
+    "**/*.test.*.snap",
+    "**/*.spec.*.snap"
+  ]
 }

--- a/packages/svelte-urql/jsr.json
+++ b/packages/svelte-urql/jsr.json
@@ -1,0 +1,6 @@
+{
+  "name": "@urql/svelte",
+  "version": "4.1.1",
+  "exports": ".",
+  "exclude": ["node_modules", "cypress"]
+}

--- a/packages/vue-urql/jsr.json
+++ b/packages/vue-urql/jsr.json
@@ -1,0 +1,6 @@
+{
+  "name": "@urql/vue",
+  "version": "1.1.3",
+  "exports": ".",
+  "exclude": ["node_modules", "cypress"]
+}

--- a/packages/vue-urql/jsr.json
+++ b/packages/vue-urql/jsr.json
@@ -4,5 +4,12 @@
   "exports": {
     ".": "./src/index.ts"
   },
-  "exclude": ["node_modules", "cypress"]
+  "exclude": [
+    "node_modules",
+    "cypress",
+    "**/*.test.*",
+    "**/*.spec.*",
+    "**/*.test.*.snap",
+    "**/*.spec.*.snap"
+  ]
 }

--- a/packages/vue-urql/jsr.json
+++ b/packages/vue-urql/jsr.json
@@ -1,6 +1,8 @@
 {
   "name": "@urql/vue",
   "version": "1.1.3",
-  "exports": ".",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "exclude": ["node_modules", "cypress"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,6 +124,9 @@ importers:
       jsdom:
         specifier: ^21.1.1
         version: 21.1.1
+      jsr:
+        specifier: ^0.12.4
+        version: 0.12.4
       lint-staged:
         specifier: ^13.2.2
         version: 13.2.2
@@ -594,7 +597,7 @@ packages:
   /@0no-co/graphql.web@1.0.5(graphql@16.6.0):
     resolution: {integrity: sha512-/ODdeNNFksS9hUvpjWFldMEpq0OqCFEIV3NVM0eU8HLUYU0Szf+2iKvr63kkbGchQwk2/1IxPF1PfoCabVkgLw==}
     peerDependencies:
-      graphql: ^16.6.0
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
     peerDependenciesMeta:
       graphql:
         optional: true
@@ -2038,10 +2041,10 @@ packages:
   /@cypress/react@7.0.2(@types/react@17.0.52)(cypress@12.8.1)(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-TTV7XNMDOO9mZUFWiGbd44Od/jqMVX/QbHYKQmK1XT3nIVFs0EvKJuHJmwN7wxLOR/+6twtyX6vTD8z8XBTliQ==}
     peerDependencies:
-      '@types/react': ^17.0.39
+      '@types/react': ^16.9.16 || ^17.0.0
       cypress: '*'
-      react: ^17.0.2 || 17
-      react-dom: ^17.0.2 || 17
+      react: ^=16.x || ^=17.x || 17
+      react-dom: ^=16.x || ^=17.x || 17
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -2293,7 +2296,7 @@ packages:
   /@mdx-js/react@1.6.22(react@17.0.2):
     resolution: {integrity: sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg==}
     peerDependencies:
-      react: ^17.0.2 || 17
+      react: ^16.13.1 || ^17.0.0 || 17
     dependencies:
       react: 17.0.2
     dev: false
@@ -2730,8 +2733,8 @@ packages:
   /@reach/router@1.3.4(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-+mtn9wjlB9NN2CNnnC/BRYtwdKBfSyyasPYraNAyvaV1occr/5NnB4CVzjEZipNHwYebQwcndGUmpFzxAUoqSA==}
     peerDependencies:
-      react: ^17.0.2 || 17
-      react-dom: ^17.0.2 || 17
+      react: 15.x || 16.x || 16.4.0-alpha.0911da3 || 17
+      react-dom: 15.x || 16.x || 16.4.0-alpha.0911da3 || 17
     dependencies:
       create-react-context: 0.3.0(prop-types@15.8.1)(react@17.0.2)
       invariant: 2.2.4
@@ -2901,8 +2904,8 @@ packages:
   /@testing-library/react-hooks@5.1.2(react-dom@17.0.2)(react-test-renderer@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-jwhtDYZ5gQUIX8cmVCVdtwNvuF5EiCOWjokRlTV+o/V0GdtRZDykUllL1OXq5PS4+J33wGLNQeeWzEHcWrH7tg==}
     peerDependencies:
-      react: ^17.0.2 || 17
-      react-dom: ^17.0.2 || 17
+      react: '>=16.9.0 || 17'
+      react-dom: '>=16.9.0 || 17'
       react-test-renderer: '>=16.9.0'
     peerDependenciesMeta:
       react-dom:
@@ -2925,8 +2928,8 @@ packages:
     resolution: {integrity: sha512-TXMCg0jT8xmuU8BkKMtp8l7Z50Ykew5WNX8UoIKTaLFwKkP2+1YDhOLA2Ga3wY4x29jyntk7EWfum0kjlYiSjQ==}
     engines: {node: '>=10'}
     peerDependencies:
-      react: ^17.0.2 || 17
-      react-dom: ^17.0.2 || 17
+      react: '*'
+      react-dom: '*'
     dependencies:
       '@babel/runtime': 7.22.5
       '@testing-library/dom': 7.30.4
@@ -4098,7 +4101,7 @@ packages:
   /babel-plugin-styled-components@1.12.0(styled-components@5.2.3):
     resolution: {integrity: sha512-FEiD7l5ZABdJPpLssKXjBUJMYqzbcNzBowfXDCdJhOpbhWiewapUaY+LZGT8R4Jg2TwOjGjG4RKeyrO5p9sBkA==}
     peerDependencies:
-      styled-components: ^5.2.3 || 5
+      styled-components: '>= 2 || 5'
     dependencies:
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-module-imports': 7.21.4
@@ -5317,7 +5320,7 @@ packages:
     resolution: {integrity: sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==}
     peerDependencies:
       prop-types: ^15.0.0
-      react: ^17.0.2 || 17
+      react: ^0.14.0 || ^15.0.0 || ^16.0.0 || 17
     dependencies:
       gud: 1.0.0
       prop-types: 15.8.1
@@ -7370,7 +7373,7 @@ packages:
     resolution: {integrity: sha512-jvHSQMXujUtncyT3ObkoQgwOzkxdnnAs7XYgJDGSqhGqPF+LZ0y4rS5b6XzaN2BR3hG2e7isVtCNOmb7gxNuYw==}
     engines: {node: '>= 0.12.0', npm: '>= 2.0.0'}
     peerDependencies:
-      styled-components: ^5.2.3 || 5
+      styled-components: '>= 4.0.0 || 5'
     dependencies:
       styled-components: 5.2.3(react-dom@17.0.2)(react-is@17.0.2)(react@17.0.2)
     dev: false
@@ -9068,6 +9071,15 @@ packages:
       verror: 1.10.0
     dev: true
 
+  /jsr@0.12.4:
+    resolution: {integrity: sha512-ZWDvqQE8014fWz9QBrkiuvRQ8mH97PRD13VIDzoMXDem3ff2S+wfXw+YAvrZE0aKzxh9FuHJX0HQRQ2MUHshig==}
+    hasBin: true
+    dependencies:
+      kolorist: 1.8.0
+      node-stream-zip: 1.15.0
+      semiver: 1.1.0
+    dev: true
+
   /jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
@@ -9117,6 +9129,10 @@ packages:
   /kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
+    dev: true
+
+  /kolorist@1.8.0:
+    resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
     dev: true
 
   /last-call-webpack-plugin@3.0.0:
@@ -9744,7 +9760,7 @@ packages:
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       prop-types: ^15.0.0
-      react: ^17.0.2 || 17
+      react: ^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0 || 17
     dependencies:
       '@babel/runtime': 7.22.5
       prop-types: 15.8.1
@@ -10039,8 +10055,8 @@ packages:
     peerDependencies:
       fibers: '>= 3.1.0'
       node-sass: ^6.0.0 || ^7.0.0
-      react: ^17.0.2 || 17
-      react-dom: ^17.0.2 || 17
+      react: ^18.0.0-0 || 17
+      react-dom: ^18.0.0-0 || 17
       sass: ^1.3.0
     peerDependenciesMeta:
       fibers:
@@ -10170,6 +10186,11 @@ packages:
 
   /node-releases@2.0.10:
     resolution: {integrity: sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==}
+
+  /node-stream-zip@1.15.0:
+    resolution: {integrity: sha512-LN4fydt9TqhZhThkZIVQnF9cwjU3qmUH9h78Mx/K7d3VvfRqqwthLwJEUOEL0QPZ0XQmNN7be5Ggit5+4dq3Bw==}
+    engines: {node: '>=0.12.0'}
+    dev: true
 
   /nopt@6.0.0:
     resolution: {integrity: sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==}
@@ -11434,7 +11455,7 @@ packages:
   /prism-react-renderer@1.2.0(react@17.0.2):
     resolution: {integrity: sha512-GHqzxLYImx1iKN1jJURcuRoA/0ygCcNhfGw1IT8nPIMzarmKQ3Nc+JcG0gi8JXQzuh0C5ShE4npMIoqNin40hg==}
     peerDependencies:
-      react: ^17.0.2 || 17
+      react: '>=0.14.9 || 17'
     dependencies:
       react: 17.0.2
     dev: false
@@ -11684,7 +11705,7 @@ packages:
   /react-dom@17.0.2(react@17.0.2):
     resolution: {integrity: sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==}
     peerDependencies:
-      react: ^17.0.2 || 17
+      react: 17.0.2 || 17
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
@@ -11695,7 +11716,7 @@ packages:
     resolution: {integrity: sha512-W3xCd9zXnanqrTUeViceufD3mIW8Ut29BUD+S2f0eO2XCOU8b6UrJfY46RDGe5lxCJzfe4j0yvIfh0RbTZhKJw==}
     engines: {node: '>=10', npm: '>=6'}
     peerDependencies:
-      react: ^17.0.2 || 17
+      react: '>=16.13.1 || 17'
     dependencies:
       '@babel/runtime': 7.22.5
       react: 17.0.2
@@ -11707,7 +11728,7 @@ packages:
   /react-from-dom@0.3.1(react@17.0.2):
     resolution: {integrity: sha512-PeNBa8iuzoD7qHA9O7YpGnXFvC+XFFwStmFh2/r2zJAvEIaRg6EwOj+EPcDIFwyYBhqPIItxIx/dGdeWiFivjQ==}
     peerDependencies:
-      react: ^17.0.2 || 17
+      react: ^15.0.0 || ^16.0.0 || 17
     dependencies:
       react: 17.0.2
     dev: false
@@ -11716,7 +11737,7 @@ packages:
     resolution: {integrity: sha512-o8RScHj6Lb8cwy3GMrVH6NJvL+y0zpJvKtc0+wmH7Bt23rszJmnqEQxRbyrqUzk9DTJIHoP42bfO5rswC9SWBQ==}
     peerDependencies:
       prop-types: ^15.6.0
-      react: ^17.0.2 || 17
+      react: ^15.6.2 || ^16.0 || ^17 || 17
     dependencies:
       prop-types: 15.7.2
       react: 17.0.2
@@ -11729,7 +11750,7 @@ packages:
   /react-helmet@5.2.1(react@17.0.2):
     resolution: {integrity: sha512-CnwD822LU8NDBnjCpZ4ySh8L6HYyngViTZLfBBb3NjtrpN8m49clH8hidHouq20I51Y6TpCTISCBbqiY5GamwA==}
     peerDependencies:
-      react: ^17.0.2 || 17
+      react: '>=15.0.0 || 17'
     dependencies:
       object-assign: 4.1.1
       prop-types: 15.8.1
@@ -11741,9 +11762,9 @@ packages:
     resolution: {integrity: sha512-JrLlvUPqh6wIkrK2hZDfOyq/Uh/WeVEr8nc7hkn2/3Ul0sx1Kr5y4kOGNacNRoj7RhwLNcQ3Udf1KJXrqc0ZtA==}
     engines: {node: '>= 6'}
     peerDependencies:
-      '@types/react': ^17.0.39
-      react: ^17.0.2 || 17
-      react-dom: ^17.0.2 || 17
+      '@types/react': '^15.0.0 || ^16.0.0 || ^17.0.0 '
+      react: ^15.0.0 || ^16.0.0 || ^17.0.0 || 17
+      react-dom: ^15.0.0 || ^16.0.0 || ^17.0.0 || 17
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -11762,7 +11783,7 @@ packages:
   /react-inlinesvg@1.2.0(react@17.0.2):
     resolution: {integrity: sha512-IsznU+UzpUwDGzBWbf0bfSRA5Jbqz87xeoqLM/nSIDPkoHksInF1wCGybTSn4sIui+30TqboRQP1wAelNTkdog==}
     peerDependencies:
-      react: ^17.0.2 || 17
+      react: ^16.3.0 || 17
     dependencies:
       exenv: 1.2.2
       react: 17.0.2
@@ -11778,7 +11799,7 @@ packages:
   /react-router-dom@5.2.0(react@17.0.2):
     resolution: {integrity: sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==}
     peerDependencies:
-      react: ^17.0.2 || 17
+      react: '>=15 || 17'
     dependencies:
       '@babel/runtime': 7.22.5
       history: 4.10.1
@@ -11793,7 +11814,7 @@ packages:
   /react-router-ga@1.2.3(react-router-dom@5.2.0)(react@17.0.2):
     resolution: {integrity: sha512-0rNBGGI6Q1hkznbLB+bAmDTS+8w3duaJYYIbCrCwof/p7RbZuv+Lsv9enumRZXxb4oTZrY95vOvFxnsRQ4cFCg==}
     peerDependencies:
-      react: ^17.0.2 || 17
+      react: ^16.8.6 || 17
       react-router-dom: ^5.0.0
     dependencies:
       react: 17.0.2
@@ -11803,7 +11824,7 @@ packages:
   /react-router@5.2.0(react@17.0.2):
     resolution: {integrity: sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==}
     peerDependencies:
-      react: ^17.0.2 || 17
+      react: '>=15 || 17'
     dependencies:
       '@babel/runtime': 7.22.5
       history: 4.10.1
@@ -11821,8 +11842,8 @@ packages:
   /react-scroll@1.8.2(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-f2ZEG5fsPbPTySI9ekcFpETCcNlqbmwbQj9hhzYK8tkgv+PA8APatSt66o/q0KSkDZxyT98ONTtXp9x0lyowEw==}
     peerDependencies:
-      react: ^17.0.2 || 17
-      react-dom: ^17.0.2 || 17
+      react: ^15.5.4 || ^16.0.0 || ^17.0.0 || 17
+      react-dom: ^15.5.4 || ^16.0.0 || ^17.0.0 || 17
     dependencies:
       lodash.throttle: 4.1.1
       prop-types: 15.8.1
@@ -11833,7 +11854,7 @@ packages:
   /react-shallow-renderer@16.14.1(react@17.0.2):
     resolution: {integrity: sha512-rkIMcQi01/+kxiTE9D3fdS959U1g7gs+/rborw++42m1O9FAQiNI/UNRZExVUoAOprn4umcXf+pFRou8i4zuBg==}
     peerDependencies:
-      react: ^17.0.2 || 17
+      react: ^16.0.0 || ^17.0.0 || 17
     dependencies:
       object-assign: 4.1.1
       react: 17.0.2
@@ -11843,7 +11864,7 @@ packages:
   /react-side-effect@1.2.0(react@17.0.2):
     resolution: {integrity: sha512-v1ht1aHg5k/thv56DRcjw+WtojuuDHFUgGfc+bFHOWsF4ZK6C2V57DO0Or0GPsg6+LSTE0M6Ry/gfzhzSwbc5w==}
     peerDependencies:
-      react: ^17.0.2 || 17
+      react: ^0.13.0 || ^0.14.0 || ^15.0.0 || ^16.0.0 || 17
     dependencies:
       react: 17.0.2
       shallowequal: 1.1.0
@@ -11851,7 +11872,7 @@ packages:
   /react-ssr-prepass@1.4.0(react@17.0.2):
     resolution: {integrity: sha512-0SzdmiQUtHvhxCabHg9BI/pkJfijGkQ0jQL6fC4YFy7idaDOuaiQLsajIkkNxffFXtJFHIWFITlve2WB88e0Jw==}
     peerDependencies:
-      react: ^17.0.2 || 17
+      react: ^16.8.0 || ^17.0.0 || 17
     dependencies:
       react: 17.0.2
     dev: true
@@ -11894,8 +11915,8 @@ packages:
   /react-static-plugin-styled-components@7.2.2(react@17.0.2)(styled-components@5.2.3):
     resolution: {integrity: sha512-yjZ2V5b4HLRs6ldbLmreXpXBiNU5y4IByPID/rYWe3J8NFenPMI7kbhiFlBDkUDEhJvGIpSFw3I8OCvAcm4yQg==}
     peerDependencies:
-      react: ^17.0.2 || 17
-      styled-components: ^5.2.3 || 5
+      react: ^16.9.0 || 17
+      styled-components: ^4.3.2 || 5
     dependencies:
       react: 17.0.2
       styled-components: 5.2.3(react-dom@17.0.2)(react-is@17.0.2)(react@17.0.2)
@@ -11992,7 +12013,7 @@ packages:
   /react-test-renderer@17.0.2(react@17.0.2):
     resolution: {integrity: sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==}
     peerDependencies:
-      react: ^17.0.2 || 17
+      react: 17.0.2 || 17
     dependencies:
       object-assign: 4.1.1
       react: 17.0.2
@@ -12004,7 +12025,7 @@ packages:
   /react-universal-component@4.5.0(react@17.0.2):
     resolution: {integrity: sha512-dBUC6afvSAQhDcE4oh1eTmfU29W0O2eZhcGXnfGUTulXkU8ejuWqlJWXXrSMx5iV1H6LNgj2NJMj3BtBMfBNhA==}
     peerDependencies:
-      react: ^17.0.2 || 17
+      react: ^16.3.0 || ^17.0.0 || 17
     dependencies:
       hoist-non-react-statics: 3.3.2
       prop-types: 15.8.1
@@ -12663,6 +12684,11 @@ packages:
     resolution: {integrity: sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==}
     dependencies:
       node-forge: 0.10.0
+
+  /semiver@1.1.0:
+    resolution: {integrity: sha512-QNI2ChmuioGC1/xjyYwyZYADILWyW6AmS1UH6gDj/SFUUUS4MBAWs/7mxnkRPc/F4iHezDP+O8t0dO8WHiEOdg==}
+    engines: {node: '>=6'}
+    dev: true
 
   /semver-compare@1.0.0:
     resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
@@ -13500,9 +13526,9 @@ packages:
     resolution: {integrity: sha512-BlR+KrLW3NL1yhvEB+9Nu9Dt51CuOnHoxd+Hj+rYPdtyR8X11uIW9rvhpy3Dk4dXXBsiW1u5U78f00Lf/afGoA==}
     engines: {node: '>=10'}
     peerDependencies:
-      react: ^17.0.2 || 17
-      react-dom: ^17.0.2 || 17
-      react-is: ^17.0.2 || 17
+      react: '>= 16.8.0 || 17'
+      react-dom: '>= 16.8.0 || 17'
+      react-is: '>= 16.8.0 || 17'
     dependencies:
       '@babel/helper-module-imports': 7.21.4
       '@babel/traverse': 7.21.5(supports-color@5.5.0)
@@ -13524,7 +13550,7 @@ packages:
     peerDependencies:
       '@babel/core': '*'
       babel-plugin-macros: '*'
-      react: ^17.0.2 || 17
+      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0 || 17'
     peerDependenciesMeta:
       '@babel/core':
         optional: true
@@ -14427,7 +14453,7 @@ packages:
   /use-sync-external-store@1.2.0(react@17.0.2):
     resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
     peerDependencies:
-      react: ^17.0.2 || 17
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || 17
     dependencies:
       react: 17.0.2
     dev: true
@@ -14565,7 +14591,7 @@ packages:
   /vite-tsconfig-paths@4.2.0(typescript@5.1.6)(vite@3.2.5):
     resolution: {integrity: sha512-jGpus0eUy5qbbMVGiTxCL1iB9ZGN6Bd37VGLJU39kTDD6ZfULTTb1bcc5IeTWqWJKiWV5YihCaibeASPiGi8kw==}
     peerDependencies:
-      vite: ^3.2.4
+      vite: '*'
     peerDependenciesMeta:
       vite:
         optional: true
@@ -14845,7 +14871,7 @@ packages:
   /webpack-flush-chunks@2.0.3(react@17.0.2):
     resolution: {integrity: sha512-CXGOyXG5YjjxyI+Qyt3VlI//JX92UmGRNP65zN3o9CIntEzfzc1J30YTKRRvF1JsE/iEzbnp5u99yCkL9obotQ==}
     peerDependencies:
-      react: ^17.0.2 || 17
+      react: '*'
     dependencies:
       react: 17.0.2
 

--- a/scripts/changesets/jsr.mjs
+++ b/scripts/changesets/jsr.mjs
@@ -9,18 +9,19 @@ import {
 } from '../actions/lib/packages.mjs';
 
 const getExports = (exports) => {
-  return Object.keys(exports).reduce((acc, item) => {
-    if (item.includes('package.json')) return acc;
-
-    const exp = exports[item];
-    return { ...acc, [item]: exp.source }
-  })
+  const exportNames = Object.keys(exports);
+  const eventualExports = {};
+  for (const exportName of exportNames) {
+    if (exportName.includes('package.json')) continue;
+    const exp = exports[exportName];
+    eventualExports[exportName] = exp.source;
+  }
+  return eventualExports;
 }
 
 export const updateJsr = async () => {
   (await listPackages()).forEach((dir) => {
     const manifest = getPackageManifest(dir);
-
     const jsrManifest = {
       name: manifest.name,
       version: manifest.version,
@@ -31,4 +32,3 @@ export const updateJsr = async () => {
     fs.writeFileSync(path.resolve(dir, 'jsr.json'), JSON.stringify(jsrManifest, undefined, 2));
   });
 }
-

--- a/scripts/changesets/jsr.mjs
+++ b/scripts/changesets/jsr.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  getPackageManifest,
+  listPackages
+} from '../actions/lib/packages.mjs';
+
+const getExports = (exports) => {
+  return Object.keys(exports).reduce((acc, item) => {
+    if (item.includes('package.json')) return acc;
+
+    const exp = exports[item];
+    return { ...acc, [item]: exp.source }
+  })
+}
+
+export const updateJsr = async () => {
+  (await listPackages()).forEach((dir) => {
+    const manifest = getPackageManifest(dir);
+
+    const jsrManifest = {
+      name: manifest.name,
+      version: manifest.version,
+      exports: manifest.exports ? getExports(manifest.exports) : manifest.source,
+      exclude: ['node_modules', 'cypress']
+    }
+
+    fs.writeFileSync(path.resolve(dir, 'jsr.json'), JSON.stringify(jsrManifest, undefined, 2));
+  });
+}
+

--- a/scripts/changesets/jsr.mjs
+++ b/scripts/changesets/jsr.mjs
@@ -3,12 +3,9 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import {
-  getPackageManifest,
-  listPackages
-} from '../actions/lib/packages.mjs';
+import { getPackageManifest, listPackages } from '../actions/lib/packages.mjs';
 
-const getExports = (exports) => {
+const getExports = exports => {
   const exportNames = Object.keys(exports);
   const eventualExports = {};
   for (const exportName of exportNames) {
@@ -17,18 +14,30 @@ const getExports = (exports) => {
     eventualExports[exportName] = exp.source;
   }
   return eventualExports;
-}
+};
 
 export const updateJsr = async () => {
-  (await listPackages()).forEach((dir) => {
+  (await listPackages()).forEach(dir => {
     const manifest = getPackageManifest(dir);
     const jsrManifest = {
       name: manifest.name,
       version: manifest.version,
-      exports: manifest.exports ? getExports(manifest.exports) : manifest.source,
-      exclude: ['node_modules', 'cypress']
-    }
+      exports: manifest.exports
+        ? getExports(manifest.exports)
+        : manifest.source,
+      exclude: [
+        'node_modules',
+        'cypress',
+        '**/*.test.*',
+        '**/*.spec.*',
+        '**/*.test.*.snap',
+        '**/*.spec.*.snap',
+      ],
+    };
 
-    fs.writeFileSync(path.resolve(dir, 'jsr.json'), JSON.stringify(jsrManifest, undefined, 2));
+    fs.writeFileSync(
+      path.resolve(dir, 'jsr.json'),
+      JSON.stringify(jsrManifest, undefined, 2)
+    );
   });
-}
+};

--- a/scripts/changesets/version.mjs
+++ b/scripts/changesets/version.mjs
@@ -6,9 +6,9 @@ import { execa } from 'execa';
 import {
   getPackageManifest,
   updatePackageManifest,
-  listPackages
+  listPackages,
 } from '../actions/lib/packages.mjs';
-import { updateJsr } from './jsr.mjs'
+import { updateJsr } from './jsr.mjs';
 
 const versionRe = /^\d+\.\d+\.\d+/i;
 const execaOpts = { stdio: 'inherit' };

--- a/scripts/changesets/version.mjs
+++ b/scripts/changesets/version.mjs
@@ -8,6 +8,7 @@ import {
   updatePackageManifest,
   listPackages
 } from '../actions/lib/packages.mjs';
+import { updateJsr } from './jsr.mjs'
 
 const versionRe = /^\d+\.\d+\.\d+/i;
 const execaOpts = { stdio: 'inherit' };
@@ -60,3 +61,5 @@ for (const example of examples) {
 
   await updatePackageManifest(example, manifest);
 }
+
+await updateJsr();


### PR DESCRIPTION
## Summary

This adds a publishing pipeline to [jsr](https://jsr.io/), for now it will only publish `@urql/core` because we have a lot of "slow types" where it doesn't infer from the generic or is implicit. I'd solve these one by one rather than creating one big PR. The PR already adds the infrastructure in each workspace to publish to JSR by means of the `jsr.json` file. This also adds a new script during versioning where it will bump all the `jsr` packages.

A point for improvement that I'm considering in scope of this PR is a transformation script for our TS codebase where we transform all the `process.env.NODE_ENV` to `import.meta.env.NODE_ENV` or we strip it out. Not doing so will cut out deno support for a while, supporting both Deno as well as Node in JSR would require `globalThis.Deno?.env.get("NODE_ENV") || process.env.NODE_ENV`. I think with regards to https://github.com/graphql/graphql-js/issues/4075 it might be a good idea to transform our ESM bundles to `import.meta.env` sometime either way.

Currently we do not support canaries on jsr.

TODO

- [x] add dry run step to the PR so we know when slow types are added
- [x] release the current version by adding it to the PR workflow for a bit