### PR TITLE
fix(vue): Fix regression causing variables to not be reactive

### DIFF
--- a/packages/vue-urql/src/useQuery.ts
+++ b/packages/vue-urql/src/useQuery.ts
@@ -75,7 +75,7 @@ export type UseQueryArgs<
    * documentation on the `pause` option.
    */
   pause?: MaybeRef<boolean>;
-} & MaybeRefObj<GraphQLRequestParams<Data, Variables>>;
+} & MaybeRefObj<GraphQLRequestParams<Data, MaybeRefObj<Variables>>>;
 
 /** State of the current query, your {@link useQuery} function is executing.
  *

--- a/packages/vue-urql/src/useSubscription.ts
+++ b/packages/vue-urql/src/useSubscription.ts
@@ -58,7 +58,7 @@ export type UseSubscriptionArgs<
    * ```
    */
   context?: MaybeRef<Partial<OperationContext>>;
-} & MaybeRefObj<GraphQLRequestParams<Data, Variables>>;
+} & MaybeRefObj<GraphQLRequestParams<Data, MaybeRefObj<Variables>>>;
 
 /** Combines previous data with an incoming subscription result’s data.
  *

--- a/packages/vue-urql/src/utils.ts
+++ b/packages/vue-urql/src/utils.ts
@@ -3,7 +3,9 @@ import type { Ref, ShallowRef } from 'vue';
 import { isRef } from 'vue';
 
 export type MaybeRef<T> = T | (() => T) | Ref<T>;
-export type MaybeRefObj<T extends {}> = { [K in keyof T]: MaybeRef<T[K]> };
+export type MaybeRefObj<T> = T extends {}
+  ? { [K in keyof T]: MaybeRef<T[K]> }
+  : T;
 
 export const unref = <T>(maybeRef: MaybeRef<T>): T =>
   typeof maybeRef === 'function'


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR, but please make sure to open an issue or discuss
  your changes first, if you’re looking to submit a larger PR.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

<!-- What's the motivation of this change? What does it solve? -->

Restore reactivity typings for `variables` input.

This regression caused a [number](https://stackoverflow.com/questions/76163956/how-to-allow-urql-typescript-to-accept-vue-reactive-variables-for-queries-crea) of [issues](https://github.com/dotansimha/graphql-code-generator-community/issues/194) using `graphql-code-generator`

## Set of changes

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->

Reuse `MaybeRef` type for variables typing.
