### PR TITLE
fix: use debug for log

### DIFF
--- a/packages/core/src/exchanges/debug.ts
+++ b/packages/core/src/exchanges/debug.ts
@@ -23,11 +23,11 @@ export const debugExchange: Exchange = ({ forward }) => {
       pipe(
         ops$,
         // eslint-disable-next-line no-console
-        tap(op => console.log('[Exchange debug]: Incoming operation: ', op)),
+        tap(op => console.debug('[Exchange debug]: Incoming operation: ', op)),
         forward,
         tap(result =>
           // eslint-disable-next-line no-console
-          console.log('[Exchange debug]: Completed operation: ', result)
+          console.debug('[Exchange debug]: Completed operation: ', result)
         )
       );
   }


### PR DESCRIPTION

## Summary

Because this is a debugging tool, the console output should be categorized as `debug`.

## Set of changes

- Update the `console.log(...)` to `console.debug(...)`
