### PR TITLE
fix(bindings): Fix handlers for subscriptions receiving null

### DIFF
--- a/.changeset/famous-deers-marry.md
+++ b/.changeset/famous-deers-marry.md
@@ -1,0 +1,8 @@
+---
+'@urql/preact': patch
+'@urql/svelte': patch
+'urql': patch
+'@urql/vue': patch
+---
+
+Fix subscription handlers to not receive `null` values.

--- a/packages/preact-urql/src/hooks/useSubscription.ts
+++ b/packages/preact-urql/src/hooks/useSubscription.ts
@@ -282,7 +282,7 @@ export function useSubscription<
               const { current: handler } = handlerRef;
               // If a handler has been passed, it's used to merge new data in
               const data =
-                partial.data !== undefined
+                partial.data != null
                   ? typeof handler === 'function'
                     ? handler(result.data, partial.data)
                     : partial.data

--- a/packages/react-urql/src/hooks/useSubscription.ts
+++ b/packages/react-urql/src/hooks/useSubscription.ts
@@ -266,10 +266,14 @@ export function useSubscription<
       deferDispatch(setState, state => {
         const nextResult = computeNextState(state[1], result);
         if (state[1] === nextResult) return state;
-        if (handlerRef.current && state[1].data !== nextResult.data) {
+        if (
+          handlerRef.current &&
+          nextResult.data != null &&
+          state[1].data !== nextResult.data
+        ) {
           nextResult.data = handlerRef.current(
             state[1].data,
-            nextResult.data!
+            nextResult.data
           ) as any;
         }
 

--- a/packages/svelte-urql/src/subscriptionStore.ts
+++ b/packages/svelte-urql/src/subscriptionStore.ts
@@ -183,7 +183,7 @@ export function subscriptionStore<
       ),
       scan((result: OperationResultState<Result, Variables>, partial) => {
         const data =
-          partial.data !== undefined
+          partial.data != null
             ? typeof handler === 'function'
               ? handler(result.data, partial.data)
               : partial.data

--- a/packages/vue-urql/src/useSubscription.ts
+++ b/packages/vue-urql/src/useSubscription.ts
@@ -306,9 +306,9 @@ export function callUseSubscription<
             subscribe(result => {
               fetching.value = true;
               data.value =
-                result.data !== undefined
+                result.data != null
                   ? typeof scanHandler.value === 'function'
-                    ? scanHandler.value(data.value as any, result.data!)
+                    ? scanHandler.value(data.value as any, result.data)
                     : result.data
                   : (result.data as any);
               error.value = result.error;


### PR DESCRIPTION
## Summary

> [!NOTE]
> Reported on Discord

The subscription handlers infer their new value argument type as `T` of `OperationResult<T>`. This means that `data: null` cases are uncovered and the handler may accidentally receive `null` values when the types specify that this isn't possible.

This may happen when a trailing value of a subscription contains a fatal error rather than a result value.

In this case it should be safe to ignore the value, since the subscription will either be restarted by the subscription client (or a `retryExchange`), or will terminate.

## Set of changes

- Handle `null` values before passing `result.data` to subscription handlers
