### PR TITLE
feat(graphcache): add possibleTypes config for deterministic fragment matching

### DIFF
--- a/.changeset/unlucky-apes-change.md
+++ b/.changeset/unlucky-apes-change.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': minor
+---
+
+Add possibleTypes config for deterministic fragment matching

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -57,6 +57,7 @@ export class Store<
   keys: KeyingConfig;
   globalIDs: Set<string> | boolean;
   schema?: SchemaIntrospector;
+  possibleTypeMap?: Map<string, Set<string>>;
 
   rootFields: { query: string; mutation: string; subscription: string };
   rootNames: { [name: string]: RootField | void };
@@ -84,6 +85,14 @@ export class Store<
       subscriptionName = schema.subscription || subscriptionName;
       // Only add schema introspector if it has types info
       if (schema.types) this.schema = schema;
+    }
+
+    if (!this.schema && opts.possibleTypes) {
+      this.possibleTypeMap = new Map();
+      for (const entry of Object.entries(opts.possibleTypes)) {
+        const [abstractType, concreteTypes] = entry;
+        this.possibleTypeMap.set(abstractType, new Set(concreteTypes));
+      }
     }
 
     this.updates = opts.updates || {};

--- a/exchanges/graphcache/src/types.ts
+++ b/exchanges/graphcache/src/types.ts
@@ -618,6 +618,16 @@ export type CacheExchangeOpts = {
    * type names may be passed instead.
    */
   globalIDs?: string[] | boolean;
+  /** Configures abstract to concrete types mapping for GraphQL types.
+   *
+   * @remarks
+   * This will disable heuristic fragment matching, allowing Graphcache to match
+   * fragment deterministically.
+   *
+   * When both `possibleTypes` and `schema` is set, `possibleTypes` value will be
+   * ignored.
+   */
+  possibleTypes?: PossibleTypesConfig;
   /** Configures Graphcache with Schema Introspection data.
    *
    * @remarks
@@ -930,6 +940,10 @@ export type OptimisticMutationConfig = {
  */
 export type KeyingConfig = {
   [typename: string]: KeyGenerator;
+};
+
+export type PossibleTypesConfig = {
+  [abstractType: string]: string[];
 };
 
 /** Serialized normalized caching data. */


### PR DESCRIPTION
We want to deterministically match fragments, but don't want the downside of schema-aware: security risk, bundle size, partial result on nullable field. 