### PR TITLE
fix(vue): Fix regression causing `pause` argument to not be reactive

### DIFF
--- a/.changeset/eight-mirrors-sing.md
+++ b/.changeset/eight-mirrors-sing.md
@@ -1,0 +1,5 @@
+---
+'@urql/vue': patch
+---
+
+Fix regression causing `pause` argument on `useQuery` and `useSubscription` to not be reactive

--- a/packages/vue-urql/src/useQuery.ts
+++ b/packages/vue-urql/src/useQuery.ts
@@ -1,6 +1,7 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 
 import type { WatchStopHandle, Ref } from 'vue';
+import { isRef } from 'vue';
 import { shallowRef, ref, watchEffect, reactive } from 'vue';
 
 import type { Subscription, Source } from 'wonka';
@@ -253,7 +254,9 @@ export function callUseQuery<T = any, V extends AnyVariables = AnyVariables>(
   const operation: Ref<Operation<T, V> | undefined> = ref();
   const extensions: Ref<Record<string, any> | undefined> = ref();
 
-  const isPaused = ref(!!unref(args.pause));
+  const isPaused: Ref<boolean> = isRef(_args.pause)
+    ? _args.pause
+    : ref(!!_args.pause);
 
   const input = shallowRef({
     request: createRequest<T, V>(unref(args.query), unref(args.variables) as V),

--- a/packages/vue-urql/src/useSubscription.ts
+++ b/packages/vue-urql/src/useSubscription.ts
@@ -4,6 +4,7 @@ import type { Source } from 'wonka';
 import { pipe, subscribe, onEnd } from 'wonka';
 
 import type { WatchStopHandle, Ref } from 'vue';
+import { isRef } from 'vue';
 import { ref, shallowRef, watchEffect, reactive } from 'vue';
 
 import type {
@@ -253,7 +254,9 @@ export function callUseSubscription<
   const extensions: Ref<Record<string, any> | undefined> = ref();
 
   const scanHandler = ref(handler);
-  const isPaused = ref(!!unref(args.pause));
+  const isPaused: Ref<boolean> = isRef(_args.pause)
+    ? _args.pause
+    : ref(!!_args.pause);
 
   const input = shallowRef({
     request: createRequest<T, V>(unref(args.query), unref(args.variables) as V),


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR, but please make sure to open an issue or discuss
  your changes first, if you’re looking to submit a larger PR.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

Solves https://github.com/urql-graphql/urql/issues/3594#issue-2316403034

## Set of changes

This is just a quick fix for getting isPaused reactive, but there might be some issues with the reactivity of other parameters.
