### PR TITLE
fix(core): Allow for empty error messages when rehydrating

### DIFF
--- a/.changeset/good-walls-obey.md
+++ b/.changeset/good-walls-obey.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Allow empty error messages when re-hydrating GraphQL errors

--- a/packages/core/src/utils/error.test.ts
+++ b/packages/core/src/utils/error.test.ts
@@ -60,6 +60,16 @@ describe('CombinedError', () => {
     expect(err.graphQLErrors).toEqual(graphQLErrors);
   });
 
+  it('accepts empty string errors for graphQLError', () => {
+    const graphQLErrors = [new Error('')];
+
+    const err = new CombinedError({ graphQLErrors });
+
+    expect(err.message).toBe('[GraphQL] ');
+
+    expect(err.graphQLErrors).toEqual(graphQLErrors);
+  });
+
   it('accepts a response that is attached to the resulting error', () => {
     const response = {};
     const err = new CombinedError({

--- a/packages/core/src/utils/error.ts
+++ b/packages/core/src/utils/error.ts
@@ -19,11 +19,11 @@ const generateErrorMessage = (
 const rehydrateGraphQlError = (error: any): GraphQLError => {
   if (
     error &&
-    error.message &&
+    typeof error.message === 'string' &&
     (error.extensions || error.name === 'GraphQLError')
   ) {
     return error;
-  } else if (typeof error === 'object' && error.message) {
+  } else if (typeof error === 'object' && typeof error.message === 'string') {
     return new GraphQLError(
       error.message,
       error.nodes,


### PR DESCRIPTION
Fixes #3649 

## Summary

Allow for empty error messages when rehydrating