### PR TITLE
chore(toe): update graphql-toe and add instructions to README

### DIFF
--- a/.changeset/lucky-bears-promise.md
+++ b/.changeset/lucky-bears-promise.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-throw-on-error': patch
+---
+
+Update `graphql-toe` and add more detail to README.

--- a/exchanges/throw-on-error/README.md
+++ b/exchanges/throw-on-error/README.md
@@ -1,8 +1,8 @@
 # @urql/exchange-throw-on-error (Exchange factory)
 
-`@urql/exchange-throw-on-error` is an exchange for the [`urql`](../../README.md) GraphQL client that makes field access to data throw an error if the field errored.
+`@urql/exchange-throw-on-error` is an exchange for the [`urql`](https://github.com/urql-graphql/urql) GraphQL client that throws on field access to errored fields.
 
-It is built on top of the [`graphql-toe`](https://github.com/graphile/graphql-toe) package.
+It is built on top of the [`graphql-toe`](https://github.com/graphile/graphql-toe) package - please see that package for more information.
 
 ## Quick Start Guide
 
@@ -12,4 +12,16 @@ First install `@urql/exchange-throw-on-error` alongside `urql`:
 yarn add @urql/exchange-throw-on-error
 # or
 npm install --save @urql/exchange-throw-on-error
+```
+
+Then add the `throwOnErrorExchange`, to your client:
+
+```js
+import { createClient, cacheExchange, fetchExchange } from 'urql';
+import { throwOnErrorExchange } from '@urql/exchange-throw-on-error';
+
+const client = createClient({
+  url: '/graphql',
+  exchanges: [cacheExchange, throwOnErrorExchange(), fetchExchange],
+});
 ```

--- a/exchanges/throw-on-error/package.json
+++ b/exchanges/throw-on-error/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@urql/core": "workspace:^5.1.1",
-    "graphql-toe": "0.1.2",
+    "graphql-toe": "^1.0.0-rc.0",
     "wonka": "^6.3.2"
   },
   "publishConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,8 +327,8 @@ importers:
         specifier: workspace:^5.1.1
         version: link:../../packages/core
       graphql-toe:
-        specifier: 0.1.2
-        version: 0.1.2
+        specifier: ^1.0.0-rc.0
+        version: 1.0.0-rc.0
       wonka:
         specifier: ^6.3.2
         version: 6.3.2
@@ -5069,8 +5069,8 @@ packages:
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
-  graphql-toe@0.1.2:
-    resolution: {integrity: sha512-XK04wXEHbLY33YHoPAnLMIafRKSOn7FTWzTCob23GC6o8DnO4ibkA8Aje+Udee8QdXx46TV6m6LQM9iU8C9vwQ==}
+  graphql-toe@1.0.0-rc.0:
+    resolution: {integrity: sha512-/reEXGT1QCrQkweajQvbK298u/duyEHGftzKlFO0K3kD050USxD55bQw0QctjhCzKEZJIvdkoCxoUfijHv4izg==}
 
   graphql@16.9.0:
     resolution: {integrity: sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==}
@@ -7628,7 +7628,6 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
-
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   q@1.5.1:
@@ -7636,7 +7635,6 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
-
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qs@6.10.4:
@@ -15811,7 +15809,7 @@ snapshots:
 
   graphemer@1.4.0: {}
 
-  graphql-toe@0.1.2: {}
+  graphql-toe@1.0.0-rc.0: {}
 
   graphql@16.9.0: {}
 


### PR DESCRIPTION
## Summary

Hi, I'm the maintainer of `graphql-toe` and we just put out a new release, v1.0.0-rc.0, which fixes an issue where errored arrays would be replaced with a null prototype object with array indicies but not an instance of array. We've also overhauled the README with greater detail.

## Set of changes

This PR:

- upgrades to this new release of `graphql-toe`
- ~~moves `wonka` from `dependencies` to `devDependencies`~~
- adds extra detail to the README

Please check the instructions I placed in the README, I'm not familiar with the exchanges system (I don't really do frontend work these days, mostly just backend stuff!) so am not certain I put the exchange in the correct position in the array. The tests didn't help clue me in since they don't seem to follow this pattern.

cc @JoviDeCroock who I have been DM-ing about this :)