### PR TITLE
patch: Mark `@urql/core` as a peer as well as a regular dependency

### DIFF
--- a/.changeset/two-hounds-yell.md
+++ b/.changeset/two-hounds-yell.md
@@ -1,0 +1,18 @@
+---
+'@urql/exchange-request-policy': minor
+'@urql/introspection': minor
+'@urql/exchange-graphcache': minor
+'@urql/preact': minor
+'@urql/svelte': minor
+'@urql/exchange-persisted': minor
+'urql': minor
+'@urql/exchange-populate': minor
+'@urql/exchange-context': minor
+'@urql/exchange-execute': minor
+'@urql/exchange-refocus': minor
+'@urql/vue': minor
+'@urql/exchange-retry': minor
+'@urql/exchange-auth': minor
+---
+
+Mark `@urql/core` as a peer dependency as well as a regular dependency.

--- a/exchanges/auth/package.json
+++ b/exchanges/auth/package.json
@@ -48,8 +48,11 @@
     "prepare": "node ../../scripts/prepare/index.js",
     "prepublishOnly": "run-s clean build"
   },
+  "peerDependencies": {
+    "@urql/core": "^5.0.0"
+  },
   "dependencies": {
-    "@urql/core": ">=5.0.0",
+    "@urql/core": "^5.0.0",
     "wonka": "^6.3.2"
   },
   "devDependencies": {

--- a/exchanges/context/package.json
+++ b/exchanges/context/package.json
@@ -47,8 +47,11 @@
     "prepare": "node ../../scripts/prepare/index.js",
     "prepublishOnly": "run-s clean build"
   },
+  "peerDependencies": {
+    "@urql/core": "^5.0.0"
+  },
   "dependencies": {
-    "@urql/core": ">=5.0.0",
+    "@urql/core": "^5.0.0",
     "wonka": "^6.3.2"
   },
   "devDependencies": {

--- a/exchanges/execute/package.json
+++ b/exchanges/execute/package.json
@@ -49,11 +49,12 @@
     "prepublishOnly": "run-s clean build"
   },
   "dependencies": {
-    "@urql/core": ">=5.0.0",
+    "@urql/core": "^5.0.0",
     "wonka": "^6.3.2"
   },
   "peerDependencies": {
-    "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+    "@urql/core": "^5.0.0",
+    "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
   },
   "devDependencies": {
     "@urql/core": "workspace:*",

--- a/exchanges/graphcache/package.json
+++ b/exchanges/graphcache/package.json
@@ -62,9 +62,12 @@
     "prepare": "node ../../scripts/prepare/index.js",
     "prepublishOnly": "run-s clean build"
   },
+  "peerDependencies": {
+    "@urql/core": "^5.0.0"
+  },
   "dependencies": {
     "@0no-co/graphql.web": "^1.0.5",
-    "@urql/core": ">=5.0.0",
+    "@urql/core": "^5.0.0",
     "wonka": "^6.3.2"
   },
   "devDependencies": {

--- a/exchanges/persisted/package.json
+++ b/exchanges/persisted/package.json
@@ -46,8 +46,11 @@
     "prepare": "node ../../scripts/prepare/index.js",
     "prepublishOnly": "run-s clean build"
   },
+  "peerDependencies": {
+    "@urql/core": "^5.0.0"
+  },
   "dependencies": {
-    "@urql/core": ">=5.0.0",
+    "@urql/core": "^5.0.0",
     "wonka": "^6.3.2"
   },
   "devDependencies": {

--- a/exchanges/populate/package.json
+++ b/exchanges/populate/package.json
@@ -47,11 +47,12 @@
     "prepublishOnly": "run-s clean build"
   },
   "dependencies": {
-    "@urql/core": ">=5.0.0",
+    "@urql/core": "^5.0.0",
     "wonka": "^6.3.2"
   },
   "peerDependencies": {
-    "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+    "@urql/core": "^5.0.0",
+    "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
   },
   "devDependencies": {
     "@urql/core": "workspace:*",

--- a/exchanges/refocus/package.json
+++ b/exchanges/refocus/package.json
@@ -53,8 +53,11 @@
     "@types/react": "^17.0.4",
     "graphql": "^16.0.0"
   },
+  "peerDependencies": {
+    "@urql/core": "^5.0.0"
+  },
   "dependencies": {
-    "@urql/core": ">=5.0.0",
+    "@urql/core": "^5.0.0",
     "wonka": "^6.3.2"
   },
   "publishConfig": {

--- a/exchanges/request-policy/package.json
+++ b/exchanges/request-policy/package.json
@@ -51,8 +51,11 @@
     "@urql/core": "workspace:*",
     "graphql": "^16.0.0"
   },
+  "peerDependencies": {
+    "@urql/core": "^5.0.0"
+  },
   "dependencies": {
-    "@urql/core": ">=5.0.0",
+    "@urql/core": "^5.0.0",
     "wonka": "^6.3.2"
   },
   "publishConfig": {

--- a/exchanges/retry/package.json
+++ b/exchanges/retry/package.json
@@ -51,8 +51,11 @@
     "@urql/core": "workspace:*",
     "graphql": "^16.0.0"
   },
+  "peerDependencies": {
+    "@urql/core": "^5.0.0"
+  },
   "dependencies": {
-    "@urql/core": ">=5.0.0",
+    "@urql/core": "^5.0.0",
     "wonka": "^6.3.2"
   },
   "publishConfig": {

--- a/packages/introspection/package.json
+++ b/packages/introspection/package.json
@@ -49,7 +49,7 @@
     "graphql": "^16.0.0"
   },
   "peerDependencies": {
-    "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+    "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
   },
   "dependencies": {},
   "publishConfig": {

--- a/packages/preact-urql/package.json
+++ b/packages/preact-urql/package.json
@@ -55,6 +55,7 @@
     "preact": "^10.13.0"
   },
   "peerDependencies": {
+    "@urql/core": "^5.0.0",
     "preact": ">= 10.0.0"
   },
   "dependencies": {

--- a/packages/react-urql/package.json
+++ b/packages/react-urql/package.json
@@ -58,6 +58,7 @@
     "vite": "^3.2.4"
   },
   "peerDependencies": {
+    "@urql/core": "^5.0.0",
     "react": ">= 16.8.0"
   },
   "dependencies": {

--- a/packages/svelte-urql/package.json
+++ b/packages/svelte-urql/package.json
@@ -49,6 +49,7 @@
     "prepublishOnly": "run-s clean build"
   },
   "peerDependencies": {
+    "@urql/core": "^5.0.0",
     "svelte": "^3.0.0 || ^4.0.0"
   },
   "dependencies": {

--- a/packages/vue-urql/package.json
+++ b/packages/vue-urql/package.json
@@ -55,6 +55,7 @@
     "vue": "^3.2.47"
   },
   "peerDependencies": {
+    "@urql/core": "^5.0.0",
     "vue": "^2.7.0 || ^3.0.0"
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,7 +182,7 @@ importers:
   exchanges/auth:
     dependencies:
       '@urql/core':
-        specifier: '>=5.0.0'
+        specifier: ^5.0.0
         version: link:../../packages/core
       wonka:
         specifier: ^6.3.2
@@ -195,7 +195,7 @@ importers:
   exchanges/context:
     dependencies:
       '@urql/core':
-        specifier: '>=5.0.0'
+        specifier: ^5.0.0
         version: link:../../packages/core
       wonka:
         specifier: ^6.3.2
@@ -208,7 +208,7 @@ importers:
   exchanges/execute:
     dependencies:
       '@urql/core':
-        specifier: '>=5.0.0'
+        specifier: ^5.0.0
         version: link:../../packages/core
       wonka:
         specifier: ^6.3.2
@@ -224,7 +224,7 @@ importers:
         specifier: ^1.0.5
         version: 1.0.5(graphql@16.6.0)
       '@urql/core':
-        specifier: '>=5.0.0'
+        specifier: ^5.0.0
         version: link:../../packages/core
       wonka:
         specifier: ^6.3.2
@@ -258,7 +258,7 @@ importers:
   exchanges/persisted:
     dependencies:
       '@urql/core':
-        specifier: '>=5.0.0'
+        specifier: ^5.0.0
         version: link:../../packages/core
       wonka:
         specifier: ^6.3.2
@@ -271,7 +271,7 @@ importers:
   exchanges/populate:
     dependencies:
       '@urql/core':
-        specifier: '>=5.0.0'
+        specifier: ^5.0.0
         version: link:../../packages/core
       wonka:
         specifier: ^6.3.2
@@ -284,7 +284,7 @@ importers:
   exchanges/refocus:
     dependencies:
       '@urql/core':
-        specifier: '>=5.0.0'
+        specifier: ^5.0.0
         version: link:../../packages/core
       wonka:
         specifier: ^6.3.2
@@ -300,7 +300,7 @@ importers:
   exchanges/request-policy:
     dependencies:
       '@urql/core':
-        specifier: '>=5.0.0'
+        specifier: ^5.0.0
         version: link:../../packages/core
       wonka:
         specifier: ^6.3.2
@@ -313,7 +313,7 @@ importers:
   exchanges/retry:
     dependencies:
       '@urql/core':
-        specifier: '>=5.0.0'
+        specifier: ^5.0.0
         version: link:../../packages/core
       wonka:
         specifier: ^6.3.2

--- a/scripts/prepare/index.js
+++ b/scripts/prepare/index.js
@@ -97,6 +97,28 @@ invariant(
   'package.json:files must include "dist" and "LICENSE"'
 );
 
+if (pkg.dependencies && pkg.dependencies['@urql/core']) {
+  invariant(
+    !!pkg.peerDependencies && !!pkg.peerDependencies['@urql/core'],
+    'package.json:peerDependencies must contain @urql/core.'
+  );
+}
+
+if (pkg.peerDependencies && pkg.peerDependencies['@urql/core']) {
+  invariant(
+    !!pkg.dependencies && !!pkg.dependencies['@urql/core'],
+    'package.json:dependencies must contain @urql/core.'
+  );
+}
+
+for (const key in pkg.peerDependencies || {}) {
+  const dependency = pkg.peerDependencies[key];
+  invariant(
+    key !== 'react' || key !== 'preact' || !dependency.includes('>='),
+    `Peer Dependency "${key}" must not contain ">=" (greater than) range`
+  );
+}
+
 if (hasReact && !hasNext) {
   invariant(
     !pkg.exports,


### PR DESCRIPTION
## Context

Originally (I reckon during the introduction of `@urql/core`), we decided to only include `@urql/core` as a dependency, since it never is a direct dependency. This allowed it to install automatically and deduplicate as long as all ranges match.

This wasn't ever a problem assuming deduplication was working (which it sometimes isn't in Yarn Legacy). However, `@urql/core` is only actively instantiated once in any given app. This means that for all exchanges it's only used to share types.

Problems with this is though, `@urql/core`'s types contain instances that TypeScript will always consider as incompatible if they're duplicated. This means that this approach stopped working for TypeScript.

## Summary

While we could provide shared global namespace types in `@urql/core`, which is my alternative proposal to solve this, we can also mark all dependencies on `@urql/core` as peer dependencies now.

Generally, peer dependencies install automatically with all package managers these days. But to keep backwards compatibility we can also keep `@urql/core` in `dependencies` at the same time. This should simply prompt package managers to always deduplicate it.

This PR also removes the `>=` range on it (although it's perfectly safe, this allows us to revamp some APIs in the next major of `@urql/core`), and updates the `graphql` peer dependency

## Set of changes

- Update prepare script
- Update `@urql/core` dependencies to also be accompanied by a peer dependency
- Update `@urql/core` ranges to `^5.0.0`
- Update `graphql` ranges to `^15.0.0 || ^16.0.0 || ^17.0.0` (dropping `0.x` ranges for peers)
  - Not a breaking change, since the update is explicitly minor and support hasn't technically changed, so overriding this is safe
