### PR TITLE
add support for Svelte 5

### DIFF
--- a/.changeset/mighty-parents-fetch.md
+++ b/.changeset/mighty-parents-fetch.md
@@ -1,0 +1,5 @@
+---
+"@urql/svelte": patch
+---
+
+add support for Svelte 5 in the `peerDependencies`

--- a/packages/svelte-urql/package.json
+++ b/packages/svelte-urql/package.json
@@ -50,7 +50,7 @@
   },
   "peerDependencies": {
     "@urql/core": "^5.0.0",
-    "svelte": "^3.0.0 || ^4.0.0"
+    "svelte": "^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "dependencies": {
     "@urql/core": "^5.0.0",


### PR DESCRIPTION


## Summary

add support for Svelte 5, currently svelte 5 is not supported

## Set of changes

svelte-urql package is changed, but shouldn't affect anything
