### PR TITLE
docs(site): Fix no favicon on site (except on home page)

### DIFF
--- a/packages/site/src/html.js
+++ b/packages/site/src/html.js
@@ -25,7 +25,7 @@ const Document = ({ Html, Head, Body, children }) => (
         rel="icon"
         type="image/png"
         sizes="32x32"
-        href="./favicon/favicon-32.png"
+        href="/favicon/favicon-32.png"
       />
       <link rel="manifest" href="./site.webmanifest" />
       <meta name="msapplication-TileColor" content="#ff4081" />


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR, but please make sure to open an issue or discuss
  your changes first, if you’re looking to submit a larger PR.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

<!-- What's the motivation of this change? What does it solve? -->

On any page of the docs site (i.e. https://commerce.nearform.com/open-source/urql/docs/basics/vue/), the _favicon_ is missing, due to a `404` error trying to fetch it.

## Set of changes

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->

The path to the _favicon_ is relatively defined in [html.js](https://github.com/urql-graphql/urql/blob/main/packages/site/src/html.js#L28), changing it to absolute path.
