### PR TITLE
update docs on composeExchanges

### DIFF
--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -511,7 +511,7 @@ This utility is used by the [`cacheExchange`](#cacheexchange) and by
 ### composeExchanges
 
 This utility accepts an array of `Exchange`s and composes them into a single one.
-It chains them in the order that they're given, left to right.
+It chains them in the order that they're given, right to left.
 
 ```js
 function composeExchanges(Exchange[]): Exchange;


### PR DESCRIPTION
The code and code-docs says its right to left (and tested it locally, it is right left) but the official docs says its left to right

Helpful links:

- https://github.com/urql-graphql/urql/blob/88bed21c015dc673d900bf1a806e43ccb2900879/packages/core/src/exchanges/compose.ts#L12
- https://github.com/urql-graphql/urql/commit/e6710d29ed426df9d21d9d9daa18ca182647db53
- https://commerce.nearform.com/open-source/urql/docs/api/core/#composeexchanges
- 

## Summary

I was using composeExchanges. Read official docs but it works in the opposite direction.

## Set of changes

Update docs
