### PR TITLE
docs: Fix sample code to avoid reading from `undefined` in `didAuthError`

### DIFF
--- a/docs/advanced/authentication.md
+++ b/docs/advanced/authentication.md
@@ -207,7 +207,7 @@ authExchange(async utils => {
   return {
     // ...
     didAuthError(error, _operation) {
-      return error.response.status === 401;
+      return error.response?.status === 401;
     },
   };
 });


### PR DESCRIPTION
## Summary

This updates an example code snippet to prevent reading `status` from `undefined`.
According to the type definitions, `response` may be undefined. I can confirm because this [happened in production](https://github.com/chromaui/addon-visual-tests/pull/349).

## Set of changes

- Updated `docs/advanced/authentication.md` to add an optional chaining operator to handle undefined response.