### PR TITLE
fix(vue): pause not working with getters

### DIFF
--- a/.changeset/friendly-timers-taste.md
+++ b/.changeset/friendly-timers-taste.md
@@ -1,0 +1,5 @@
+---
+'@urql/vue': patch
+---
+
+Restore the possibility to use a getter for the pause property.

--- a/packages/vue-urql/src/useMutation.ts
+++ b/packages/vue-urql/src/useMutation.ts
@@ -63,7 +63,7 @@ export interface UseMutationResponse<T, V extends AnyVariables = AnyVariables> {
    *
    * @param variables - variables using which the mutation will be executed.
    * @param context - optionally, context options that will be merged with
-   * {@link UseMutationArgs.context} and the `Client`’s options.
+   * the `Client`’s options.
    * @returns the {@link OperationResult} of the mutation.
    *
    * @remarks

--- a/packages/vue-urql/src/useQuery.test.ts
+++ b/packages/vue-urql/src/useQuery.test.ts
@@ -116,15 +116,17 @@ describe('useQuery', () => {
         () => subject.source as OperationResultSource<OperationResult>
       );
 
+    const pause = ref(true);
+
     const _query = useQuery({
       query: `{ test }`,
-      pause: true,
+      pause: () => pause.value,
     });
     const query = reactive(_query);
 
     expect(executeQuery).not.toHaveBeenCalled();
 
-    query.resume();
+    pause.value = false;
     await nextTick();
     expect(query.fetching).toBe(true);
 

--- a/packages/vue-urql/src/useQuery.ts
+++ b/packages/vue-urql/src/useQuery.ts
@@ -1,7 +1,7 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 
 import type { WatchStopHandle, Ref } from 'vue';
-import { computed, isRef, reactive, ref, shallowRef, watchEffect } from 'vue';
+import { reactive, ref, shallowRef, watch, watchEffect } from 'vue';
 
 import type { Subscription, Source } from 'wonka';
 import { pipe, subscribe, onEnd } from 'wonka';
@@ -254,12 +254,11 @@ export function callUseQuery<T = any, V extends AnyVariables = AnyVariables>(
   const operation: Ref<Operation<T, V> | undefined> = ref();
   const extensions: Ref<Record<string, any> | undefined> = ref();
 
-  const isPaused: Ref<boolean> =
-    typeof _args.pause === 'function'
-      ? computed(_args.pause)
-      : isRef(_args.pause)
-      ? _args.pause
-      : ref(!!_args.pause);
+  const isPaused: Ref<boolean> = ref(!!unref(args.pause));
+  watch(
+    () => !!unref(args.pause),
+    value => (isPaused.value = value)
+  );
 
   const input = shallowRef({
     request: createRequest<T, V>(unref(args.query), unref(args.variables) as V),

--- a/packages/vue-urql/src/useQuery.ts
+++ b/packages/vue-urql/src/useQuery.ts
@@ -1,8 +1,7 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 
 import type { WatchStopHandle, Ref } from 'vue';
-import { isRef } from 'vue';
-import { shallowRef, ref, watchEffect, reactive } from 'vue';
+import { computed, isRef, reactive, ref, shallowRef, watchEffect } from 'vue';
 
 import type { Subscription, Source } from 'wonka';
 import { pipe, subscribe, onEnd } from 'wonka';
@@ -20,6 +19,7 @@ import type {
 import { createRequest } from '@urql/core';
 
 import { useClient } from './useClient';
+
 import type { MaybeRef, MaybeRefObj } from './utils';
 import { unref, updateShallowRef } from './utils';
 
@@ -254,9 +254,12 @@ export function callUseQuery<T = any, V extends AnyVariables = AnyVariables>(
   const operation: Ref<Operation<T, V> | undefined> = ref();
   const extensions: Ref<Record<string, any> | undefined> = ref();
 
-  const isPaused: Ref<boolean> = isRef(_args.pause)
-    ? _args.pause
-    : ref(!!_args.pause);
+  const isPaused: Ref<boolean> =
+    typeof _args.pause === 'function'
+      ? computed(_args.pause)
+      : isRef(_args.pause)
+      ? _args.pause
+      : ref(!!_args.pause);
 
   const input = shallowRef({
     request: createRequest<T, V>(unref(args.query), unref(args.variables) as V),

--- a/packages/vue-urql/src/useQuery.ts
+++ b/packages/vue-urql/src/useQuery.ts
@@ -256,7 +256,7 @@ export function callUseQuery<T = any, V extends AnyVariables = AnyVariables>(
 
   const isPaused: Ref<boolean> = ref(!!unref(args.pause));
   if (isRef(args.pause) || typeof args.pause === 'function') {
-    watch(args.pause, value => (isPaused.value = value));
+    stops.push(watch(args.pause, value => (isPaused.value = value)));
   }
 
   const input = shallowRef({

--- a/packages/vue-urql/src/useQuery.ts
+++ b/packages/vue-urql/src/useQuery.ts
@@ -1,7 +1,7 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 
-import type { WatchStopHandle, Ref } from 'vue';
-import { reactive, ref, shallowRef, watch, watchEffect } from 'vue';
+import type { Ref, WatchStopHandle } from 'vue';
+import { isRef, reactive, ref, shallowRef, watch, watchEffect } from 'vue';
 
 import type { Subscription, Source } from 'wonka';
 import { pipe, subscribe, onEnd } from 'wonka';
@@ -255,10 +255,9 @@ export function callUseQuery<T = any, V extends AnyVariables = AnyVariables>(
   const extensions: Ref<Record<string, any> | undefined> = ref();
 
   const isPaused: Ref<boolean> = ref(!!unref(args.pause));
-  watch(
-    () => !!unref(args.pause),
-    value => (isPaused.value = value)
-  );
+  if (isRef(args.pause) || typeof args.pause === 'function') {
+    watch(args.pause, value => (isPaused.value = value));
+  }
 
   const input = shallowRef({
     request: createRequest<T, V>(unref(args.query), unref(args.variables) as V),

--- a/packages/vue-urql/src/useSubscription.ts
+++ b/packages/vue-urql/src/useSubscription.ts
@@ -36,7 +36,7 @@ export type UseSubscriptionArgs<
    * @remarks
    * `pause` may be set to `true` to stop {@link useSubscription} from starting
    * its subscription automatically. This will pause the subscription until
-   * {@link UseSubscriptonState.resume} is called, or, if `pause` is a reactive
+   * {@link UseSubscriptionResponse.resume} is called, or, if `pause` is a reactive
    * ref of a boolean, until this ref changes to `true`.
    */
   pause?: MaybeRef<boolean>;
@@ -143,7 +143,7 @@ export interface UseSubscriptionResponse<
    *
    * @remarks
    * This is the subscription {@link Operation} that is currently active.
-   * When {@link UseQueryState.fetching} is `true`, this is the
+   * When {@link UseSubscriptionResponse.fetching} is `true`, this is the
    * last `Operation` that the current state was for.
    */
   operation: Ref<Operation<T, V> | undefined>;

--- a/packages/vue-urql/src/useSubscription.ts
+++ b/packages/vue-urql/src/useSubscription.ts
@@ -3,8 +3,8 @@
 import type { Source } from 'wonka';
 import { pipe, subscribe, onEnd } from 'wonka';
 
-import type { WatchStopHandle, Ref } from 'vue';
-import { reactive, ref, shallowRef, watch, watchEffect } from 'vue';
+import type { Ref, WatchStopHandle } from 'vue';
+import { isRef, reactive, ref, shallowRef, watch, watchEffect } from 'vue';
 
 import type {
   Client,
@@ -255,10 +255,9 @@ export function callUseSubscription<
 
   const scanHandler = ref(handler);
   const isPaused: Ref<boolean> = ref(!!unref(args.pause));
-  watch(
-    () => !!unref(args.pause),
-    value => (isPaused.value = value)
-  );
+  if (isRef(args.pause) || typeof args.pause === 'function') {
+    watch(args.pause, value => (isPaused.value = value));
+  }
 
   const input = shallowRef({
     request: createRequest<T, V>(unref(args.query), unref(args.variables) as V),

--- a/packages/vue-urql/src/useSubscription.ts
+++ b/packages/vue-urql/src/useSubscription.ts
@@ -4,8 +4,7 @@ import type { Source } from 'wonka';
 import { pipe, subscribe, onEnd } from 'wonka';
 
 import type { WatchStopHandle, Ref } from 'vue';
-import { isRef } from 'vue';
-import { ref, shallowRef, watchEffect, reactive } from 'vue';
+import { computed, isRef, reactive, ref, shallowRef, watchEffect } from 'vue';
 
 import type {
   Client,
@@ -19,6 +18,7 @@ import type {
 import { createRequest } from '@urql/core';
 
 import { useClient } from './useClient';
+
 import type { MaybeRef, MaybeRefObj } from './utils';
 import { unref, updateShallowRef } from './utils';
 
@@ -254,9 +254,12 @@ export function callUseSubscription<
   const extensions: Ref<Record<string, any> | undefined> = ref();
 
   const scanHandler = ref(handler);
-  const isPaused: Ref<boolean> = isRef(_args.pause)
-    ? _args.pause
-    : ref(!!_args.pause);
+  const isPaused: Ref<boolean> =
+    typeof _args.pause === 'function'
+      ? computed(_args.pause)
+      : isRef(_args.pause)
+      ? _args.pause
+      : ref(!!_args.pause);
 
   const input = shallowRef({
     request: createRequest<T, V>(unref(args.query), unref(args.variables) as V),

--- a/packages/vue-urql/src/useSubscription.ts
+++ b/packages/vue-urql/src/useSubscription.ts
@@ -256,7 +256,7 @@ export function callUseSubscription<
   const scanHandler = ref(handler);
   const isPaused: Ref<boolean> = ref(!!unref(args.pause));
   if (isRef(args.pause) || typeof args.pause === 'function') {
-    watch(args.pause, value => (isPaused.value = value));
+    stops.push(watch(args.pause, value => (isPaused.value = value)));
   }
 
   const input = shallowRef({

--- a/packages/vue-urql/src/useSubscription.ts
+++ b/packages/vue-urql/src/useSubscription.ts
@@ -4,7 +4,7 @@ import type { Source } from 'wonka';
 import { pipe, subscribe, onEnd } from 'wonka';
 
 import type { WatchStopHandle, Ref } from 'vue';
-import { computed, isRef, reactive, ref, shallowRef, watchEffect } from 'vue';
+import { reactive, ref, shallowRef, watch, watchEffect } from 'vue';
 
 import type {
   Client,
@@ -254,12 +254,11 @@ export function callUseSubscription<
   const extensions: Ref<Record<string, any> | undefined> = ref();
 
   const scanHandler = ref(handler);
-  const isPaused: Ref<boolean> =
-    typeof _args.pause === 'function'
-      ? computed(_args.pause)
-      : isRef(_args.pause)
-      ? _args.pause
-      : ref(!!_args.pause);
+  const isPaused: Ref<boolean> = ref(!!unref(args.pause));
+  watch(
+    () => !!unref(args.pause),
+    value => (isPaused.value = value)
+  );
 
   const input = shallowRef({
     request: createRequest<T, V>(unref(args.query), unref(args.variables) as V),


### PR DESCRIPTION
## Summary

This PR fixes a bug noted by @negezor: the `pause` property was not working with a getter, see https://github.com/urql-graphql/urql/pull/3595#issuecomment-2142285519.

## Set of changes

1) Minor fixes in `useQuery.ts` and `useSubscription.ts` to manage the case where pause is a getter.

2) Corrected some typos in the docs of `useQuery.ts` and `useSubscription.ts`.

3) Modified a test in `useQuery.test.ts` to use a reactive `pause` property with a getter.
