### PR TITLE
fix(core): make `metadata` available in production

### DIFF
--- a/.changeset/fluffy-starfishes-unite.md
+++ b/.changeset/fluffy-starfishes-unite.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': minor
+---
+
+Fixes an issue where `addMetadata` calls were stripped in production mode, ensuring consistent metadata availability (e.g., `cacheOutcome`) in both development and production environments

--- a/.changeset/fluffy-starfishes-unite.md
+++ b/.changeset/fluffy-starfishes-unite.md
@@ -2,4 +2,4 @@
 '@urql/core': minor
 ---
 
-Fixes an issue where `addMetadata` calls were stripped in production mode, ensuring consistent metadata availability (e.g., `cacheOutcome`) in both development and production environments
+Remove `addMetadata` transform where we'd strip out metadata for production environments, this particularly affects `OperationResult.context.metadata.cacheOutcome`

--- a/scripts/babel/transform-debug-target.mjs
+++ b/scripts/babel/transform-debug-target.mjs
@@ -4,17 +4,9 @@ const warningDevCheckTemplate = `
   process.env.NODE_ENV !== 'production' ? NODE : undefined
 `.trim();
 
-const noopTransformTemplate = `
-  process.env.NODE_ENV !== 'production' ? NODE : FALLBACK
-`.trim();
-
 const plugin = ({ template, types: t }) => {
   const wrapWithDevCheck = template.expression(warningDevCheckTemplate, {
     placeholderPattern: /^NODE$/,
-  });
-
-  const wrapWithNoopTransform = template.expression(noopTransformTemplate, {
-    placeholderPattern: /^(NODE|FALLBACK)$/,
   });
 
   let name = 'unknownExchange';
@@ -47,14 +39,6 @@ const plugin = ({ template, types: t }) => {
           }
 
           path.replaceWith(wrapWithDevCheck({ NODE: path.node }));
-        } else if (path.node.callee.name === 'addMetadata') {
-          path.node[visited] = true;
-          path.replaceWith(
-            wrapWithNoopTransform({
-              NODE: path.node,
-              FALLBACK: path.node.arguments[0],
-            })
-          );
         }
       },
     },


### PR DESCRIPTION
Fixes https://github.com/urql-graphql/urql/issues/3715

## Summary
This change addresses a bug where the `addMetadata` function was being stripped or modified in production builds, resulting in the meta field being unavailable. The absence of meta caused inconsistent behaviour between development and production environments, particularly for TTL-based re-requests and cache outcomes. 

Previously, [there was an attempt to add back the meta to production bundles](https://github.com/urql-graphql/urql/pull/3464), but perhaps the babel file was missed. 

## Set of Changes
### Modified Babel Transformer:
Updated the Babel transformer to preserve `addMetadata` calls in production, ensuring metadata (e.g., `cacheOutcome`) is always available.

### Affected Package:
@urql/core: The core package was updated to fix the issue.