### PR TITLE
fix(vue): Support getter-functions on `MaybeRef`-typed inputs

### DIFF
--- a/.changeset/itchy-cups-remember.md
+++ b/.changeset/itchy-cups-remember.md
@@ -1,0 +1,5 @@
+---
+'@urql/vue': patch
+---
+
+Add missing support for getter functions as input arguments values to `useQuery`, `useSubscription`, and `useMutation`

--- a/packages/vue-urql/src/useMutation.ts
+++ b/packages/vue-urql/src/useMutation.ts
@@ -17,7 +17,8 @@ import type {
 import { createRequest } from '@urql/core';
 
 import { useClient } from './useClient';
-import { unwrapPossibleProxy } from './utils';
+import type { MaybeRef } from './utils';
+import { unref } from './utils';
 
 /** State of the last mutation executed by {@link useMutation}.
  *
@@ -131,7 +132,7 @@ export function useMutation<T = any, V extends AnyVariables = AnyVariables>(
 }
 
 export function callUseMutation<T = any, V extends AnyVariables = AnyVariables>(
-  query: TypedDocumentNode<T, V> | DocumentNode | string,
+  query: MaybeRef<TypedDocumentNode<T, V> | DocumentNode | string>,
   client: Ref<Client> = useClient()
 ): UseMutationResponse<T, V> {
   const data: Ref<T | undefined> = ref();
@@ -156,7 +157,7 @@ export function callUseMutation<T = any, V extends AnyVariables = AnyVariables>(
 
       return pipe(
         client.value.executeMutation<T, V>(
-          createRequest<T, V>(query, unwrapPossibleProxy(variables)),
+          createRequest<T, V>(unref(query), unref(variables)),
           context || {}
         ),
         onPush(result => {

--- a/packages/vue-urql/src/utils.ts
+++ b/packages/vue-urql/src/utils.ts
@@ -2,11 +2,15 @@ import type { GraphQLRequest, AnyVariables } from '@urql/core';
 import type { Ref, ShallowRef } from 'vue';
 import { isRef } from 'vue';
 
-export function unwrapPossibleProxy<V>(possibleProxy: V | Ref<V>): V {
-  return possibleProxy && isRef(possibleProxy)
-    ? possibleProxy.value
-    : possibleProxy;
-}
+export type MaybeRef<T> = T | (() => T) | Ref<T>;
+export type MaybeRefObj<T extends {}> = { [K in keyof T]: MaybeRef<T[K]> };
+
+export const unref = <T>(maybeRef: MaybeRef<T>): T =>
+  typeof maybeRef === 'function'
+    ? (maybeRef as () => T)()
+    : maybeRef != null && isRef(maybeRef)
+    ? maybeRef.value
+    : maybeRef;
 
 export interface RequestState<
   Data = any,


### PR DESCRIPTION
Resolves #3556

## Summary

Supports getter functions on `MaybeRef`-typed inputs.

## Set of changes

- Add `(() => T)` to `MaybeRef` and handle in `unref`
