### PR TITLE
Allow @defer to work in queries with suspense enabled

### DIFF
--- a/.changeset/shiny-eagles-join.md
+++ b/.changeset/shiny-eagles-join.md
@@ -1,0 +1,5 @@
+---
+'urql': minor
+---
+
+Support use of defer with suspense

--- a/packages/react-urql/src/hooks/useQuery.ts
+++ b/packages/react-urql/src/hooks/useQuery.ts
@@ -263,7 +263,12 @@ export function useQuery<
 
         const subscription = pipe(
           source,
-          takeWhile(() => (suspense && !resolve) || !result),
+          takeWhile(
+            () =>
+              (suspense && !resolve) ||
+              !result ||
+              ('hasNext' in result && result.hasNext)
+          ),
           subscribe(_result => {
             result = _result;
             if (resolve) resolve(result);


### PR DESCRIPTION
Fixes an issue where suspending a query with `hasNext: true` - primarily from use of the defer directive - would cause an early teardown and trigger an AbortError

At first glance, not sure how to test this, as I couldn't find an appropriate starting point.