### PR TITLE
perf(core): remove duplicate `JSON.stringify` call on `data` in `ssrExchange`

### DIFF
--- a/.changeset/sweet-goats-judge.md
+++ b/.changeset/sweet-goats-judge.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Removes double serialization of `data` in `ssrExchange`

--- a/packages/core/src/exchanges/ssr.ts
+++ b/packages/core/src/exchanges/ssr.ts
@@ -109,7 +109,6 @@ const serializeResult = (
   includeExtensions: boolean
 ): SerializedResult => {
   const serialized: SerializedResult = {
-    data: JSON.stringify(result.data),
     hasNext: result.hasNext,
   };
 


### PR DESCRIPTION

## Summary

Removes the unnecessary `JSON.stringify` when serializing, since it will be called below anyway

![image](https://github.com/user-attachments/assets/6ea2e313-3740-4a8e-945a-e7fc13d03558)

## Set of changes

Removing the `data` pre-property in exchange/ssr during serialization
