### PR TITLE
fix(core): typo in cacheHit debug message

### DIFF
--- a/.changeset/heavy-hairs-bow.md
+++ b/.changeset/heavy-hairs-bow.md
@@ -1,0 +1,5 @@
+---
+"@urql/core": patch
+---
+
+Correct typo in cacheHit debug message of the `debugExchange`

--- a/packages/core/src/exchanges/cache.ts
+++ b/packages/core/src/exchanges/cache.ts
@@ -72,7 +72,7 @@ export const cacheExchange: Exchange = ({ forward, client, dispatchDebug }) => {
           ...(cachedResult
             ? {
                 type: 'cacheHit',
-                message: 'The result was successfully retried from the cache',
+                message: 'The result was successfully retrieved from the cache',
               }
             : {
                 type: 'cacheMiss',


### PR DESCRIPTION
## Summary

When printing debug message, the following message is printed when an item is returned from the cache:

> The result was successfully retried from the cache

Based on the source code, this has nothing to do with retrying at all, it's just a typo and should be:

> The result was successfully retrieved from the cache