### PR TITLE
fix(core): Fix multibyte character decoding by using `stream` option

### DIFF
--- a/.changeset/nervous-flies-confess.md
+++ b/.changeset/nervous-flies-confess.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Fix `fetchSource` not text-decoding response chunks as streams, which could cause UTF-8 decoding to break.


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR, but please make sure to open an issue or discuss
  your changes first, if you’re looking to submit a larger PR.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary
Huge thanks for open-sourcing such a great library. In my private frontend project where I'm using urql, I happened to find an issue where multibyte strings fetched via urql occasionally become garbled. After inspecting the network and logic, I found that the root cause was decoding strings without considering UTF-8 character boundaries.

Fortunately, in frontend development, the TextDecoder API provides a useful `stream` option, and I confirmed that simply enabling this resolves the issue. As for the Node.js or other backend dev environment, I believe the problem could be addressed by using StringDecoder or something, but I haven't explored that part yet.

I would like to request this change be merged in order to simplify my vendoring. I created this PR primarily to share the issue for now, but would be happy to receive any suggestions on how to proceed or how to approach testing. Thank you!

## Set of changes

- Just added an option `stream: true` to TextDecoder::decode call
