### PR TITLE
perf(vue): use shallowRef for data

### DIFF
--- a/.changeset/old-humans-knock.md
+++ b/.changeset/old-humans-knock.md
@@ -1,0 +1,5 @@
+---
+'@urql/vue': patch
+---
+
+Use `shallowRef` for data variable to avoid extra overhead for heavy objects

--- a/packages/vue-urql/src/useMutation.ts
+++ b/packages/vue-urql/src/useMutation.ts
@@ -1,7 +1,7 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 
 import type { Ref } from 'vue';
-import { ref } from 'vue';
+import { shallowRef } from 'vue';
 import { pipe, onPush, filter, toPromise, take } from 'wonka';
 
 import type {
@@ -133,7 +133,7 @@ export function callUseMutation<T = any, V extends AnyVariables = AnyVariables>(
   query: MaybeRef<DocumentInput<T, V>>,
   client: Ref<Client> = useClient()
 ): UseMutationResponse<T, V> {
-  const data: Ref<T | undefined> = ref();
+  const data: Ref<T | undefined> = shallowRef();
 
   const { fetching, operation, extensions, stale, error } = useRequestState<
     T,

--- a/packages/vue-urql/src/useQuery.ts
+++ b/packages/vue-urql/src/useQuery.ts
@@ -1,7 +1,7 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 
 import type { Ref, WatchStopHandle } from 'vue';
-import { ref, watchEffect } from 'vue';
+import { shallowRef, watchEffect } from 'vue';
 
 import type { Subscription } from 'wonka';
 import { pipe, subscribe, onEnd } from 'wonka';
@@ -239,7 +239,7 @@ export function callUseQuery<T = any, V extends AnyVariables = AnyVariables>(
   client: Ref<Client> = useClient(),
   stops?: WatchStopHandle[]
 ): UseQueryResponse<T, V> {
-  const data: Ref<T | undefined> = ref();
+  const data: Ref<T | undefined> = shallowRef();
 
   const { fetching, operation, extensions, stale, error } = useRequestState<
     T,

--- a/packages/vue-urql/src/useSubscription.ts
+++ b/packages/vue-urql/src/useSubscription.ts
@@ -3,7 +3,7 @@
 import { pipe, subscribe, onEnd } from 'wonka';
 
 import type { Ref, WatchStopHandle } from 'vue';
-import { isRef, ref, watchEffect } from 'vue';
+import { shallowRef, isRef, watchEffect } from 'vue';
 
 import type {
   Client,
@@ -239,7 +239,7 @@ export function callUseSubscription<
   client: Ref<Client> = useClient(),
   stops?: WatchStopHandle[]
 ): UseSubscriptionResponse<T, R, V> {
-  const data: Ref<R | undefined> = ref();
+  const data: Ref<R | undefined> = shallowRef();
 
   const { fetching, operation, extensions, stale, error } = useRequestState<
     T,


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR, but please make sure to open an issue or discuss
  your changes first, if you’re looking to submit a larger PR.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

As graphql response usually contains a quite huge nested objects structure, wrapping it with `ref()` is not memory efficient.
Instead of doing this, it's more efficient to use `shallowRef()` for `data` reactive variable, where the payload is stored.

However, in https://github.com/urql-graphql/urql/pull/3611 while optimizing other variables, @negezor missed the `data` variable. I can assume there was a reason for that, so I consider this PR as a suggestion/discussion. Personally, I don't see any negative side effects from using `shallowRef()`, but maybe you guys have some thought on it.

I see only one possible scenario in which this would be a "breaking change": updating some nested `data` parts manually outside of this plugin, but I'd say - this is a quite specific pattern.

<!-- What's the motivation of this change? What does it solve? -->

## Set of changes
- Replaces `ref()` with `shallowRef()` for the `data` variable

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->
