### PR TITLE
fix: use nullish coalescing for get method preference

### DIFF
--- a/.changeset/twenty-cows-roll.md
+++ b/.changeset/twenty-cows-roll.md
@@ -1,0 +1,6 @@
+---
+'@urql/exchange-persisted': patch
+'@urql/core': patch
+---
+
+Use nullish coalescing for `preferGetMethod` and `preferGetForPersistedQueries` so that `false` is kept if set.

--- a/exchanges/persisted/src/persistedExchange.test.ts
+++ b/exchanges/persisted/src/persistedExchange.test.ts
@@ -174,7 +174,7 @@ it('skips operation when generateHash returns a nullish value', async () => {
   expect(operations[0]).not.toHaveProperty('extensions.persistedQuery');
 });
 
-it.each([true, 'force', 'within-url-limit'] as const)(
+it.each([true, false, 'force', 'within-url-limit'] as const)(
   'sets `context.preferGetMethod` to %s when `options.preferGetForPersistedQueries` is %s',
   async preferGetMethodValue => {
     const { exchangeArgs } = makeExchangeArgs();

--- a/exchanges/persisted/src/persistedExchange.ts
+++ b/exchanges/persisted/src/persistedExchange.ts
@@ -138,7 +138,9 @@ export const persistedExchange =
     if (!options) options = {};
 
     const preferGetForPersistedQueries =
-      options.preferGetForPersistedQueries || 'within-url-limit';
+      options.preferGetForPersistedQueries != null
+        ? options.preferGetForPersistedQueries
+        : 'within-url-limit';
     const enforcePersistedQueries = !!options.enforcePersistedQueries;
     const hashFn = options.generateHash || hash;
     const enableForMutation = !!options.enableForMutation;
@@ -170,10 +172,7 @@ export const persistedExchange =
             sha256Hash,
           },
         };
-        if (
-          persistedOperation.kind === 'query' &&
-          preferGetForPersistedQueries
-        ) {
+        if (persistedOperation.kind === 'query') {
           persistedOperation.context.preferGetMethod =
             preferGetForPersistedQueries;
         }

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -549,7 +549,8 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
     fetchSubscriptions: opts.fetchSubscriptions,
     fetchOptions: opts.fetchOptions,
     fetch: opts.fetch,
-    preferGetMethod: opts.preferGetMethod || 'within-url-limit',
+    preferGetMethod:
+      opts.preferGetMethod != null ? opts.preferGetMethod : 'within-url-limit',
     requestPolicy: opts.requestPolicy || 'cache-first',
   };
 


### PR DESCRIPTION
## Summary

Resolves https://github.com/urql-graphql/urql/issues/3811

## Set of changes

Use nullish coalescing instead of `||` for `preferGetMethod` and `preferGetForPersistedQueries` so that `false` is kept if set.