### PR TITLE
allow to provide underlying storage for ssr exchange

### DIFF
--- a/.changeset/fluffy-mirrors-pretend.md
+++ b/.changeset/fluffy-mirrors-pretend.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': minor
+---
+
+allow to provide underlying storage for ssr exchange

--- a/packages/core/src/exchanges/ssr.ts
+++ b/packages/core/src/exchanges/ssr.ts
@@ -36,6 +36,10 @@ export interface SSRData {
   [key: string]: SerializedResult;
 }
 
+export interface SSRDataStorage {
+  [key: string]: SerializedResult | null;
+}
+
 /** Options for the `ssrExchange` allowing it to either operate on the server- or client-side. */
 export interface SSRExchangeParams {
   /** Indicates to the {@link SSRExchange} whether it's currently in server-side or client-side mode.
@@ -74,6 +78,11 @@ export interface SSRExchangeParams {
    * not serialize this data by default, unless this flag is set.
    */
   includeExtensions?: boolean;
+
+  /**
+   * If provided, this will be used as underlying storage for the serialized results.
+   */
+  storage?: SSRDataStorage;
 }
 
 /** An `SSRExchange` either in server-side mode, serializing results, or client-side mode, deserializing and replaying results..
@@ -188,7 +197,8 @@ const revalidated = new Set<number>();
 export const ssrExchange = (params: SSRExchangeParams = {}): SSRExchange => {
   const staleWhileRevalidate = !!params.staleWhileRevalidate;
   const includeExtensions = !!params.includeExtensions;
-  const data: Record<string, SerializedResult | null> = {};
+  const data: SSRDataStorage =
+    params.storage !== undefined ? params.storage : {};
 
   // On the client-side, we delete results from the cache as they're resolved
   // this is delayed so that concurrent queries don't delete each other's data


### PR DESCRIPTION
## Summary

This change allows to optionally provide the storage that is used in the ssr exchange for storing the serialized results.

## Detailed description

The goal is to enable streaming SSR with @tanstack/start.
When it is possible to pass in a custom storage into the ssr exchange, a proxy can be passed in.
This can be used on the server to stream the serialized results to the client as soon as they are available, as well as retrieve them on the client.

A demo implementation is available here: https://github.com/schiller-manuel/start-urql/blob/main/app/router.tsx#L17

