### PR TITLE
major(core|persisted): use GET for queries by default

### DIFF
--- a/.changeset/giant-pets-buy.md
+++ b/.changeset/giant-pets-buy.md
@@ -1,0 +1,9 @@
+---
+'@urql/exchange-persisted': major
+'@urql/core': major
+---
+
+By default leverage GET for queries where the query-string + variables comes down to less than 2048 characters.
+When upgrading it's important to see whether your server supports `GET`, if it doesn't ideally adding support for it
+or alternatively setting `preferGetMethod` in the `createClient` method as well as `preferGetForPersistedQueries` for
+the persisted exchange to `false`.

--- a/exchanges/persisted/src/persistedExchange.ts
+++ b/exchanges/persisted/src/persistedExchange.ts
@@ -44,7 +44,7 @@ export interface PersistedExchangeOptions {
    * GET requests are frequently used to make GraphQL requests more
    * cacheable on CDNs.
    *
-   * @defaultValue `undefined` - disabled
+   * @defaultValue `within-url-limit` - Use GET requests for persisted queries within the URL limit.
    */
   preferGetForPersistedQueries?: OperationContext['preferGetMethod'];
   /** Enforces non-automatic persisted queries by ignoring APQ errors.
@@ -137,7 +137,8 @@ export const persistedExchange =
   ({ forward }) => {
     if (!options) options = {};
 
-    const preferGetForPersistedQueries = options.preferGetForPersistedQueries;
+    const preferGetForPersistedQueries =
+      options.preferGetForPersistedQueries || 'within-url-limit';
     const enforcePersistedQueries = !!options.enforcePersistedQueries;
     const hashFn = options.generateHash || hash;
     const enableForMutation = !!options.enableForMutation;

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -148,7 +148,7 @@ describe('promisified methods', () => {
       fetchOptions: undefined,
       fetch: undefined,
       suspense: false,
-      preferGetMethod: undefined,
+      preferGetMethod: 'within-url-limit',
     });
     expect(queryResult).toHaveProperty('then');
   });
@@ -174,7 +174,7 @@ describe('promisified methods', () => {
       fetchOptions: undefined,
       fetch: undefined,
       suspense: false,
-      preferGetMethod: undefined,
+      preferGetMethod: 'within-url-limit',
     });
     expect(mutationResult).toHaveProperty('then');
   });

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -549,7 +549,7 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
     fetchSubscriptions: opts.fetchSubscriptions,
     fetchOptions: opts.fetchOptions,
     fetch: opts.fetch,
-    preferGetMethod: opts.preferGetMethod,
+    preferGetMethod: opts.preferGetMethod || 'within-url-limit',
     requestPolicy: opts.requestPolicy || 'cache-first',
   };
 


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR, but please make sure to open an issue or discuss
  your changes first, if you’re looking to submit a larger PR.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

I've been thinking about this for quite a while but it's time that this default is switched up, most GraphQL clients force you in this paradigm of always leveraging POST which misses out on a lot of benefits. The settings to actually do it the "right way" HTTP semantically is hidden behind an option.

The downside is that some servers _might_ not support GET, however they are still free to turn this off. I prefer the explicit having to turn it off from having a degraded default experience.

The default should still be persisted operations but at least we take a step forward HTTP semantically wise.
