### PR TITLE
fix(graphcache): incorrectly matching all concrete types

### DIFF
--- a/.changeset/red-eyes-lick.md
+++ b/.changeset/red-eyes-lick.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix where we would incorrectly match all fragment concrete types because they belong to the abstract type

--- a/exchanges/graphcache/src/cacheExchange.test.ts
+++ b/exchanges/graphcache/src/cacheExchange.test.ts
@@ -3853,7 +3853,7 @@ describe('commutativity', () => {
   });
 });
 
-describe.only('abstract types', () => {
+describe('abstract types', () => {
   it('works with two responses giving different concrete types for a union', () => {
     const query = gql`
       query ($id: ID!) {


### PR DESCRIPTION
Resolves #3600 

## Summary

Currently we are holding a mapping of abstract --> concrete types, however when we are in a write operation we always say the fragment matches. This meant that in the union case we would often write concrete type maps to another concrete type. This is invalid, I changed the condition to check whether the fragment actually matches before writing an abstract to concrete type mapping. This however begs the question whether this functionality is worth keeping around because a heuristic match could still make us fall into the concrete to concrete mapping which could in turn cause unexpected behavior in later queries.
