### PR TITLE
fix(docs): fix typo'd URL

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,7 @@ As you use it in your app, it's split into three parts:
 
 - Bindings — such as for React, Preact, Vue, or Svelte — which interact with `@urql/core`'s
   `Client`.
-- The Client — as created [with the core `@urql/core` package](./basics/code.md), which interacts with "exchanges" to execute GraphQL
+- The Client — as created [with the core `@urql/core` package](./basics/core.md), which interacts with "exchanges" to execute GraphQL
   operations, and which you can also use directly.
 - Exchanges, which provide functionality like fetching or caching to the `Client`.
 


### PR DESCRIPTION
At least I think this is where it was meant to go. The current one 404s.