### PR TITLE
fix(solid): Correctly track query data reads with suspense

### DIFF
--- a/.changeset/healthy-years-ring.md
+++ b/.changeset/healthy-years-ring.md
@@ -1,0 +1,5 @@
+---
+'@urql/solid': patch
+---
+
+fix(solid): Correctly track query data reads with suspense

--- a/.changeset/healthy-years-ring.md
+++ b/.changeset/healthy-years-ring.md
@@ -2,4 +2,4 @@
 '@urql/solid': patch
 ---
 
-fix(solid): Correctly track query data reads with suspense
+Correctly track query data reads with suspense

--- a/packages/solid-urql/src/createQuery.ts
+++ b/packages/solid-urql/src/createQuery.ts
@@ -321,11 +321,7 @@ export const createQuery = <
     ): any {
       if (isSuspense() && prop === 'data') {
         const resource = dataResource();
-        if (resource !== undefined) {
-          return resource.data;
-        }
-
-        return undefined;
+        if (resource === undefined) return undefined;
       }
 
       return Reflect.get(target, prop);


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR, but please make sure to open an issue or discuss
  your changes first, if you’re looking to submit a larger PR.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

<!-- What's the motivation of this change? What does it solve? -->
This PR fixes a bug in `@urql/solid` that the change tracking for `query.data` is not working when the client has `suspense: true`.

## Set of changes

Read data from the store instead of the resource, so further changes on store can be tracked and reflected to the returned value