### PR TITLE
fix(solid): Export Provider from the entry

### DIFF
--- a/.changeset/chilly-cows-brake.md
+++ b/.changeset/chilly-cows-brake.md
@@ -1,0 +1,5 @@
+---
+'@urql/solid': patch
+---
+
+Export Provider from the entry

--- a/package.json
+++ b/package.json
@@ -113,5 +113,6 @@
   "dependencies": {
     "@actions/github": "^5.1.1",
     "node-fetch": "^3.3.1"
-  }
+  },
+  "packageManager": "pnpm@9.9.0+sha512.60c18acd138bff695d339be6ad13f7e936eea6745660d4cc4a776d5247c540d0edee1a563695c183a66eb917ef88f2b4feb1fc25f32a7adcadc7aaf3438e99c1"
 }

--- a/packages/solid-urql/src/index.ts
+++ b/packages/solid-urql/src/index.ts
@@ -1,7 +1,7 @@
 export * from '@urql/core';
 
 export { type UseClient } from './context';
-export { useClient } from './context';
+export { useClient, Provider } from './context';
 
 export {
   type CreateMutationState,


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR, but please make sure to open an issue or discuss
  your changes first, if you’re looking to submit a larger PR.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

<!-- What's the motivation of this change? What does it solve? -->
Adds the missing export for context provider component in `@urql/solid`

## Set of changes

- Adds the export