### PR TITLE
chore: @urql/next expose SSRContext

### DIFF
--- a/.changeset/hungry-pandas-accept.md
+++ b/.changeset/hungry-pandas-accept.md
@@ -1,0 +1,5 @@
+---
+'@urql/next': patch
+---
+
+export SSRContext from provider

--- a/packages/next-urql/src/index.ts
+++ b/packages/next-urql/src/index.ts
@@ -1,3 +1,3 @@
 export * from 'urql';
 export { useQuery } from './useQuery';
-export { UrqlProvider } from './Provider';
+export { UrqlProvider, SSRContext } from './Provider';


### PR DESCRIPTION
## Summary

Export `SSRContext` from @urql/next so the provider can be used in tests.

## Set of changes

Exports `SSRContext` from `@urql/next`

