### PR TITLE
chore(SSRExchange): Remove 2nd data serialization

### DIFF
--- a/packages/core/src/exchanges/ssr.ts
+++ b/packages/core/src/exchanges/ssr.ts
@@ -113,10 +113,6 @@ const serializeResult = (
     hasNext: result.hasNext,
   };
 
-  if (result.data !== undefined) {
-    serialized.data = JSON.stringify(result.data);
-  }
-
   if (includeExtensions && result.extensions !== undefined) {
     serialized.extensions = JSON.stringify(result.extensions);
   }


### PR DESCRIPTION
It is unnecessary to set it a 2nd time.

The preceding code is

```
  const serialized: SerializedResult = {
    data: JSON.stringify(result.data),
    hasNext: result.hasNext,
  };
```

which has initialized `serialized.data` with the very same value that the removed code is setting.

<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR, but please make sure to open an issue or discuss
  your changes first, if you’re looking to submit a larger PR.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

<!-- What's the motivation of this change? What does it solve? -->

## Set of changes

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->
