### PR TITLE
Use shallowRef instead of ref for deep objects

### DIFF
--- a/.changeset/old-onions-travel.md
+++ b/.changeset/old-onions-travel.md
@@ -1,0 +1,5 @@
+---
+'@urql/vue': minor
+---
+
+Use shallowRef to avoid creating deeply reactive objects for heavy objects

--- a/.changeset/old-onions-travel.md
+++ b/.changeset/old-onions-travel.md
@@ -2,4 +2,4 @@
 '@urql/vue': minor
 ---
 
-Use shallowRef to avoid creating deeply reactive objects for heavy objects
+Use `shallowRef` to avoid creating deeply reactive objects for heavy objects

--- a/packages/vue-urql/src/useClient.ts
+++ b/packages/vue-urql/src/useClient.ts
@@ -1,5 +1,5 @@
 import type { App, Ref } from 'vue';
-import { getCurrentInstance, inject, provide, isRef, ref } from 'vue';
+import { getCurrentInstance, inject, provide, isRef, shallowRef } from 'vue';
 import type { ClientOptions } from '@urql/core';
 import { Client } from '@urql/core';
 
@@ -36,7 +36,7 @@ const clientsPerInstance = new WeakMap<{}, Ref<Client>>();
 export function provideClient(opts: ClientOptions | Client | Ref<Client>) {
   let client: Ref<Client>;
   if (!isRef(opts)) {
-    client = ref(opts instanceof Client ? opts : new Client(opts));
+    client = shallowRef(opts instanceof Client ? opts : new Client(opts));
   } else {
     client = opts;
   }
@@ -78,7 +78,7 @@ export function provideClient(opts: ClientOptions | Client | Ref<Client>) {
 export function install(app: App, opts: ClientOptions | Client | Ref<Client>) {
   let client: Ref<Client>;
   if (!isRef(opts)) {
-    client = ref(opts instanceof Client ? opts : new Client(opts));
+    client = shallowRef(opts instanceof Client ? opts : new Client(opts));
   } else {
     client = opts;
   }

--- a/packages/vue-urql/src/useMutation.ts
+++ b/packages/vue-urql/src/useMutation.ts
@@ -1,7 +1,7 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 
 import type { Ref } from 'vue';
-import { ref } from 'vue';
+import { ref, shallowRef } from 'vue';
 import type { DocumentNode } from 'graphql';
 import { pipe, onPush, filter, toPromise, take } from 'wonka';
 
@@ -138,9 +138,9 @@ export function callUseMutation<T = any, V extends AnyVariables = AnyVariables>(
   const data: Ref<T | undefined> = ref();
   const stale: Ref<boolean> = ref(false);
   const fetching: Ref<boolean> = ref(false);
-  const error: Ref<CombinedError | undefined> = ref();
-  const operation: Ref<Operation<T, V> | undefined> = ref();
-  const extensions: Ref<Record<string, any> | undefined> = ref();
+  const error: Ref<CombinedError | undefined> = shallowRef();
+  const operation: Ref<Operation<T, V> | undefined> = shallowRef();
+  const extensions: Ref<Record<string, any> | undefined> = shallowRef();
 
   return {
     data,

--- a/packages/vue-urql/src/useQuery.ts
+++ b/packages/vue-urql/src/useQuery.ts
@@ -250,9 +250,9 @@ export function callUseQuery<T = any, V extends AnyVariables = AnyVariables>(
   const data: Ref<T | undefined> = ref();
   const stale: Ref<boolean> = ref(false);
   const fetching: Ref<boolean> = ref(false);
-  const error: Ref<CombinedError | undefined> = ref();
-  const operation: Ref<Operation<T, V> | undefined> = ref();
-  const extensions: Ref<Record<string, any> | undefined> = ref();
+  const error: Ref<CombinedError | undefined> = shallowRef();
+  const operation: Ref<Operation<T, V> | undefined> = shallowRef();
+  const extensions: Ref<Record<string, any> | undefined> = shallowRef();
 
   const isPaused: Ref<boolean> = ref(!!unref(args.pause));
   if (isRef(args.pause) || typeof args.pause === 'function') {

--- a/packages/vue-urql/src/useSubscription.ts
+++ b/packages/vue-urql/src/useSubscription.ts
@@ -249,9 +249,9 @@ export function callUseSubscription<
   const data: Ref<R | undefined> = ref();
   const stale: Ref<boolean> = ref(false);
   const fetching: Ref<boolean> = ref(false);
-  const error: Ref<CombinedError | undefined> = ref();
-  const operation: Ref<Operation<T, V> | undefined> = ref();
-  const extensions: Ref<Record<string, any> | undefined> = ref();
+  const error: Ref<CombinedError | undefined> = shallowRef();
+  const operation: Ref<Operation<T, V> | undefined> = shallowRef();
+  const extensions: Ref<Record<string, any> | undefined> = shallowRef();
 
   const scanHandler = ref(handler);
   const isPaused: Ref<boolean> = ref(!!unref(args.pause));


### PR DESCRIPTION
## Summary

Instead of using `ref` for deep objects, it is much more efficient from a performance point of view to look at reactivity only at the moment of setting the value, rather than changing its internal properties.

## Set of changes

- Replaces `ref` with `shallowRef` for the client in `useClient.ts`
- Replaces `ref` with `shallowRef` for `error`, `operation` and `extensions` in `useMutation.ts`, `useQuery.ts` and `useSubscription.ts`

I don't consider this a breaking change since these properties should always be considered read-only. Since properties are always overwritten completely, and nested reactivity is not needed in them. Because changing them will not lead to the desired result in most cases.