### PR TITLE
fix(core): Use documentId for operation hash if it's available

### DIFF
--- a/.changeset/forty-walls-hug.md
+++ b/.changeset/forty-walls-hug.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Use `documentId` from persisted documents for document keys, when it's available.

--- a/packages/core/src/utils/request.test.ts
+++ b/packages/core/src/utils/request.test.ts
@@ -81,6 +81,16 @@ describe('createRequest', () => {
       variables: { test: 5 },
     });
   });
+
+  it('should hash persisted documents consistently', () => {
+    const doc = parse('{ testG }');
+    const docPersisted = parse('{ testG }');
+    (docPersisted as any).documentId = 'testG';
+
+    const req = createRequest(doc, undefined);
+    const reqPersisted = createRequest(docPersisted, undefined);
+    expect(req.key).not.toBe(reqPersisted.key);
+  });
 });
 
 describe('stringifyDocument ', () => {

--- a/packages/core/src/utils/request.ts
+++ b/packages/core/src/utils/request.ts
@@ -12,6 +12,10 @@ import type {
   RequestExtensions,
 } from '../types';
 
+type PersistedDocumentNode = TypedDocumentNode & {
+  documentId?: string;
+};
+
 /** A `DocumentNode` annotated with its hashed key.
  * @internal
  */
@@ -90,11 +94,16 @@ export const stringifyDocument = (
 const hashDocument = (
   node: string | DefinitionNode | DocumentNode
 ): HashValue => {
-  let key = phash(stringifyDocument(node));
-  // Add the operation name to the produced hash
-  if ((node as DocumentNode).definitions) {
-    const operationName = getOperationName(node as DocumentNode);
-    if (operationName) key = phash(`\n# ${operationName}`, key);
+  let key: HashValue;
+  if ((node as PersistedDocumentNode).documentId) {
+    key = phash((node as PersistedDocumentNode).documentId!);
+  } else {
+    key = phash(stringifyDocument(node));
+    // Add the operation name to the produced hash
+    if ((node as DocumentNode).definitions) {
+      const operationName = getOperationName(node as DocumentNode);
+      if (operationName) key = phash(`\n# ${operationName}`, key);
+    }
   }
   return key;
 };


### PR DESCRIPTION
## Summary

When persisted documents have hidden definitions (i.e. `definitions: []`), but have a `documentId`, we'd generate identical keys for all of these documents.

Instead, we should always use `documentId` to create a request key when it's available.

## Set of changes

- Use `documentId` in `hashDocument`
