### PR TITLE
fix(core): ensure operationKey is different when dealing with files

### DIFF
--- a/.changeset/shaggy-wasps-bow.md
+++ b/.changeset/shaggy-wasps-bow.md
@@ -1,5 +1,8 @@
 ---
-'@urql/exchange-graphcache': patch
+'@urql/core': patch
 ---
 
-Fix case where the same operation.key comes in and doesn't get deduplicated
+Change how we calculate the `OperationKey` to take files into account, before we
+would encode them to `null` resulting in every mutation with the same variables
+(excluding the files) to have the same key. This resulted in mutations that upload
+different files at the same time to share a result in GraphCache.

--- a/.changeset/shaggy-wasps-bow.md
+++ b/.changeset/shaggy-wasps-bow.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix case where the same operation.key comes in and doesn't get deduplicated

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -162,9 +162,7 @@ export const cacheExchange =
         operation.kind === 'mutation' &&
         operation.context.requestPolicy !== 'network-only'
       ) {
-        const key = (operation.key +
-          (operation.context._instance || 0)) as number;
-        operations.set(key, operation);
+        operations.set(operation.key, operation);
         // This executes an optimistic update for mutations and registers it if necessary
         initDataState('write', store.data, operation.key, true, false);
         const { dependencies } = _write(
@@ -233,11 +231,7 @@ export const cacheExchange =
         : 'miss';
 
       results.set(operation.key, result.data);
-      const key =
-        operation.kind === 'mutation'
-          ? operation.key + (operation.context._instance || 0)
-          : operation.key;
-      operations.set(key, operation);
+      operations.set(operation.key, operation);
       updateDependencies(operation, result.dependencies);
 
       return {
@@ -255,11 +249,8 @@ export const cacheExchange =
       pendingOperations: Operations
     ): OperationResult => {
       // Retrieve the original operation to get unfiltered variables
-      const key =
-        result.operation.kind === 'mutation'
-          ? result.operation.key + (result.operation.context._instance || 0)
-          : result.operation.key;
-      const operation = operations.get(key) || result.operation;
+      const operation =
+        operations.get(result.operation.key) || result.operation;
       if (operation.kind === 'mutation') {
         // Collect previous dependencies that have been written for optimistic updates
         const dependencies = optimisticKeysToDependencies.get(operation.key);
@@ -410,13 +401,9 @@ export const cacheExchange =
           if (!shouldReexecute) {
             /*noop*/
           } else if (!isBlockedByOptimisticUpdate(res.dependencies)) {
-            const key =
-              res.operation.kind === 'mutation'
-                ? res.operation.key + (res.operation.context._instance || 0)
-                : result.operation.key;
             client.reexecuteOperation(
               toRequestPolicy(
-                operations.get(key) || res.operation,
+                operations.get(res.operation.key) || res.operation,
                 'network-only'
               )
             );

--- a/packages/core/src/utils/variables.ts
+++ b/packages/core/src/utils/variables.ts
@@ -19,10 +19,11 @@ const stringify = (x: any, includeFiles: boolean): string => {
     out += ']';
     return out;
   } else if (
-    (FileConstructor !== NoopConstructor && x instanceof FileConstructor) ||
-    (BlobConstructor !== NoopConstructor && x instanceof BlobConstructor)
+    !includeFiles &&
+    ((FileConstructor !== NoopConstructor && x instanceof FileConstructor) ||
+      (BlobConstructor !== NoopConstructor && x instanceof BlobConstructor))
   ) {
-    return includeFiles ? x.toString() : 'null';
+    return 'null';
   }
 
   const keys = Object.keys(x).sort();

--- a/packages/core/src/utils/variables.ts
+++ b/packages/core/src/utils/variables.ts
@@ -3,18 +3,18 @@ export type FileMap = Map<string, File | Blob>;
 const seen: Set<any> = new Set();
 const cache: WeakMap<any, any> = new WeakMap();
 
-const stringify = (x: any): string => {
+const stringify = (x: any, includeFiles: boolean): string => {
   if (x === null || seen.has(x)) {
     return 'null';
   } else if (typeof x !== 'object') {
     return JSON.stringify(x) || '';
   } else if (x.toJSON) {
-    return stringify(x.toJSON());
+    return stringify(x.toJSON(), includeFiles);
   } else if (Array.isArray(x)) {
     let out = '[';
     for (const value of x) {
       if (out.length > 1) out += ',';
-      out += stringify(value) || 'null';
+      out += stringify(value, includeFiles) || 'null';
     }
     out += ']';
     return out;
@@ -22,7 +22,7 @@ const stringify = (x: any): string => {
     (FileConstructor !== NoopConstructor && x instanceof FileConstructor) ||
     (BlobConstructor !== NoopConstructor && x instanceof BlobConstructor)
   ) {
-    return 'null';
+    return includeFiles ? x.toString() : 'null';
   }
 
   const keys = Object.keys(x).sort();
@@ -33,16 +33,16 @@ const stringify = (x: any): string => {
   ) {
     const key = cache.get(x) || Math.random().toString(36).slice(2);
     cache.set(x, key);
-    return stringify({ __key: key });
+    return stringify({ __key: key }, includeFiles);
   }
 
   seen.add(x);
   let out = '{';
   for (const key of keys) {
-    const value = stringify(x[key]);
+    const value = stringify(x[key], includeFiles);
     if (value) {
       if (out.length > 1) out += ',';
-      out += stringify(key) + ':' + value;
+      out += stringify(key, includeFiles) + ':' + value;
     }
   }
 
@@ -79,9 +79,9 @@ const extract = (map: FileMap, path: string, x: any): void => {
  * replacing their values, which remain stable for the objects’
  * instance.
  */
-export const stringifyVariables = (x: any): string => {
+export const stringifyVariables = (x: any, includeFiles?: boolean): string => {
   seen.clear();
-  return stringify(x);
+  return stringify(x, includeFiles || false);
 };
 
 class NoopConstructor {}


### PR DESCRIPTION
Fixes https://github.com/urql-graphql/urql/issues/3541

## Summary

Change how we calculate the `OperationKey` to take files into account, before we
would encode them to `null` resulting in every mutation with the same variables
(excluding the files) to have the same key. This resulted in mutations that upload
different files at the same time to share a result in GraphCache.