### PR TITLE
Use effectScope instead of manually stopping effects

### DIFF
--- a/.changeset/kind-bugs-do.md
+++ b/.changeset/kind-bugs-do.md
@@ -1,0 +1,5 @@
+---
+'@urql/vue': minor
+---
+
+Use `effectScope` instead of manually stopping effects

--- a/packages/vue-urql/src/useQuery.ts
+++ b/packages/vue-urql/src/useQuery.ts
@@ -242,7 +242,7 @@ export function useQuery<T = any, V extends AnyVariables = AnyVariables>(
 
 export function callUseQuery<T = any, V extends AnyVariables = AnyVariables>(
   args: UseQueryArgs<T, V>,
-  client: Ref<Client> = useClient(),
+  client: Ref<Client> = useClient()
 ): UseQueryResponse<T, V> {
   const data: Ref<T | undefined> = ref();
   const stale: Ref<boolean> = ref(false);


### PR DESCRIPTION
## Summary

This PR eliminates the need to manually stop effects, as Vue has an efficient `effectScope` API. Manual stopping is less readable and consumes more memory unnecessarily, since Vue will still write the effects to scope.

## Set of changes

- Removes `stops` in `useQuery.ts` and `useSubscription.ts`
- Replaces `stops` with `effectScope` in `useClientHandle.ts`

This should be a minor change. However, for most users this won't matter because everything basically uses methods directly instead of `useClientHandle`, which is much more efficient.