### PR TITLE
patch(retry): Make options argument optional

### DIFF
--- a/.changeset/slow-hotels-yawn.md
+++ b/.changeset/slow-hotels-yawn.md
@@ -2,4 +2,4 @@
 "@urql/exchange-retry": patch
 ---
 
-minor(exchanges/retry): make options argument optional
+Mark options argument as optional (`retryExchange()`)

--- a/.changeset/slow-hotels-yawn.md
+++ b/.changeset/slow-hotels-yawn.md
@@ -1,0 +1,5 @@
+---
+"@urql/exchange-retry": patch
+---
+
+minor(exchanges/retry): make options argument optional

--- a/exchanges/retry/src/retryExchange.ts
+++ b/exchanges/retry/src/retryExchange.ts
@@ -108,7 +108,7 @@ interface RetryState {
  * });
  * ```
  */
-export const retryExchange = (options: RetryExchangeOptions): Exchange => {
+export const retryExchange = (options: RetryExchangeOptions = {}): Exchange => {
   const { retryIf, retryWith } = options;
   const MIN_DELAY = options.initialDelayMs || 1000;
   const MAX_DELAY = options.maxDelayMs || 15_000;


### PR DESCRIPTION
Since all options are optional, as they already have default values (as stated in https://nearform.com/open-source/urql/docs/advanced/retry-operations/ ), let's make the `options` argument optional.

So that one can call `retryExchange()` instead of `retryExchange({})`
