### PR TITLE
feat(vue): refactor composable functions

### DIFF
--- a/.changeset/chatty-mice-join.md
+++ b/.changeset/chatty-mice-join.md
@@ -1,0 +1,5 @@
+---
+'@urql/vue': minor
+---
+
+Refactor composable functions with care of reactivity to fix possible memory leaks

--- a/.changeset/chatty-mice-join.md
+++ b/.changeset/chatty-mice-join.md
@@ -2,4 +2,4 @@
 '@urql/vue': minor
 ---
 
-Refactor composable functions with care of reactivity to fix possible memory leaks
+Refactor composable functions with a focus on avoiding memory leaks and Vue best practices

--- a/packages/vue-urql/src/useClientHandle.ts
+++ b/packages/vue-urql/src/useClientHandle.ts
@@ -1,5 +1,4 @@
-import type { DocumentNode } from 'graphql';
-import type { AnyVariables, Client, TypedDocumentNode } from '@urql/core';
+import type { AnyVariables, Client, DocumentInput } from '@urql/core';
 import type { WatchStopHandle } from 'vue';
 import { getCurrentInstance, onMounted, onBeforeUnmount } from 'vue';
 
@@ -75,7 +74,7 @@ export interface ClientHandle {
    * function or when chained in an `async setup()` function.
    */
   useMutation<T = any, V extends AnyVariables = AnyVariables>(
-    query: TypedDocumentNode<T, V> | DocumentNode | string
+    query: DocumentInput<T, V>
   ): UseMutationResponse<T, V>;
 }
 
@@ -153,7 +152,7 @@ export function useClientHandle(): ClientHandle {
     },
 
     useMutation<T = any, V extends AnyVariables = AnyVariables>(
-      query: TypedDocumentNode<T, V> | DocumentNode | string
+      query: DocumentInput<T, V>
     ): UseMutationResponse<T, V> {
       return callUseMutation(query, client);
     },

--- a/packages/vue-urql/src/useClientHandle.ts
+++ b/packages/vue-urql/src/useClientHandle.ts
@@ -1,6 +1,7 @@
 import type { DocumentNode } from 'graphql';
 import type { AnyVariables, Client, TypedDocumentNode } from '@urql/core';
-import { getCurrentInstance, onMounted } from 'vue';
+import type { WatchStopHandle } from 'vue';
+import { getCurrentInstance, onMounted, onBeforeUnmount } from 'vue';
 
 import { useClient } from './useClient';
 
@@ -128,6 +129,12 @@ export interface ClientHandle {
  */
 export function useClientHandle(): ClientHandle {
   const client = useClient();
+  const stops: WatchStopHandle[] = [];
+
+  onBeforeUnmount(() => {
+    let stop: WatchStopHandle | void;
+    while ((stop = stops.shift())) stop();
+  });
 
   const handle: ClientHandle = {
     client: client.value,
@@ -135,14 +142,14 @@ export function useClientHandle(): ClientHandle {
     useQuery<T = any, V extends AnyVariables = AnyVariables>(
       args: UseQueryArgs<T, V>
     ): UseQueryResponse<T, V> {
-      return callUseQuery(args, client);
+      return callUseQuery(args, client, stops);
     },
 
     useSubscription<T = any, R = T, V extends AnyVariables = AnyVariables>(
       args: UseSubscriptionArgs<T, V>,
       handler?: SubscriptionHandlerArg<T, R>
     ): UseSubscriptionResponse<T, R, V> {
-      return callUseSubscription(args, handler, client);
+      return callUseSubscription(args, handler, client, stops);
     },
 
     useMutation<T = any, V extends AnyVariables = AnyVariables>(
@@ -164,7 +171,7 @@ export function useClientHandle(): ClientHandle {
             );
           }
 
-          return callUseQuery(args, client);
+          return callUseQuery(args, client, stops);
         },
 
         useSubscription<T = any, R = T, V extends AnyVariables = AnyVariables>(
@@ -177,7 +184,7 @@ export function useClientHandle(): ClientHandle {
             );
           }
 
-          return callUseSubscription(args, handler, client);
+          return callUseSubscription(args, handler, client, stops);
         },
       });
     });

--- a/packages/vue-urql/src/useClientHandle.ts
+++ b/packages/vue-urql/src/useClientHandle.ts
@@ -1,7 +1,6 @@
 import type { DocumentNode } from 'graphql';
 import type { AnyVariables, Client, TypedDocumentNode } from '@urql/core';
-import type { WatchStopHandle } from 'vue';
-import { getCurrentInstance, onMounted, onBeforeUnmount } from 'vue';
+import { getCurrentInstance, onMounted } from 'vue';
 
 import { useClient } from './useClient';
 
@@ -129,12 +128,6 @@ export interface ClientHandle {
  */
 export function useClientHandle(): ClientHandle {
   const client = useClient();
-  const stops: WatchStopHandle[] = [];
-
-  onBeforeUnmount(() => {
-    let stop: WatchStopHandle | void;
-    while ((stop = stops.shift())) stop();
-  });
 
   const handle: ClientHandle = {
     client: client.value,
@@ -142,14 +135,14 @@ export function useClientHandle(): ClientHandle {
     useQuery<T = any, V extends AnyVariables = AnyVariables>(
       args: UseQueryArgs<T, V>
     ): UseQueryResponse<T, V> {
-      return callUseQuery(args, client, stops);
+      return callUseQuery(args, client);
     },
 
     useSubscription<T = any, R = T, V extends AnyVariables = AnyVariables>(
       args: UseSubscriptionArgs<T, V>,
       handler?: SubscriptionHandlerArg<T, R>
     ): UseSubscriptionResponse<T, R, V> {
-      return callUseSubscription(args, handler, client, stops);
+      return callUseSubscription(args, handler, client);
     },
 
     useMutation<T = any, V extends AnyVariables = AnyVariables>(
@@ -171,7 +164,7 @@ export function useClientHandle(): ClientHandle {
             );
           }
 
-          return callUseQuery(args, client, stops);
+          return callUseQuery(args, client);
         },
 
         useSubscription<T = any, R = T, V extends AnyVariables = AnyVariables>(
@@ -184,7 +177,7 @@ export function useClientHandle(): ClientHandle {
             );
           }
 
-          return callUseSubscription(args, handler, client, stops);
+          return callUseSubscription(args, handler, client);
         },
       });
     });

--- a/packages/vue-urql/src/useMutation.test.ts
+++ b/packages/vue-urql/src/useMutation.test.ts
@@ -1,5 +1,5 @@
 import { OperationResult, OperationResultSource } from '@urql/core';
-import { reactive } from 'vue';
+import { readonly } from 'vue';
 import { vi, expect, it, beforeEach, describe } from 'vitest';
 
 vi.mock('./useClient.ts', async () => {
@@ -30,15 +30,13 @@ describe('useMutation', () => {
         () => subject.source as OperationResultSource<OperationResult>
       );
 
-    const mutation = reactive(
-      useMutation(gql`
-        mutation {
-          test
-        }
-      `)
-    );
+    const mutation = useMutation(gql`
+      mutation {
+        test
+      }
+    `);
 
-    expect(mutation).toMatchObject({
+    expect(readonly(mutation)).toMatchObject({
       data: undefined,
       stale: false,
       fetching: false,
@@ -50,18 +48,18 @@ describe('useMutation', () => {
 
     const promise = mutation.executeMutation({ test: true });
 
-    expect(mutation.fetching).toBe(true);
-    expect(mutation.stale).toBe(false);
-    expect(mutation.error).toBe(undefined);
+    expect(mutation.fetching.value).toBe(true);
+    expect(mutation.stale.value).toBe(false);
+    expect(mutation.error.value).toBe(undefined);
 
     expect(clientMutation).toHaveBeenCalledTimes(1);
 
     subject.next({ data: { test: true }, stale: false });
-    await promise.then(function () {
-      expect(mutation.fetching).toBe(false);
-      expect(mutation.stale).toBe(false);
-      expect(mutation.error).toBe(undefined);
-      expect(mutation.data).toEqual({ test: true });
-    });
+
+    await promise;
+    expect(mutation.fetching.value).toBe(false);
+    expect(mutation.stale.value).toBe(false);
+    expect(mutation.error.value).toBe(undefined);
+    expect(mutation.data.value).toHaveProperty('test', true);
   });
 });

--- a/packages/vue-urql/src/useMutation.ts
+++ b/packages/vue-urql/src/useMutation.ts
@@ -11,10 +11,11 @@ import type {
   Operation,
   OperationContext,
   OperationResult,
+  DocumentInput,
 } from '@urql/core';
 
 import { useClient } from './useClient';
-import type { MaybeRef, MutationDocumentNode } from './utils';
+import type { MaybeRef } from './utils';
 import { createRequestWithArgs, useRequestState } from './utils';
 
 /** State of the last mutation executed by {@link useMutation}.
@@ -123,13 +124,13 @@ export interface UseMutationResponse<T, V extends AnyVariables = AnyVariables> {
  * ```
  */
 export function useMutation<T = any, V extends AnyVariables = AnyVariables>(
-  query: MutationDocumentNode
+  query: DocumentInput<T, V>
 ): UseMutationResponse<T, V> {
   return callUseMutation(query);
 }
 
 export function callUseMutation<T = any, V extends AnyVariables = AnyVariables>(
-  query: MaybeRef<MutationDocumentNode>,
+  query: MaybeRef<DocumentInput<T, V>>,
   client: Ref<Client> = useClient()
 ): UseMutationResponse<T, V> {
   const data: Ref<T | undefined> = ref();

--- a/packages/vue-urql/src/useMutation.ts
+++ b/packages/vue-urql/src/useMutation.ts
@@ -14,7 +14,7 @@ import type {
 } from '@urql/core';
 
 import { useClient } from './useClient';
-import type { MaybeRef, MutationQuery } from './utils';
+import type { MaybeRef, MutationDocumentNode } from './utils';
 import { createRequestWithArgs, useRequestState } from './utils';
 
 /** State of the last mutation executed by {@link useMutation}.
@@ -123,13 +123,13 @@ export interface UseMutationResponse<T, V extends AnyVariables = AnyVariables> {
  * ```
  */
 export function useMutation<T = any, V extends AnyVariables = AnyVariables>(
-  query: MutationQuery
+  query: MutationDocumentNode
 ): UseMutationResponse<T, V> {
   return callUseMutation(query);
 }
 
 export function callUseMutation<T = any, V extends AnyVariables = AnyVariables>(
-  query: MaybeRef<MutationQuery>,
+  query: MaybeRef<MutationDocumentNode>,
   client: Ref<Client> = useClient()
 ): UseMutationResponse<T, V> {
   const data: Ref<T | undefined> = ref();

--- a/packages/vue-urql/src/useMutation.ts
+++ b/packages/vue-urql/src/useMutation.ts
@@ -2,24 +2,20 @@
 
 import type { Ref } from 'vue';
 import { ref } from 'vue';
-import type { DocumentNode } from 'graphql';
 import { pipe, onPush, filter, toPromise, take } from 'wonka';
 
 import type {
   Client,
   AnyVariables,
-  TypedDocumentNode,
   CombinedError,
   Operation,
   OperationContext,
   OperationResult,
 } from '@urql/core';
-import { createRequest } from '@urql/core';
 
 import { useClient } from './useClient';
-import type { MaybeRef } from './utils';
-import { useRequestState } from './utils';
-import { unref } from './utils';
+import type { MaybeRef, MutationQuery } from './utils';
+import { createRequestWithArgs, useRequestState } from './utils';
 
 /** State of the last mutation executed by {@link useMutation}.
  *
@@ -127,13 +123,13 @@ export interface UseMutationResponse<T, V extends AnyVariables = AnyVariables> {
  * ```
  */
 export function useMutation<T = any, V extends AnyVariables = AnyVariables>(
-  query: TypedDocumentNode<T, V> | DocumentNode | string
+  query: MutationQuery
 ): UseMutationResponse<T, V> {
   return callUseMutation(query);
 }
 
 export function callUseMutation<T = any, V extends AnyVariables = AnyVariables>(
-  query: MaybeRef<TypedDocumentNode<T, V> | DocumentNode | string>,
+  query: MaybeRef<MutationQuery>,
   client: Ref<Client> = useClient()
 ): UseMutationResponse<T, V> {
   const data: Ref<T | undefined> = ref();
@@ -158,7 +154,7 @@ export function callUseMutation<T = any, V extends AnyVariables = AnyVariables>(
 
       return pipe(
         client.value.executeMutation<T, V>(
-          createRequest<T, V>(unref(query), unref(variables)),
+          createRequestWithArgs({ query, variables }),
           context || {}
         ),
         onPush(result => {

--- a/packages/vue-urql/src/useMutation.ts
+++ b/packages/vue-urql/src/useMutation.ts
@@ -1,7 +1,7 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 
 import type { Ref } from 'vue';
-import { ref, shallowRef } from 'vue';
+import { ref } from 'vue';
 import type { DocumentNode } from 'graphql';
 import { pipe, onPush, filter, toPromise, take } from 'wonka';
 
@@ -18,6 +18,7 @@ import { createRequest } from '@urql/core';
 
 import { useClient } from './useClient';
 import type { MaybeRef } from './utils';
+import { useRequestState } from './utils';
 import { unref } from './utils';
 
 /** State of the last mutation executed by {@link useMutation}.
@@ -136,11 +137,11 @@ export function callUseMutation<T = any, V extends AnyVariables = AnyVariables>(
   client: Ref<Client> = useClient()
 ): UseMutationResponse<T, V> {
   const data: Ref<T | undefined> = ref();
-  const stale: Ref<boolean> = ref(false);
-  const fetching: Ref<boolean> = ref(false);
-  const error: Ref<CombinedError | undefined> = shallowRef();
-  const operation: Ref<Operation<T, V> | undefined> = shallowRef();
-  const extensions: Ref<Record<string, any> | undefined> = shallowRef();
+
+  const { fetching, operation, extensions, stale, error } = useRequestState<
+    T,
+    V
+  >();
 
   return {
     data,

--- a/packages/vue-urql/src/useQuery.test.ts
+++ b/packages/vue-urql/src/useQuery.test.ts
@@ -1,5 +1,9 @@
-import { OperationResult, OperationResultSource } from '@urql/core';
-import { nextTick, reactive, ref } from 'vue';
+import {
+  OperationResult,
+  OperationResultSource,
+  RequestPolicy,
+} from '@urql/core';
+import { computed, nextTick, reactive, ref } from 'vue';
 import { vi, expect, it, describe } from 'vitest';
 
 vi.mock('./useClient.ts', async () => ({
@@ -10,9 +14,27 @@ vi.mock('./useClient.ts', async () => ({
 
 import { pipe, makeSubject, fromValue, delay } from 'wonka';
 import { createClient } from '@urql/core';
-import { useQuery } from './useQuery';
+import { useQuery, UseQueryArgs } from './useQuery';
 
 const client = createClient({ url: '/graphql', exchanges: [] });
+
+const createQuery = (args: UseQueryArgs) => {
+  const executeQuery = vi
+    .spyOn(client, 'executeQuery')
+    .mockImplementation(request => {
+      return pipe(
+        fromValue({ operation: request, data: { test: true } }),
+        delay(1)
+      ) as any;
+    });
+
+  const query$ = useQuery(args);
+
+  return {
+    query$,
+    executeQuery,
+  };
+};
 
 describe('useQuery', () => {
   it('runs a query and updates data', async () => {
@@ -79,18 +101,9 @@ describe('useQuery', () => {
   });
 
   it('runs queries as a promise-like that resolves even when the query changes', async () => {
-    const executeQuery = vi
-      .spyOn(client, 'executeQuery')
-      .mockImplementation(request => {
-        return pipe(
-          fromValue({ operation: request, data: { test: true } }),
-          delay(1)
-        ) as any;
-      });
-
     const doc = ref('{ test }');
 
-    const query$ = useQuery({
+    const { executeQuery, query$ } = createQuery({
       query: doc,
     });
 
@@ -108,36 +121,194 @@ describe('useQuery', () => {
     );
   });
 
-  it('reacts to variables changing', async () => {
-    const executeQuery = vi
-      .spyOn(client, 'executeQuery')
-      .mockImplementation(request => {
-        return pipe(
-          fromValue({ operation: request, data: { test: true } }),
-          delay(1)
-        ) as any;
-      });
+  it('reacts to ref variables changing', async () => {
+    const variables = ref({ prop: 1 });
 
-    const variables = {
-      test: ref(1),
-    };
-    const query$ = useQuery({
-      query: '{ test }',
+    const { executeQuery, query$ } = createQuery({
+      query: ref('{ test }'),
       variables,
     });
 
     await query$;
-
     expect(executeQuery).toHaveBeenCalledTimes(1);
+    expect(query$.operation.value).toHaveProperty('variables.prop', 1);
 
-    expect(query$.operation.value).toHaveProperty('variables.test', 1);
+    variables.value.prop++;
+    await query$;
+    expect(executeQuery).toHaveBeenCalledTimes(2);
+    expect(query$.operation.value).toHaveProperty('variables.prop', 2);
 
-    variables.test.value = 2;
+    variables.value = { prop: 3 };
+    await query$;
+    expect(executeQuery).toHaveBeenCalledTimes(3);
+    expect(query$.operation.value).toHaveProperty('variables.prop', 3);
+  });
+
+  it('reacts to nested ref variables changing', async () => {
+    const prop = ref(1);
+
+    const { executeQuery, query$ } = createQuery({
+      query: ref('{ test }'),
+      variables: { prop },
+    });
 
     await query$;
+    expect(executeQuery).toHaveBeenCalledTimes(1);
+    expect(query$.operation.value).toHaveProperty('variables.prop', 1);
 
+    prop.value++;
+    await query$;
     expect(executeQuery).toHaveBeenCalledTimes(2);
-    expect(query$.operation.value).toHaveProperty('variables.test', 2);
+    expect(query$.operation.value).toHaveProperty('variables.prop', 2);
+  });
+
+  it('reacts to deep nested ref variables changing', async () => {
+    const prop = ref(1);
+
+    const { executeQuery, query$ } = createQuery({
+      query: ref('{ test }'),
+      variables: { deep: { nested: { prop } } },
+    });
+
+    await query$;
+    expect(executeQuery).toHaveBeenCalledTimes(1);
+    expect(query$.operation.value).toHaveProperty(
+      'variables.deep.nested.prop',
+      1
+    );
+
+    prop.value++;
+    await query$;
+    expect(executeQuery).toHaveBeenCalledTimes(2);
+    expect(query$.operation.value).toHaveProperty(
+      'variables.deep.nested.prop',
+      2
+    );
+  });
+
+  it('reacts to reactive variables changing', async () => {
+    const prop = ref(1);
+    const variables = reactive({ prop: 1, deep: { nested: { prop } } });
+
+    const { executeQuery, query$ } = createQuery({
+      query: ref('{ test }'),
+      variables,
+    });
+
+    await query$;
+    expect(executeQuery).toHaveBeenCalledTimes(1);
+    expect(query$.operation.value).toHaveProperty('variables.prop', 1);
+
+    variables.prop++;
+    await query$;
+    expect(executeQuery).toHaveBeenCalledTimes(2);
+    expect(query$.operation.value).toHaveProperty('variables.prop', 2);
+
+    prop.value++;
+    await query$;
+    expect(executeQuery).toHaveBeenCalledTimes(3);
+    expect(query$.operation.value).toHaveProperty(
+      'variables.deep.nested.prop',
+      2
+    );
+  });
+
+  it('reacts to computed variables changing', async () => {
+    const prop = ref(1);
+    const prop2 = ref(1);
+    const variables = computed(() => ({
+      prop: prop.value,
+      deep: { nested: { prop2 } },
+    }));
+
+    const { executeQuery, query$ } = createQuery({
+      query: ref('{ test }'),
+      variables,
+    });
+
+    await query$;
+    expect(executeQuery).toHaveBeenCalledTimes(1);
+    expect(query$.operation.value).toHaveProperty('variables.prop', 1);
+
+    prop.value++;
+    await query$;
+    expect(executeQuery).toHaveBeenCalledTimes(2);
+    expect(query$.operation.value).toHaveProperty('variables.prop', 2);
+
+    prop2.value++;
+    await query$;
+    expect(executeQuery).toHaveBeenCalledTimes(3);
+    expect(query$.operation.value).toHaveProperty(
+      'variables.deep.nested.prop2',
+      2
+    );
+  });
+
+  it('reacts to callback variables changing', async () => {
+    const prop = ref(1);
+    const prop2 = ref(1);
+    const variables = () => ({
+      prop: prop.value,
+      deep: { nested: { prop2 } },
+    });
+
+    const { executeQuery, query$ } = createQuery({
+      query: ref('{ test }'),
+      variables,
+    });
+
+    await query$;
+    expect(executeQuery).toHaveBeenCalledTimes(1);
+    expect(query$.operation.value).toHaveProperty('variables.prop', 1);
+
+    prop.value++;
+    await query$;
+    expect(executeQuery).toHaveBeenCalledTimes(2);
+    expect(query$.operation.value).toHaveProperty('variables.prop', 2);
+
+    prop2.value++;
+    await query$;
+    expect(executeQuery).toHaveBeenCalledTimes(3);
+    expect(query$.operation.value).toHaveProperty(
+      'variables.deep.nested.prop2',
+      2
+    );
+  });
+
+  it('reacts to reactive context argument', async () => {
+    const context = ref<{ requestPolicy: RequestPolicy }>({
+      requestPolicy: 'cache-only',
+    });
+
+    const { executeQuery, query$ } = createQuery({
+      query: ref('{ test }'),
+      context,
+    });
+
+    await query$;
+    expect(executeQuery).toHaveBeenCalledTimes(1);
+
+    context.value.requestPolicy = 'network-only';
+    await query$;
+    expect(executeQuery).toHaveBeenCalledTimes(2);
+  });
+
+  it('reacts to callback context argument', async () => {
+    const requestPolicy = ref<RequestPolicy>('cache-only');
+
+    const { executeQuery, query$ } = createQuery({
+      query: ref('{ test }'),
+      context: () => ({
+        requestPolicy: requestPolicy.value,
+      }),
+    });
+
+    await query$;
+    expect(executeQuery).toHaveBeenCalledTimes(1);
+
+    requestPolicy.value = 'network-only';
+    await query$;
+    expect(executeQuery).toHaveBeenCalledTimes(2);
   });
 
   it('pauses query when asked to do so', async () => {
@@ -148,17 +319,15 @@ describe('useQuery', () => {
         () => subject.source as OperationResultSource<OperationResult>
       );
 
-    const pause = ref(true);
-
     const _query = useQuery({
       query: `{ test }`,
-      pause: () => pause.value,
+      pause: true,
     });
     const query = reactive(_query);
 
     expect(executeQuery).not.toHaveBeenCalled();
 
-    pause.value = false;
+    query.resume();
     await nextTick();
     expect(query.fetching).toBe(true);
 
@@ -166,5 +335,71 @@ describe('useQuery', () => {
 
     expect(query.fetching).toBe(false);
     expect(query.data).toEqual({ test: true });
+  });
+
+  it('pauses query with ref variable', async () => {
+    const pause = ref(true);
+
+    const { executeQuery, query$ } = createQuery({
+      query: ref('{ test }'),
+      pause,
+    });
+
+    await query$;
+    expect(executeQuery).not.toHaveBeenCalled();
+
+    pause.value = false;
+    await query$;
+    expect(executeQuery).toHaveBeenCalledTimes(1);
+
+    query$.pause();
+    query$.resume();
+    await query$;
+    expect(executeQuery).toHaveBeenCalledTimes(2);
+  });
+
+  it('pauses query with computed variable', async () => {
+    const pause = ref(true);
+
+    const { executeQuery, query$ } = createQuery({
+      query: ref('{ test }'),
+      pause: computed(() => pause.value),
+    });
+
+    await query$;
+    expect(executeQuery).not.toHaveBeenCalled();
+
+    pause.value = false;
+    await query$;
+    expect(executeQuery).toHaveBeenCalledTimes(1);
+
+    query$.pause();
+    query$.resume();
+    await query$;
+    // this shouldn't be called, as pause/resume functionality should works in sync with passed `pause` variable, e.g.:
+    // if we pass readonly computed variable, then we want to make sure that its value fully controls the state of the request.
+    expect(executeQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it('pauses query with callback', async () => {
+    const pause = ref(true);
+
+    const { executeQuery, query$ } = createQuery({
+      query: ref('{ test }'),
+      pause: () => pause.value,
+    });
+
+    await query$;
+    expect(executeQuery).not.toHaveBeenCalled();
+
+    pause.value = false;
+    await query$;
+    expect(executeQuery).toHaveBeenCalledTimes(1);
+
+    query$.pause();
+    query$.resume();
+    await query$;
+    // the same as computed variable example - user has full control over the request state if using callback
+    expect(executeQuery).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/vue-urql/src/useQuery.test.ts
+++ b/packages/vue-urql/src/useQuery.test.ts
@@ -120,6 +120,51 @@ describe('useQuery', () => {
     );
   });
 
+  it('runs a query with different variables', async () => {
+    const simpleVariables = {
+      null: null,
+      NaN: NaN,
+      empty: '',
+      bool: false,
+      int: 1,
+      float: 1.1,
+      string: 'string',
+      blob: new Blob(),
+      date: new Date(),
+    };
+
+    const variablesSet = {
+      func: () => 'func',
+      ref: ref('ref'),
+      computed: computed(() => 'computed'),
+      ...simpleVariables,
+    };
+
+    const variablesSetUnwrapped = {
+      func: 'func',
+      ref: 'ref',
+      computed: 'computed',
+      ...simpleVariables,
+    };
+
+    const { query$ } = createQuery({
+      query: ref('{ test }'),
+      variables: {
+        ...variablesSet,
+        nested: variablesSet,
+        array: [variablesSet],
+      },
+    });
+
+    await query$;
+
+    expect(query$.operation.value?.variables).toStrictEqual({
+      ...variablesSetUnwrapped,
+      nested: variablesSetUnwrapped,
+      array: [variablesSetUnwrapped],
+    });
+  });
+
   it('reacts to ref variables changing', async () => {
     const variables = ref({ prop: 1 });
 

--- a/packages/vue-urql/src/useQuery.test.ts
+++ b/packages/vue-urql/src/useQuery.test.ts
@@ -3,7 +3,7 @@ import {
   OperationResultSource,
   RequestPolicy,
 } from '@urql/core';
-import { computed, nextTick, reactive, ref } from 'vue';
+import { computed, nextTick, reactive, readonly, ref } from 'vue';
 import { vi, expect, it, describe } from 'vitest';
 
 vi.mock('./useClient.ts', async () => ({
@@ -45,12 +45,11 @@ describe('useQuery', () => {
         () => subject.source as OperationResultSource<OperationResult>
       );
 
-    const _query = useQuery({
+    const query = useQuery({
       query: `{ test }`,
     });
-    const query = reactive(_query);
 
-    expect(query).toMatchObject({
+    expect(readonly(query)).toMatchObject({
       data: undefined,
       stale: false,
       fetching: true,
@@ -76,12 +75,12 @@ describe('useQuery', () => {
       }
     );
 
-    expect(query.fetching).toBe(true);
+    expect(query.fetching.value).toBe(true);
 
     subject.next({ data: { test: true } });
 
-    expect(query.fetching).toBe(false);
-    expect(query.data).toEqual({ test: true });
+    expect(query.fetching.value).toBe(false);
+    expect(query.data.value).toHaveProperty('test', true);
   });
 
   it('runs queries as a promise-like that resolves when used', async () => {
@@ -319,22 +318,21 @@ describe('useQuery', () => {
         () => subject.source as OperationResultSource<OperationResult>
       );
 
-    const _query = useQuery({
+    const query = useQuery({
       query: `{ test }`,
       pause: true,
     });
-    const query = reactive(_query);
 
     expect(executeQuery).not.toHaveBeenCalled();
 
     query.resume();
     await nextTick();
-    expect(query.fetching).toBe(true);
+    expect(query.fetching.value).toBe(true);
 
     subject.next({ data: { test: true } });
 
-    expect(query.fetching).toBe(false);
-    expect(query.data).toEqual({ test: true });
+    expect(query.fetching.value).toBe(false);
+    expect(query.data.value).toHaveProperty('test', true);
   });
 
   it('pauses query with ref variable', async () => {

--- a/packages/vue-urql/src/useQuery.ts
+++ b/packages/vue-urql/src/useQuery.ts
@@ -262,7 +262,7 @@ export function callUseQuery<T = any, V extends AnyVariables = AnyVariables>(
     pause,
     resume,
     executeQuery(opts?: Partial<OperationContext>): UseQueryResponse<T, V> {
-      const s = (source.value = execute(opts));
+      const s = execute(opts);
 
       return {
         ...response,

--- a/packages/vue-urql/src/useQuery.ts
+++ b/packages/vue-urql/src/useQuery.ts
@@ -19,8 +19,7 @@ import type {
 import { useClient } from './useClient';
 
 import type { MaybeRef, MaybeRefObj } from './utils';
-import { useRequestState } from './utils';
-import { useClientState } from './utils';
+import { useRequestState, useClientState } from './utils';
 
 /** Input arguments for the {@link useQuery} function.
  *

--- a/packages/vue-urql/src/useQuery.ts
+++ b/packages/vue-urql/src/useQuery.ts
@@ -237,7 +237,7 @@ export function useQuery<T = any, V extends AnyVariables = AnyVariables>(
 export function callUseQuery<T = any, V extends AnyVariables = AnyVariables>(
   args: UseQueryArgs<T, V>,
   client: Ref<Client> = useClient(),
-  stops: WatchStopHandle[] = []
+  stops?: WatchStopHandle[]
 ): UseQueryResponse<T, V> {
   const data: Ref<T | undefined> = ref();
 
@@ -287,7 +287,7 @@ export function callUseQuery<T = any, V extends AnyVariables = AnyVariables>(
     }
   );
 
-  stops.push(teardown, teardownQuery);
+  stops && stops.push(teardown, teardownQuery);
 
   const then: UseQueryResponse<T, V>['then'] = (onFulfilled, onRejected) => {
     let sub: Subscription | void;

--- a/packages/vue-urql/src/useSubscription.ts
+++ b/packages/vue-urql/src/useSubscription.ts
@@ -17,8 +17,7 @@ import type {
 import { useClient } from './useClient';
 
 import type { MaybeRef, MaybeRefObj } from './utils';
-import { useRequestState } from './utils';
-import { useClientState } from './utils';
+import { useRequestState, useClientState } from './utils';
 
 /** Input arguments for the {@link useSubscription} function.
  *

--- a/packages/vue-urql/src/useSubscription.ts
+++ b/packages/vue-urql/src/useSubscription.ts
@@ -239,7 +239,6 @@ export function callUseSubscription<
   client: Ref<Client> = useClient()
 ): UseSubscriptionResponse<T, R, V> {
   const data: Ref<R | undefined> = ref();
-  const scanHandler = ref(handler);
 
   const { fetching, operation, extensions, stale, error } = useRequestState<
     T,
@@ -269,12 +268,10 @@ export function callUseSubscription<
             stale.value = !!result.stale;
             operation.value = result.operation;
 
-            if (result.data != null && scanHandler) {
-              const handler = isRef(scanHandler)
-                ? scanHandler.value
-                : scanHandler;
-              if (typeof handler === 'function') {
-                data.value = handler(data.value, result.data);
+            if (result.data != null && handler) {
+              const cb = isRef(handler) ? handler.value : handler;
+              if (typeof cb === 'function') {
+                data.value = cb(data.value, result.data);
                 return;
               }
             }

--- a/packages/vue-urql/src/useSubscription.ts
+++ b/packages/vue-urql/src/useSubscription.ts
@@ -293,7 +293,7 @@ export function callUseSubscription<
     executeSubscription(
       opts?: Partial<OperationContext>
     ): UseSubscriptionResponse<T, R, V> {
-      source.value = execute(opts);
+      execute(opts);
       return state;
     },
   };

--- a/packages/vue-urql/src/useSubscription.ts
+++ b/packages/vue-urql/src/useSubscription.ts
@@ -237,7 +237,7 @@ export function callUseSubscription<
   args: UseSubscriptionArgs<T, V>,
   handler?: SubscriptionHandlerArg<T, R>,
   client: Ref<Client> = useClient(),
-  stops: WatchStopHandle[] = []
+  stops?: WatchStopHandle[]
 ): UseSubscriptionResponse<T, R, V> {
   const data: Ref<R | undefined> = ref();
 
@@ -285,7 +285,7 @@ export function callUseSubscription<
     }
   });
 
-  stops.push(teardown, teardownSubscription);
+  stops && stops.push(teardown, teardownSubscription);
 
   const state: UseSubscriptionResponse<T, R, V> = {
     data,

--- a/packages/vue-urql/src/utils.ts
+++ b/packages/vue-urql/src/utils.ts
@@ -10,13 +10,18 @@ import type {
 } from '@urql/core';
 import { createRequest } from '@urql/core';
 import type { Ref } from 'vue';
-import { watchEffect } from 'vue';
-import { isReadonly } from 'vue';
-import { computed, readonly, ref, shallowRef } from 'vue';
-import { isRef } from 'vue';
+import {
+  watchEffect,
+  isReadonly,
+  computed,
+  readonly,
+  ref,
+  shallowRef,
+  isRef,
+} from 'vue';
 import type { UseSubscriptionArgs } from './useSubscription';
 import type { UseQueryArgs } from './useQuery';
-import type { DocumentNode } from 'graphql/index';
+import type { DocumentNode } from 'graphql';
 
 export type MaybeRef<T> = T | (() => T) | Ref<T>;
 export type MaybeRefObj<T> = T extends {}

--- a/packages/vue-urql/src/utils.ts
+++ b/packages/vue-urql/src/utils.ts
@@ -64,7 +64,8 @@ export function useClientState<T = any, V extends AnyVariables = AnyVariables>(
     // unwrap possible nested reactive variables with `readonly()`
     for (const prop in vars) {
       if (Object.hasOwn(vars, prop)) {
-        if (isRef(vars[prop])) {
+        const value = vars[prop];
+        if (value && (typeof value === 'object' || isRef(value))) {
           vars = readonly(vars);
           break;
         }

--- a/packages/vue-urql/src/utils.ts
+++ b/packages/vue-urql/src/utils.ts
@@ -33,14 +33,12 @@ const unwrapDeeply = <T>(input: T): T => {
     return unwrapDeeply(input()) as T;
   }
 
-  if (Array.isArray(input)) {
-    return input.map(item => unwrapDeeply(item)) as T;
-  }
-
   if (input && typeof input === 'object') {
-    const out = {} as T;
+    const isArray = Array.isArray(input);
+    const out = (isArray ? [] : {}) as T;
     for (const prop in input) {
       if (
+        isArray ||
         (Object.hasOwn || Object.prototype.hasOwnProperty.call)(input, prop)
       ) {
         out[prop] = unwrapDeeply(input[prop]);

--- a/packages/vue-urql/src/utils.ts
+++ b/packages/vue-urql/src/utils.ts
@@ -1,6 +1,20 @@
-import type { GraphQLRequest, AnyVariables } from '@urql/core';
-import type { Ref, ShallowRef } from 'vue';
+import type {
+  AnyVariables,
+  Client,
+  CombinedError,
+  Operation,
+  OperationContext,
+  OperationResult,
+} from '@urql/core';
+import { createRequest } from '@urql/core';
+import type { Ref } from 'vue';
+import { watchEffect } from 'vue';
+import { isReadonly } from 'vue';
+import { computed, readonly, ref, shallowRef } from 'vue';
 import { isRef } from 'vue';
+import type { Source } from 'wonka';
+import type { UseSubscriptionArgs } from './useSubscription';
+import type { UseQueryArgs } from './useQuery';
 
 export type MaybeRef<T> = T | (() => T) | Ref<T>;
 export type MaybeRefObj<T> = T extends {}
@@ -14,32 +28,91 @@ export const unref = <T>(maybeRef: MaybeRef<T>): T =>
     ? maybeRef.value
     : maybeRef;
 
-export interface RequestState<
-  Data = any,
-  Variables extends AnyVariables = AnyVariables,
-> {
-  request: GraphQLRequest<Data, Variables>;
-  isPaused: boolean;
-}
-
-export function createRequestState<
-  Data = any,
-  Variables extends AnyVariables = AnyVariables,
->(
-  request: GraphQLRequest<Data, Variables>,
-  isPaused: boolean
-): RequestState<Data, Variables> {
-  return { request, isPaused };
-}
-
-export const updateShallowRef = <T extends Record<string, any>>(
-  ref: ShallowRef<T>,
-  next: T
-) => {
-  for (const key in next) {
-    if (ref.value[key] !== next[key]) {
-      ref.value = next;
-      return;
-    }
-  }
+export const useRequestState = <
+  T = any,
+  V extends AnyVariables = AnyVariables,
+>() => {
+  const stale: Ref<boolean> = ref(false);
+  const fetching: Ref<boolean> = ref(false);
+  const error: Ref<CombinedError | undefined> = shallowRef();
+  const operation: Ref<Operation<T, V> | undefined> = shallowRef();
+  const extensions: Ref<Record<string, any> | undefined> = shallowRef();
+  return {
+    stale,
+    fetching,
+    error,
+    operation,
+    extensions,
+  };
 };
+
+export function useClientState<T = any, V extends AnyVariables = AnyVariables>(
+  args: UseQueryArgs<T, V> | UseSubscriptionArgs<T, V>,
+  client: Ref<Client>,
+  method: keyof Pick<Client, 'executeSubscription' | 'executeQuery'>
+) {
+  const source: Ref<Source<OperationResult<T, V>> | undefined> = shallowRef();
+
+  const isPaused: Ref<boolean> = isRef(args.pause)
+    ? args.pause
+    : typeof args.pause === 'function'
+    ? computed(args.pause)
+    : ref(!!args.pause);
+
+  const request = computed(() => {
+    let vars = unref(args.variables);
+
+    // unwrap possible nested reactive variables
+    for (const prop in vars) {
+      if (Object.hasOwn(vars, prop)) {
+        if (isRef(vars[prop])) {
+          vars = readonly(vars);
+          break;
+        }
+      }
+    }
+    return createRequest<T, V>(unref(args.query), vars as V);
+  });
+
+  const requestOptions = computed(() => {
+    return 'requestPolicy' in args
+      ? {
+          requestPolicy: unref(args.requestPolicy),
+          ...unref(args.context),
+        }
+      : {
+          ...unref(args.context),
+        };
+  });
+
+  const pause = () => {
+    if (!isReadonly(isPaused)) {
+      isPaused.value = true;
+    }
+  };
+
+  const resume = () => {
+    if (!isReadonly(isPaused)) {
+      isPaused.value = false;
+    }
+  };
+
+  const execute = (opts?: Partial<OperationContext>) => {
+    return client.value[method]<T, V>(request.value, {
+      ...requestOptions.value,
+      ...opts,
+    });
+  };
+
+  watchEffect(() => {
+    source.value = !isPaused.value ? execute() : undefined;
+  });
+
+  return {
+    source,
+    isPaused,
+    pause,
+    resume,
+    execute,
+  };
+}

--- a/packages/vue-urql/src/utils.ts
+++ b/packages/vue-urql/src/utils.ts
@@ -133,7 +133,7 @@ export function useClientState<T = any, V extends AnyVariables = AnyVariables>(
   };
 
   // it's important to use `watchEffect()` here instead of `watch()`
-  // because it listening for reactive variables inside `execute()` function
+  // because it listening for reactive variables inside `executeRaw()` function
   watchEffect(() => {
     source.value = !isPaused.value ? executeRaw() : undefined;
   });

--- a/packages/vue-urql/src/utils.ts
+++ b/packages/vue-urql/src/utils.ts
@@ -61,8 +61,7 @@ export function useClientState<T = any, V extends AnyVariables = AnyVariables>(
 
   const request = computed(() => {
     let vars = unref(args.variables);
-
-    // unwrap possible nested reactive variables
+    // unwrap possible nested reactive variables with `readonly()`
     for (const prop in vars) {
       if (Object.hasOwn(vars, prop)) {
         if (isRef(vars[prop])) {
@@ -104,6 +103,8 @@ export function useClientState<T = any, V extends AnyVariables = AnyVariables>(
     });
   };
 
+  // it's important to use `watchEffect()` here instead of `watch()`
+  // because it listening for reactive variables inside `execute()` function
   watchEffect(() => {
     source.value = !isPaused.value ? execute() : undefined;
   });

--- a/packages/vue-urql/src/utils.ts
+++ b/packages/vue-urql/src/utils.ts
@@ -129,7 +129,6 @@ export function useClientState<T = any, V extends AnyVariables = AnyVariables>(
 
   const execute = (opts?: Partial<OperationContext>) => {
     source.value = executeRaw(opts);
-    return source.value;
   };
 
   // it's important to use `watchEffect()` here instead of `watch()`

--- a/packages/vue-urql/src/utils.ts
+++ b/packages/vue-urql/src/utils.ts
@@ -133,7 +133,7 @@ export function useClientState<T = any, V extends AnyVariables = AnyVariables>(
 
   // it's important to use `watchEffect()` here instead of `watch()`
   // because it listening for reactive variables inside `executeRaw()` function
-  watchEffect(() => {
+  const teardown = watchEffect(() => {
     source.value = !isPaused.value ? executeRaw() : undefined;
   });
 
@@ -143,5 +143,6 @@ export function useClientState<T = any, V extends AnyVariables = AnyVariables>(
     pause,
     resume,
     execute,
+    teardown,
   };
 }

--- a/packages/vue-urql/src/utils.ts
+++ b/packages/vue-urql/src/utils.ts
@@ -26,6 +26,12 @@ const unwrap = <T>(maybeRef: MaybeRef<T>): T =>
     ? maybeRef.value
     : maybeRef;
 
+const _toString = Object.prototype.toString;
+const isPlainObject = (obj: any): boolean => {
+  return _toString.call(obj) === '[object Object]';
+};
+export const isArray = Array.isArray;
+
 const unwrapDeeply = <T>(input: T): T => {
   input = isRef(input) ? (input.value as T) : input;
 
@@ -34,17 +40,29 @@ const unwrapDeeply = <T>(input: T): T => {
   }
 
   if (input && typeof input === 'object') {
-    const isArray = Array.isArray(input);
-    const out = (isArray ? [] : {}) as T;
-    for (const prop in input) {
-      if (
-        isArray ||
-        (Object.hasOwn || Object.prototype.hasOwnProperty.call)(input, prop)
-      ) {
-        out[prop] = unwrapDeeply(input[prop]);
+    if (isArray(input)) {
+      const length = input.length;
+      const out = new Array(length) as T;
+      let i = 0;
+      for (; i < length; i++) {
+        out[i] = unwrapDeeply(input[i]);
       }
+
+      return out;
+    } else if (isPlainObject(input)) {
+      const keys = Object.keys(input);
+      const length = keys.length;
+      let i = 0;
+      let key: string;
+      const out = {} as T;
+
+      for (; i < length; i++) {
+        key = keys[i];
+        out[key] = unwrapDeeply(input[key]);
+      }
+
+      return out;
     }
-    return out;
   }
 
   return input;

--- a/packages/vue-urql/src/utils.ts
+++ b/packages/vue-urql/src/utils.ts
@@ -120,17 +120,22 @@ export function useClientState<T = any, V extends AnyVariables = AnyVariables>(
     }
   };
 
-  const execute = (opts?: Partial<OperationContext>) => {
+  const executeRaw = (opts?: Partial<OperationContext>) => {
     return client.value[method]<T, V>(request.value, {
       ...requestOptions.value,
       ...opts,
     });
   };
 
+  const execute = (opts?: Partial<OperationContext>) => {
+    source.value = executeRaw(opts);
+    return source.value;
+  };
+
   // it's important to use `watchEffect()` here instead of `watch()`
   // because it listening for reactive variables inside `execute()` function
   watchEffect(() => {
-    source.value = !isPaused.value ? execute() : undefined;
+    source.value = !isPaused.value ? executeRaw() : undefined;
   });
 
   return {

--- a/packages/vue-urql/src/utils.ts
+++ b/packages/vue-urql/src/utils.ts
@@ -27,8 +27,15 @@ const unwrap = <T>(maybeRef: MaybeRef<T>): T =>
     : maybeRef;
 
 const _toString = Object.prototype.toString;
-const isPlainObject = (obj: any): boolean => {
-  return _toString.call(obj) === '[object Object]';
+const isPlainObject = (value: any): boolean => {
+  if (typeof value !== 'object' || value === null) return false;
+
+  if (_toString.call(value) !== '[object Object]') return false;
+
+  return (
+    value.constructor &&
+    Object.getPrototypeOf(value).constructor === Object.prototype.constructor
+  );
 };
 export const isArray = Array.isArray;
 

--- a/packages/vue-urql/src/utils.ts
+++ b/packages/vue-urql/src/utils.ts
@@ -26,12 +26,8 @@ const unwrap = <T>(maybeRef: MaybeRef<T>): T =>
     ? maybeRef.value
     : maybeRef;
 
-const _toString = Object.prototype.toString;
 const isPlainObject = (value: any): boolean => {
   if (typeof value !== 'object' || value === null) return false;
-
-  if (_toString.call(value) !== '[object Object]') return false;
-
   return (
     value.constructor &&
     Object.getPrototypeOf(value).constructor === Object.prototype.constructor

--- a/packages/vue-urql/src/utils.ts
+++ b/packages/vue-urql/src/utils.ts
@@ -45,12 +45,14 @@ export const createRequestWithArgs = <
 ) => {
   let vars = unwrap(args.variables);
   // unwrap possible nested reactive variables with `readonly()`
-  for (const prop in vars) {
-    if (Object.hasOwn(vars, prop)) {
-      const value = vars[prop];
-      if (value && (typeof value === 'object' || isRef(value))) {
-        vars = readonly(vars);
-        break;
+  if (vars) {
+    for (const prop in vars) {
+      if ((Object.hasOwn || Object.prototype.hasOwnProperty.call)(vars, prop)) {
+        const value = vars[prop];
+        if (value && (typeof value === 'object' || isRef(value))) {
+          vars = readonly(vars);
+          break;
+        }
       }
     }
   }

--- a/packages/vue-urql/src/utils.ts
+++ b/packages/vue-urql/src/utils.ts
@@ -2,11 +2,11 @@ import type {
   AnyVariables,
   Client,
   CombinedError,
+  DocumentInput,
   Operation,
   OperationContext,
   OperationResult,
   OperationResultSource,
-  TypedDocumentNode,
 } from '@urql/core';
 import { createRequest } from '@urql/core';
 import type { Ref } from 'vue';
@@ -21,17 +21,11 @@ import {
 } from 'vue';
 import type { UseSubscriptionArgs } from './useSubscription';
 import type { UseQueryArgs } from './useQuery';
-import type { DocumentNode } from 'graphql';
 
 export type MaybeRef<T> = T | (() => T) | Ref<T>;
 export type MaybeRefObj<T> = T extends {}
   ? { [K in keyof T]: MaybeRef<T[K]> }
   : T;
-
-export type MutationDocumentNode<
-  T = any,
-  V extends AnyVariables = AnyVariables,
-> = TypedDocumentNode<T, V> | DocumentNode | string;
 
 const unwrap = <T>(maybeRef: MaybeRef<T>): T =>
   typeof maybeRef === 'function'
@@ -47,7 +41,7 @@ export const createRequestWithArgs = <
   args:
     | UseQueryArgs<T, V>
     | UseSubscriptionArgs<T, V>
-    | { query: MaybeRef<MutationDocumentNode>; variables: V }
+    | { query: MaybeRef<DocumentInput<T, V>>; variables: V }
 ) => {
   let vars = unwrap(args.variables);
   // unwrap possible nested reactive variables with `readonly()`

--- a/packages/vue-urql/src/utils.ts
+++ b/packages/vue-urql/src/utils.ts
@@ -23,10 +23,10 @@ export type MaybeRefObj<T> = T extends {}
   ? { [K in keyof T]: MaybeRef<T[K]> }
   : T;
 
-export type MutationQuery<T = any, V extends AnyVariables = AnyVariables> =
-  | TypedDocumentNode<T, V>
-  | DocumentNode
-  | string;
+export type MutationDocumentNode<
+  T = any,
+  V extends AnyVariables = AnyVariables,
+> = TypedDocumentNode<T, V> | DocumentNode | string;
 
 const unwrap = <T>(maybeRef: MaybeRef<T>): T =>
   typeof maybeRef === 'function'
@@ -42,7 +42,7 @@ export const createRequestWithArgs = <
   args:
     | UseQueryArgs<T, V>
     | UseSubscriptionArgs<T, V>
-    | { query: MaybeRef<MutationQuery>; variables: V }
+    | { query: MaybeRef<MutationDocumentNode>; variables: V }
 ) => {
   let vars = unwrap(args.variables);
   // unwrap possible nested reactive variables with `readonly()`

--- a/packages/vue-urql/src/utils.ts
+++ b/packages/vue-urql/src/utils.ts
@@ -28,7 +28,7 @@ export type MutationQuery<T = any, V extends AnyVariables = AnyVariables> =
   | DocumentNode
   | string;
 
-export const unref = <T>(maybeRef: MaybeRef<T>): T =>
+const unwrap = <T>(maybeRef: MaybeRef<T>): T =>
   typeof maybeRef === 'function'
     ? (maybeRef as () => T)()
     : maybeRef != null && isRef(maybeRef)
@@ -44,7 +44,7 @@ export const createRequestWithArgs = <
     | UseSubscriptionArgs<T, V>
     | { query: MaybeRef<MutationQuery>; variables: V }
 ) => {
-  let vars = unref(args.variables);
+  let vars = unwrap(args.variables);
   // unwrap possible nested reactive variables with `readonly()`
   for (const prop in vars) {
     if (Object.hasOwn(vars, prop)) {
@@ -55,7 +55,7 @@ export const createRequestWithArgs = <
       }
     }
   }
-  return createRequest<T, V>(unref(args.query), vars as V);
+  return createRequest<T, V>(unwrap(args.query), vars as V);
 };
 
 export const useRequestState = <
@@ -95,11 +95,11 @@ export function useClientState<T = any, V extends AnyVariables = AnyVariables>(
   const requestOptions = computed(() => {
     return 'requestPolicy' in args
       ? {
-          requestPolicy: unref(args.requestPolicy),
-          ...unref(args.context),
+          requestPolicy: unwrap(args.requestPolicy),
+          ...unwrap(args.context),
         }
       : {
-          ...unref(args.context),
+          ...unwrap(args.context),
         };
   });
 


### PR DESCRIPTION
Resolves https://github.com/urql-graphql/urql/issues/3507
Resolves https://github.com/urql-graphql/urql/issues/3633

## Summary

This includes https://github.com/urql-graphql/urql/pull/3612, but fixed reactivity loosing here.

In addition, a little refactoring for `use*` composable functions for reducing code duplication and adding more test cases.

## Set of changes

* Remove wrapping args in reactive in useQuery.ts and useSubscription.ts
* Add `createRequestWithArgs()`, `useClientState()` and `useRequestState()` utils to avoid code duplication.
* Refactor `useQuery()`, `useSubscription()` and `useMutation()` to use shared  utils mentioned above.
* Add `isReadonly()` check before changing `isPaused` variable, as it could be readonly.
* ~~Remove `onBeforeUnmount` and unwatch handlers, as [watcher automatically stopped when the owner component is unmounted](https://vuejs.org/guide/essentials/watchers.html#stopping-a-watcher)~~
* Remove `flush: 'pre'` in watcher options, as this is default setting
* Rename `unref()` to `unwrap()` to avoid confusions with vue function
* Reuse `then()` handler for `useQuery()` for cleaner code and avoid duplications
* Cover of reactive arguments usage with test cases