### PR TITLE
fix(react-urql): Upgrade muted warning code for React 19 internals

### DIFF
--- a/.changeset/rich-melons-play.md
+++ b/.changeset/rich-melons-play.md
@@ -1,0 +1,5 @@
+---
+'urql': patch
+---
+
+Upgrade false-positive circumvention for internal React warning to support React 19

--- a/packages/react-urql/src/hooks/state.ts
+++ b/packages/react-urql/src/hooks/state.ts
@@ -72,9 +72,7 @@ function deferDispatch<F extends Dispatch<any>>(
   value: F extends Dispatch<infer State> ? State : void
 ): void;
 
-function deferDispatch<F extends Dispatch<any>>(
-  setState: F
-): ReturnType<F>;
+function deferDispatch<F extends Dispatch<any>>(setState: F): ReturnType<F>;
 
 function deferDispatch<F extends Dispatch<any>>(
   setState: F,

--- a/packages/react-urql/src/hooks/state.ts
+++ b/packages/react-urql/src/hooks/state.ts
@@ -67,7 +67,8 @@ export const hasDepsChanged = <T extends { length: number }>(a: T, b: T) => {
 
 const ReactSharedInternals =
   (React as any).__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED ||
-  (React as any).__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE;
+  (React as any)
+    .__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE;
 
 export function deferDispatch<Dispatch extends React.Dispatch<any>>(
   setState: Dispatch,
@@ -76,7 +77,9 @@ export function deferDispatch<Dispatch extends React.Dispatch<any>>(
   if (!!ReactSharedInternals && process.env.NODE_ENV !== 'production') {
     const currentOwner = ReactSharedInternals.ReactCurrentOwner
       ? ReactSharedInternals.ReactCurrentOwner.current
-      : (ReactSharedInternals.A && ReactSharedInternals.A.getOwner && ReactSharedInternals.A.getOwner());
+      : ReactSharedInternals.A &&
+        ReactSharedInternals.A.getOwner &&
+        ReactSharedInternals.A.getOwner();
     if (currentOwner) {
       Promise.resolve(value).then(setState);
     } else {

--- a/packages/react-urql/src/hooks/useQuery.ts
+++ b/packages/react-urql/src/hooks/useQuery.ts
@@ -308,7 +308,7 @@ export function useQuery<
     () =>
       [
         source,
-        computeNextState(initialState, getSnapshot(source, suspense)),
+        computeNextState(initialState, deferDispatch(() => getSnapshot(source, suspense))),
         deps,
       ] as const
   );
@@ -319,7 +319,7 @@ export function useQuery<
       source,
       (currentResult = computeNextState(
         state[1],
-        getSnapshot(source, suspense)
+        deferDispatch(() => getSnapshot(source, suspense))
       )),
       deps,
     ]);

--- a/packages/react-urql/src/hooks/useQuery.ts
+++ b/packages/react-urql/src/hooks/useQuery.ts
@@ -308,7 +308,10 @@ export function useQuery<
     () =>
       [
         source,
-        computeNextState(initialState, deferDispatch(() => getSnapshot(source, suspense))),
+        computeNextState(
+          initialState,
+          deferDispatch(() => getSnapshot(source, suspense))
+        ),
         deps,
       ] as const
   );


### PR DESCRIPTION
Resolves #3764

## Summary

Same as before: the warning is irrelevant, and we're looking to mute it. We can make the deferred dispatching permanent, since we don't want to rely on internals

As before, just because the warning is issued that doesn't mean anything is wrong. We're only doing this to mute this warning.

## Set of changes

- Update how `ReactCurrentOwner` is accessed using new internals
- Always defer `setState` dispatch unless there's no synchronous/concurrent update in parallel
