### PR TITLE
chore: Omit minified files and `sourcesContent` in published packages

### DIFF
--- a/.changeset/purple-baboons-nail.md
+++ b/.changeset/purple-baboons-nail.md
@@ -1,0 +1,23 @@
+---
+'@urql/exchange-auth': patch
+'@urql/exchange-context': patch
+'@urql/exchange-execute': patch
+'@urql/exchange-graphcache': patch
+'@urql/exchange-persisted': patch
+'@urql/exchange-populate': patch
+'@urql/exchange-refocus': patch
+'@urql/exchange-request-policy': patch
+'@urql/exchange-retry': patch
+'@urql/exchange-throw-on-error': patch
+'@urql/core': patch
+'@urql/introspection': patch
+'@urql/next': patch
+'@urql/preact': patch
+'urql': patch
+'@urql/solid': patch
+'@urql/storage-rn': patch
+'@urql/svelte': patch
+'@urql/vue': patch
+---
+
+Omit minified files and sourcemaps' `sourcesContent` in published packages

--- a/scripts/rollup/config.mjs
+++ b/scripts/rollup/config.mjs
@@ -8,6 +8,7 @@ import cleanup from './cleanup-plugin.mjs';
 import * as settings from './settings.mjs';
 
 const plugins = makePlugins();
+const isCI = !!process.env.CI;
 
 const chunkFileNames = extension => {
   let hasDynamicChunk = false;
@@ -141,8 +142,8 @@ export default [
     output: [
       output({ format: 'cjs', isProduction: false }),
       output({ format: 'esm', isProduction: false }),
-      output({ format: 'cjs', isProduction: true }),
-      output({ format: 'esm', isProduction: true }),
+      !isCI && output({ format: 'cjs', isProduction: true }),
+      !isCI && output({ format: 'esm', isProduction: true }),
     ].filter(Boolean),
   },
   {

--- a/scripts/rollup/config.mjs
+++ b/scripts/rollup/config.mjs
@@ -92,7 +92,7 @@ const output = ({ format, isProduction }) => {
     exports: 'named',
     sourcemap: true,
     banner: chunk => (chunk.name === 'urql-next' ? '"use client"' : undefined),
-    sourcemapExcludeSources: false,
+    sourcemapExcludeSources: isCI,
     hoistTransitiveImports: false,
     indent: false,
     freeze: false,


### PR DESCRIPTION
## Summary

We shouldn't publish with minified files due to the source map sizes and increased publish size. They're not meant to be used directly and we mostly relied on them for measurements.

Definitely a trade-off, but we shouldn't include `sourcesContent`. It likely doesn't help debugging much over our "half prettified" outputs and increases size substantially

## Set of changes

- Disable `sourcesContent` when publishing
- Disable minified bundle output when publishing
