### PR TITLE
fix(core,graphcache): Update optional graphql types with TS 5.5 compatible switch

### DIFF
--- a/.changeset/old-ears-hunt.md
+++ b/.changeset/old-ears-hunt.md
@@ -1,0 +1,6 @@
+---
+'@urql/exchange-graphcache': patch
+'@urql/core': patch
+---
+
+Fix compatibility with Typescript >5.5 (See: https://github.com/0no-co/graphql.web/pull/49)

--- a/exchanges/graphcache/package.json
+++ b/exchanges/graphcache/package.json
@@ -66,6 +66,7 @@
     "@urql/core": "^5.0.0"
   },
   "dependencies": {
+    "@0no-co/graphql.web": "^1.0.13",
     "@0no-co/graphql.web": "^1.0.5",
     "@urql/core": "workspace:^5.1.1",
     "wonka": "^6.3.2"

--- a/exchanges/graphcache/package.json
+++ b/exchanges/graphcache/package.json
@@ -67,7 +67,6 @@
   },
   "dependencies": {
     "@0no-co/graphql.web": "^1.0.13",
-    "@0no-co/graphql.web": "^1.0.5",
     "@urql/core": "workspace:^5.1.1",
     "wonka": "^6.3.2"
   },

--- a/exchanges/graphcache/src/ast/graphql.ts
+++ b/exchanges/graphcache/src/ast/graphql.ts
@@ -1,6 +1,6 @@
 import type * as GraphQL from 'graphql';
 
-type OrNever<T> = 0 extends 1 & T ? never : T;
+type OrNever<T> = void extends T ? never : T;
 
 export type IntrospectionQuery =
   | {

--- a/exchanges/graphcache/src/operations/shared.ts
+++ b/exchanges/graphcache/src/operations/shared.ts
@@ -3,6 +3,7 @@ import type { CombinedError, ErrorLike, FormattedNode } from '@urql/core';
 import type {
   InlineFragmentNode,
   FragmentDefinitionNode,
+  FieldNode,
 } from '@0no-co/graphql.web';
 import { Kind } from '@0no-co/graphql.web';
 
@@ -211,7 +212,7 @@ export class SelectionIterator {
     ];
   }
 
-  next() {
+  next(): FormattedNode<FieldNode> | undefined {
     while (this.stack.length > 0) {
       let state = this.stack[this.stack.length - 1];
       while (state.index < state.selectionSet.length) {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     }
   },
   "devDependencies": {
-    "@0no-co/graphql.web": "^1.0.8",
+    "@0no-co/graphql.web": "^1.0.13",
     "@actions/artifact": "^2.0.0",
     "@actions/core": "^1.10.1",
     "@babel/core": "^7.25.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,7 +55,7 @@
     "jsr": "jsr publish"
   },
   "dependencies": {
-    "@0no-co/graphql.web": "^1.0.5",
+    "@0no-co/graphql.web": "^1.0.13",
     "wonka": "^6.3.2"
   },
   "publishConfig": {

--- a/packages/core/src/utils/graphql.ts
+++ b/packages/core/src/utils/graphql.ts
@@ -1,7 +1,7 @@
 import type * as GraphQLWeb from '@0no-co/graphql.web';
 import type * as GraphQL from 'graphql';
 
-type OrNever<T> = 0 extends 1 & T ? never : T;
+type OrNever<T> = void extends T ? never : T;
 
 export type GraphQLError =
   | GraphQLWeb.GraphQLError

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,7 +220,7 @@ importers:
     dependencies:
       '@0no-co/graphql.web':
         specifier: ^1.0.13
-        version: 1.0.13(graphql@16.6.0)
+        version: 1.0.13(graphql@16.9.0)
       '@urql/core':
         specifier: workspace:^5.1.1
         version: link:../../packages/core

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         version: 3.3.2
     devDependencies:
       '@0no-co/graphql.web':
-        specifier: ^1.0.8
-        version: 1.0.8(graphql@16.9.0)
+        specifier: ^1.0.13
+        version: 1.0.13(graphql@16.9.0)
       '@actions/artifact':
         specifier: ^2.0.0
         version: 2.1.9(encoding@0.1.13)
@@ -219,8 +219,8 @@ importers:
   exchanges/graphcache:
     dependencies:
       '@0no-co/graphql.web':
-        specifier: ^1.0.5
-        version: 1.0.8(graphql@16.9.0)
+        specifier: ^1.0.13
+        version: 1.0.13(graphql@16.6.0)
       '@urql/core':
         specifier: workspace:^5.1.1
         version: link:../../packages/core
@@ -340,8 +340,8 @@ importers:
   packages/core:
     dependencies:
       '@0no-co/graphql.web':
-        specifier: ^1.0.5
-        version: 1.0.8(graphql@16.9.0)
+        specifier: ^1.0.13
+        version: 1.0.13(graphql@16.9.0)
       wonka:
         specifier: ^6.3.2
         version: 6.3.2
@@ -624,8 +624,8 @@ importers:
 
 packages:
 
-  '@0no-co/graphql.web@1.0.8':
-    resolution: {integrity: sha512-8BG6woLtDMvXB9Ajb/uE+Zr/U7y4qJ3upXi0JQHZmsKUJa7HjF/gFvmL2f3/mSmfZoQGRr9VoY97LCX2uaFMzA==}
+  '@0no-co/graphql.web@1.0.13':
+    resolution: {integrity: sha512-jqYxOevheVTU1S36ZdzAkJIdvRp2m3OYIG5SEoKDw5NI8eVwkoI0D/Q3DYNGmXCxkA6CQuoa7zvMiDPTLqUNuw==}
     peerDependencies:
       graphql: ^16.6.0
     peerDependenciesMeta:
@@ -9885,7 +9885,7 @@ packages:
 
 snapshots:
 
-  '@0no-co/graphql.web@1.0.8(graphql@16.9.0)':
+  '@0no-co/graphql.web@1.0.13(graphql@16.9.0)':
     optionalDependencies:
       graphql: 16.9.0
 


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR, but please make sure to open an issue or discuss
  your changes first, if you’re looking to submit a larger PR.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

Resolves #3724

## Summary

<!-- What's the motivation of this change? What does it solve? -->

1. TypeScript changed the behaviour of "unresolved" any from 5.5 so doing `type Doc = OrNever<UnresolvedType> | LocalType` will always be any.
2. Without `graphql` as optional peer dependency in `@urql/core`, `graphql.web` will be unable to resolve it when using a strict package manager like Yarn Berry.

Both problems are covered by #3724 

## Set of changes

1. Changed OrNever to 
```typescript
type OrNever<T> = void extends T ? never : T;
```
Which is compatible with both newer and older TypeScript versions.


2. Added `graphql` as optional peer dependency for packages that are using `graphql.web`

As a sidenote, there is a `graphql` import without fallback in `urql/packages/preact-urql/src/hooks/useRequest.ts` that will also break inference, but I am not sure how would you like to handle that.

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->
