### PR TITLE
Forbid `signal` property in client's fetchOptions

### DIFF
--- a/.changeset/khaki-experts-hammer.md
+++ b/.changeset/khaki-experts-hammer.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Use types to forbid broken signal option

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -79,7 +79,9 @@ export interface ClientOptions {
    *
    * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/fetch} for a description of this object.
    */
-  fetchOptions?: RequestInit | (() => RequestInit);
+  fetchOptions?:
+    | Omit<RequestInit, 'signal'>
+    | (() => Omit<RequestInit, 'signal'>);
   /** A `fetch` function polyfill used by fetch exchanges to make API calls.
    *
    * @remarks


### PR DESCRIPTION
Forbid `signal` property in client's fetchOptions

It was misleading to suggest that `signal` can be passed in, as it gets overwritten in the following code:

https://github.com/urql-graphql/urql/blob/00d36ceb7b67c7c8ec95caffef1ab5f818f5ceee/packages/core/src/internal/fetchSource.ts#L269

Once `AbortSignal.any` gets [fuller support](https://caniuse.com/mdn-api_abortsignal_any_static), reconsider the approach taken in [this PR](https://github.com/urql-graphql/urql/pull/3781)

<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR, but please make sure to open an issue or discuss
  your changes first, if you’re looking to submit a larger PR.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

<!-- What's the motivation of this change? What does it solve? -->

## Set of changes

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->
