### PR TITLE
Add hasNext to urql-next query-state

### DIFF
--- a/.changeset/tiny-tigers-lick.md
+++ b/.changeset/tiny-tigers-lick.md
@@ -1,0 +1,5 @@
+---
+'@urql/next': patch
+---
+
+Add type for hasNext to the query-state in urql-next

--- a/packages/next-urql/src/useQuery.ts
+++ b/packages/next-urql/src/useQuery.ts
@@ -110,6 +110,8 @@ export interface UseQueryState<
   data?: Data;
   /** The {@link OperationResult.error} for the executed query. */
   error?: CombinedError;
+  /** The {@link OperationResult.hasNext} for the executed query. */
+  hasNext: boolean;
   /** The {@link OperationResult.extensions} for the executed query. */
   extensions?: Record<string, any>;
   /** The {@link Operation} that the current state is for.


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR, but please make sure to open an issue or discuss
  your changes first, if you’re looking to submit a larger PR.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

<!-- What's the motivation of this change? What does it solve? -->
In PR #3703, `hasNext` was added. However, after upgrading urql to version 4.2.1, the @urql/next `UseQueryState` did not have type information for `hasNext`, resulting in an error.


## Set of changes

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->
hasNext has been added to UseQueryState in @urql/next.
