### PR TITLE
Fix @_required directive when the schema is available

### DIFF
--- a/exchanges/graphcache/src/operations/query.ts
+++ b/exchanges/graphcache/src/operations/query.ts
@@ -534,7 +534,7 @@ const readSelection = (
       (directives.optional ||
         (optionalRef && !directives.required) ||
         !!getFieldError(ctx) ||
-        (store.schema &&
+        (!directives.required && store.schema &&
           isFieldNullable(store.schema, typename, fieldName, ctx.store.logger)))
     ) {
       // The field is uncached or has errored, so it'll be set to null and skipped


### PR DESCRIPTION
If graphcache was configured with the full schema, the `@_required` directive would be ignored on nullable fields. This diff tweaks the condition to fix that behaviour.