### PR TITLE
chore: change `global` -> `globalThis` in tests

### DIFF
--- a/exchanges/execute/src/execute.test.ts
+++ b/exchanges/execute/src/execute.test.ts
@@ -47,7 +47,7 @@ const exchangeArgs = {
 const expectedQueryOperationName = 'getUser';
 const expectedSubscribeOperationName = 'subscribeToUser';
 
-const fetchMock = (global as any).fetch as Mock;
+const fetchMock = (globalThis as any).fetch as Mock;
 const mockHttpResponseData = { key: 'value' };
 
 beforeEach(() => {

--- a/exchanges/graphcache/src/offlineExchange.test.ts
+++ b/exchanges/graphcache/src/offlineExchange.test.ts
@@ -105,11 +105,11 @@ describe('storage', () => {
 describe('offline', () => {
   beforeAll(() => {
     vi.resetAllMocks();
-    global.navigator = { onLine: true } as any;
+    globalThis.navigator = { onLine: true } as any;
   });
 
   it('should intercept errored mutations', () => {
-    const onlineSpy = vi.spyOn(navigator, 'onLine', 'get');
+    const onlineSpy = vi.spyOn(globalThis.navigator, 'onLine', 'get');
 
     const client = createClient({
       url: 'http://0.0.0.0',

--- a/packages/core/src/exchanges/debug.test.ts
+++ b/packages/core/src/exchanges/debug.test.ts
@@ -29,7 +29,7 @@ beforeEach(() => {
 });
 
 it('forwards query operations correctly', async () => {
-  vi.spyOn(global.console, 'log').mockImplementation(() => {
+  vi.spyOn(globalThis.console, 'log').mockImplementation(() => {
     /** Do NOthing */
   });
   const { source: ops$, next, complete } = input;

--- a/packages/core/src/exchanges/fetch.test.ts
+++ b/packages/core/src/exchanges/fetch.test.ts
@@ -17,14 +17,14 @@ import { queryOperation } from '../test-utils';
 import { OperationResult } from '../types';
 import { fetchExchange } from './fetch';
 
-const fetch = (global as any).fetch as Mock;
+const fetch = (globalThis as any).fetch as Mock;
 const abort = vi.fn();
 
 const abortError = new Error();
 abortError.name = 'AbortError';
 
 beforeAll(() => {
-  (global as any).AbortController = function AbortController() {
+  (globalThis as any).AbortController = function AbortController() {
     this.signal = undefined;
     this.abort = abort;
   };
@@ -36,7 +36,7 @@ afterEach(() => {
 });
 
 afterAll(() => {
-  (global as any).AbortController = undefined;
+  (globalThis as any).AbortController = undefined;
 });
 
 const response = JSON.stringify({

--- a/packages/core/src/internal/fetchSource.test.ts
+++ b/packages/core/src/internal/fetchSource.test.ts
@@ -16,11 +16,11 @@ import { gql } from '../gql';
 import { OperationResult, Operation } from '../types';
 import { makeOperation } from '../utils';
 
-const fetch = (global as any).fetch as Mock;
+const fetch = (globalThis as any).fetch as Mock;
 const abort = vi.fn();
 
 beforeAll(() => {
-  (global as any).AbortController = function AbortController() {
+  (globalThis as any).AbortController = function AbortController() {
     this.signal = undefined;
     this.abort = abort;
   };
@@ -32,7 +32,7 @@ beforeEach(() => {
 });
 
 afterAll(() => {
-  (global as any).AbortController = undefined;
+  (globalThis as any).AbortController = undefined;
 });
 
 const response = JSON.stringify({

--- a/packages/core/src/utils/variables.test.ts
+++ b/packages/core/src/utils/variables.test.ts
@@ -68,14 +68,14 @@ describe('stringifyVariables', () => {
   });
 
   it('stringifies plain objects from foreign JS contexts correctly', () => {
-    const global: typeof globalThis = new Script(
+    const scriptGlobal: typeof globalThis = new Script(
       'exports = globalThis'
     ).runInNewContext({}).exports;
 
-    const plain = new global.Function('return { test: true }')();
+    const plain = new scriptGlobal.Function('return { test: true }')();
     expect(stringifyVariables(plain)).toBe('{"test":true}');
 
-    const data = new global.Function('return new (class Test {})')();
+    const data = new scriptGlobal.Function('return new (class Test {})')();
     expect(stringifyVariables(data)).toMatch(/^{"__key":"\w+"}$/);
   });
 });

--- a/packages/preact-urql/src/components/Mutation.test.tsx
+++ b/packages/preact-urql/src/components/Mutation.test.tsx
@@ -20,7 +20,7 @@ describe('Mutation', () => {
   beforeEach(() => {
     vi.useFakeTimers();
 
-    vi.spyOn(global.console, 'error').mockImplementation(() => {
+    vi.spyOn(globalThis.console, 'error').mockImplementation(() => {
       // do nothing
     });
   });

--- a/packages/preact-urql/src/components/Query.test.tsx
+++ b/packages/preact-urql/src/components/Query.test.tsx
@@ -24,7 +24,7 @@ const client = {
 
 describe('Query', () => {
   beforeEach(() => {
-    vi.spyOn(global.console, 'error').mockImplementation(() => {
+    vi.spyOn(globalThis.console, 'error').mockImplementation(() => {
       // do nothing
     });
   });

--- a/packages/preact-urql/src/components/Subscription.test.tsx
+++ b/packages/preact-urql/src/components/Subscription.test.tsx
@@ -21,7 +21,7 @@ const client = {
 describe('Subscription', () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    vi.spyOn(global.console, 'error').mockImplementation(() => {
+    vi.spyOn(globalThis.console, 'error').mockImplementation(() => {
       // do nothing
     });
   });

--- a/packages/preact-urql/src/hooks/useMutation.test.tsx
+++ b/packages/preact-urql/src/hooks/useMutation.test.tsx
@@ -39,7 +39,7 @@ const MutationUser: FC<typeof props> = ({ query }) => {
 };
 
 beforeAll(() => {
-  vi.spyOn(global.console, 'error').mockImplementation(() => {
+  vi.spyOn(globalThis.console, 'error').mockImplementation(() => {
     // do nothing
   });
 });

--- a/packages/preact-urql/src/hooks/useQuery.test.tsx
+++ b/packages/preact-urql/src/hooks/useQuery.test.tsx
@@ -42,7 +42,7 @@ const QueryUser: FC<UseQueryArgs<{ myVar: number }>> = ({
 
 beforeEach(() => {
   vi.useFakeTimers();
-  vi.spyOn(global.console, 'error');
+  vi.spyOn(globalThis.console, 'error');
 });
 
 describe('useQuery', () => {

--- a/packages/preact-urql/src/hooks/useSubscription.test.tsx
+++ b/packages/preact-urql/src/hooks/useSubscription.test.tsx
@@ -41,7 +41,7 @@ const SubscriptionUser: FC<{
 };
 
 beforeAll(() => {
-  vi.spyOn(global.console, 'error').mockImplementation(() => {
+  vi.spyOn(globalThis.console, 'error').mockImplementation(() => {
     // do nothing
   });
 });

--- a/packages/react-urql/src/components/Mutation.test.tsx
+++ b/packages/react-urql/src/components/Mutation.test.tsx
@@ -31,7 +31,7 @@ describe('Mutation', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     // TODO: Fix use of act()
-    vi.spyOn(global.console, 'error').mockImplementation(() => {
+    vi.spyOn(globalThis.console, 'error').mockImplementation(() => {
       // do nothing
     });
   });

--- a/packages/react-urql/src/components/Query.test.tsx
+++ b/packages/react-urql/src/components/Query.test.tsx
@@ -34,7 +34,7 @@ const variables = {
 describe('Query', () => {
   beforeEach(() => {
     // TODO: Fix use of act()
-    vi.spyOn(global.console, 'error').mockImplementation(() => {
+    vi.spyOn(globalThis.console, 'error').mockImplementation(() => {
       // do nothing
     });
   });

--- a/packages/react-urql/src/hooks/useMutation.test.tsx
+++ b/packages/react-urql/src/hooks/useMutation.test.tsx
@@ -45,7 +45,7 @@ const MutationUser = ({ query }: { query: any }) => {
 beforeEach(() => {
   vi.useFakeTimers();
 
-  vi.spyOn(global.console, 'error').mockImplementation(() => {
+  vi.spyOn(globalThis.console, 'error').mockImplementation(() => {
     // do nothing
   });
 

--- a/packages/react-urql/src/hooks/useQuery.spec.ts
+++ b/packages/react-urql/src/hooks/useQuery.spec.ts
@@ -41,7 +41,7 @@ const mockVariables = {
 describe('useQuery', () => {
   beforeAll(() => {
     // TODO: Fix use of act()
-    vi.spyOn(global.console, 'error').mockImplementation(() => {
+    vi.spyOn(globalThis.console, 'error').mockImplementation(() => {
       // do nothing
     });
   });

--- a/packages/react-urql/src/hooks/useQuery.test.tsx
+++ b/packages/react-urql/src/hooks/useQuery.test.tsx
@@ -55,7 +55,7 @@ const QueryUser = ({
 beforeEach(() => {
   vi.useFakeTimers();
   // TODO: Fix use of act()
-  vi.spyOn(global.console, 'error').mockImplementation(() => {
+  vi.spyOn(globalThis.console, 'error').mockImplementation(() => {
     // do nothings
   });
 

--- a/scripts/vitest/setup.js
+++ b/scripts/vitest/setup.js
@@ -1,15 +1,15 @@
 // This script is run before each `.test.ts` file.
 import { vi } from 'vitest';
 
-global.AbortController = undefined;
-global.fetch = vi.fn();
+globalThis.AbortController = undefined;
+globalThis.fetch = vi.fn();
 
 process.on('unhandledRejection', error => {
   throw error;
 });
 
 const originalConsole = console;
-global.console = {
+globalThis.console = {
   ...originalConsole,
   warn: (vi.SpyInstance = () => {
     /* noop */


### PR DESCRIPTION

## Summary

This is more of a maintenance change. The Node docs officially recommend to switch to `globalThis` instead of `global`, see https://nodejs.org/api/globals.html#global . `globalThis` is available in all other runtimes as well which makes the test suite easier to run outside of node. I'm working on getting vitest to run in Deno and I'm using urql's test suite for that.

## Set of changes

Replaces usages of `global` in the test suite to `globalThis`.