### PR TITLE
fix(graphcache): mutation would cause dependent operations and reexecuting operations become the same set

### DIFF
--- a/.changeset/tidy-spies-turn.md
+++ b/.changeset/tidy-spies-turn.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+fix bug that mutation would cause dependent operations and reexecuting operations to become the same set

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -136,8 +136,9 @@ export const cacheExchange =
         // Upon completion, all dependent operations become reexecuting operations, preventing
         // them from reexecuting prior operations again, causing infinite loops
         const _reexecutingOperations = reexecutingOperations;
+        reexecutingOperations = dependentOperations;
         if (operation.kind === 'query') {
-          (reexecutingOperations = dependentOperations).add(operation.key);
+          reexecutingOperations.add(operation.key);
         }
         (dependentOperations = _reexecutingOperations).clear();
       }


### PR DESCRIPTION


## Summary

The PR #2761 moved `reexecutingOperations = dependentOperations` assignment into `if (operation.kind === 'query')` guard. Thus after a completion of mutation, `dependentOperations = _reexecutingOperations` make reexecuting and dependent operations the same set object.

I noticed this issue after debugging the bug reported in discord https://discord.com/channels/1082378892523864074/1082386845553406002/1281542643670712334

