### PR TITLE
moved the data constant outside of the ssrExchange closure

### DIFF
--- a/packages/core/src/exchanges/ssr.ts
+++ b/packages/core/src/exchanges/ssr.ts
@@ -168,6 +168,7 @@ const deserializeResult = (
 });
 
 const revalidated = new Set<number>();
+const data: Record<string, SerializedResult | null> = {};
 
 /** Creates a server-side rendering `Exchange` that either captures responses on the server-side or replays them on the client-side.
  *
@@ -188,7 +189,6 @@ const revalidated = new Set<number>();
 export const ssrExchange = (params: SSRExchangeParams = {}): SSRExchange => {
   const staleWhileRevalidate = !!params.staleWhileRevalidate;
   const includeExtensions = !!params.includeExtensions;
-  const data: Record<string, SerializedResult | null> = {};
 
   // On the client-side, we delete results from the cache as they're resolved
   // this is delayed so that concurrent queries don't delete each other's data


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR, but please make sure to open an issue or discuss
  your changes first, if you’re looking to submit a larger PR.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

In scenarios when ssrExchange was called multiple times, each time a new reference of the `data` constant was created. However, within the `ssr` function defined inside `ssrExchange`, only the very first reference of the data variable was used, which caused a mismatch. For example, in Next.js this caused a bug where during client-side navigation, if a query was prefetched inside `getServerSideProps` of the page the user has navigated to, the result was stored in the SSR cache, but it was never used, as it was filled into a different object (different reference) than the one that was used originally. Because of this, the URQL client searched for the data in the wrong place and it never found it. This caused the query to be refetched and the layout to shift because of the missing data.

## Set of changes

The data constant (object to which the SSR-prefetched data is stored) was moved outside of the `ssrExchange` closure to ensure just a single reference being used.
