### PR TITLE
Adding Solid to README for visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 ## ✨ Features
 
-- 📦 **One package** to get a working GraphQL client in React, Preact, Vue, and Svelte
+- 📦 **One package** to get a working GraphQL client in React, Preact, Vue, Solid and Svelte
 - ⚙️ Fully **customisable** behaviour [via "exchanges"](https://formidable.com/open-source/urql/docs/advanced/authoring-exchanges/)
 - 🗂 Logical but simple default behaviour and document caching
 - 🌱 Normalized caching via [`@urql/exchange-graphcache`](https://formidable.com/open-source/urql/docs/graphcache)


### PR DESCRIPTION
I came to the URQL looking for a Solid adapter and went elsewhere because the README didn't list it. A colleague however pointed out that the adapter does exist in the package. Making a PR so other Solid users aren't confused by the README.