### PR TITLE
fix(graphcache): Remove `for-of` syntax from Graphcache code for JSC memory reduction 

### DIFF
--- a/.changeset/wet-buses-appear.md
+++ b/.changeset/wet-buses-appear.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Remove `for-of` syntax from `@urql/exchange-graphcache` for JSC memory reduction

--- a/exchanges/graphcache/src/ast/traversal.ts
+++ b/exchanges/graphcache/src/ast/traversal.ts
@@ -81,11 +81,11 @@ export const isDeferred = (
   vars: Variables
 ): boolean => {
   const { defer } = getDirectives(node);
-  if (defer) {
-    for (const argument of defer.arguments || []) {
-      if (getName(argument) === 'if') {
+  if (defer && defer.arguments) {
+    for (let i = 0; defer.arguments && i < defer.arguments.length; i++) {
+      if (getName(defer.arguments[i]) === 'if') {
         // Return whether `@defer(if: )` is enabled
-        return !!valueFromASTUntyped(argument.value, vars);
+        return !!valueFromASTUntyped(defer.arguments[i].value, vars);
       }
     }
     return true;

--- a/exchanges/graphcache/src/ast/traversal.ts
+++ b/exchanges/graphcache/src/ast/traversal.ts
@@ -81,7 +81,7 @@ export const isDeferred = (
   vars: Variables
 ): boolean => {
   const { defer } = getDirectives(node);
-  if (defer && defer.arguments) {
+  if (defer) {
     for (let i = 0; defer.arguments && i < defer.arguments.length; i++) {
       if (getName(defer.arguments[i]) === 'if') {
         // Return whether `@defer(if: )` is enabled

--- a/exchanges/graphcache/src/operations/invalidate.ts
+++ b/exchanges/graphcache/src/operations/invalidate.ts
@@ -30,8 +30,9 @@ export const invalidateType = (
   excludedEntities: string[]
 ) => {
   const types = InMemoryData.getEntitiesForType(typename);
-  for (const entity of types) {
-    if (excludedEntities.includes(entity)) continue;
-    invalidateEntity(entity);
+  const iterator = types[Symbol.iterator]();
+  for (let result = iterator.next(); !result.done; result = iterator.next()) {
+    if (excludedEntities.includes(result.value)) continue;
+    invalidateEntity(result.value);
   }
 };


### PR DESCRIPTION
> [!NOTE]
> I'll have to look into the bundlesize impact. Currently, this seems to have an outsized impact of `0.13kB` minzipped, which seems a little high for what this is doing.