### PR TITLE
Actual value for timeout

### DIFF
--- a/.changeset/puny-beans-allow.md
+++ b/.changeset/puny-beans-allow.md
@@ -1,0 +1,7 @@
+---
+'@urql/exchange-graphcache': patch
+'@urql/exchange-auth': patch
+'@urql/core': patch
+---
+
+Use actual values instead of omitting the setTimeout delay since leaving it out emits a warning in the bun runtime. Replaced all omitted calls with the default value 1

--- a/exchanges/auth/src/authExchange.test.ts
+++ b/exchanges/auth/src/authExchange.test.ts
@@ -193,7 +193,7 @@ it('adds the same token to subsequent operations', async () => {
     toPromise
   );
 
-  await new Promise(resolve => setTimeout(resolve));
+  await new Promise(resolve => setTimeout(resolve, 1));
 
   next(queryOperation);
 
@@ -249,7 +249,7 @@ it('triggers authentication when an operation did error', async () => {
     publish
   );
 
-  await new Promise(resolve => setTimeout(resolve));
+  await new Promise(resolve => setTimeout(resolve, 1));
 
   result.mockReturnValueOnce({
     ...queryResponse,
@@ -264,7 +264,7 @@ it('triggers authentication when an operation did error', async () => {
   expect(result).toHaveBeenCalledTimes(1);
   expect(didAuthError).toHaveBeenCalledTimes(1);
 
-  await new Promise(resolve => setTimeout(resolve));
+  await new Promise(resolve => setTimeout(resolve, 1));
 
   expect(result).toHaveBeenCalledTimes(2);
   expect(operations.length).toBe(2);
@@ -307,13 +307,13 @@ it('triggers authentication when an operation will error', async () => {
     publish
   );
 
-  await new Promise(resolve => setTimeout(resolve));
+  await new Promise(resolve => setTimeout(resolve, 1));
 
   next(queryOperation);
   expect(result).toHaveBeenCalledTimes(0);
   expect(willAuthError).toHaveBeenCalledTimes(1);
 
-  await new Promise(resolve => setTimeout(resolve));
+  await new Promise(resolve => setTimeout(resolve, 1));
 
   expect(result).toHaveBeenCalledTimes(1);
   expect(operations.length).toBe(1);
@@ -369,7 +369,7 @@ it('calls willAuthError on queued operations', async () => {
   expect(initialAuthResolve).toBeDefined();
   initialAuthResolve!();
 
-  await new Promise(resolve => setTimeout(resolve));
+  await new Promise(resolve => setTimeout(resolve, 1));
 
   expect(willAuthError).toHaveBeenCalledTimes(2);
   expect(result).toHaveBeenCalledTimes(2);
@@ -411,7 +411,7 @@ it('does not infinitely retry authentication when an operation did error', async
     publish
   );
 
-  await new Promise(resolve => setTimeout(resolve));
+  await new Promise(resolve => setTimeout(resolve, 1));
 
   result.mockImplementation(x => ({
     ...queryResponse,
@@ -429,7 +429,7 @@ it('does not infinitely retry authentication when an operation did error', async
   expect(result).toHaveBeenCalledTimes(1);
   expect(didAuthError).toHaveBeenCalledTimes(1);
 
-  await new Promise(resolve => setTimeout(resolve));
+  await new Promise(resolve => setTimeout(resolve, 1));
 
   expect(result).toHaveBeenCalledTimes(2);
   expect(operations.length).toBe(2);
@@ -489,7 +489,7 @@ it('passes on errors during initialization', async () => {
   expect(output).toHaveBeenCalledTimes(0);
 
   next(queryOperation);
-  await new Promise(resolve => setTimeout(resolve));
+  await new Promise(resolve => setTimeout(resolve, 1));
   expect(result).toHaveBeenCalledTimes(0);
   expect(output).toHaveBeenCalledTimes(1);
   expect(init).toHaveBeenCalledTimes(1);
@@ -498,7 +498,7 @@ it('passes on errors during initialization', async () => {
   );
 
   next(queryOperation);
-  await new Promise(resolve => setTimeout(resolve));
+  await new Promise(resolve => setTimeout(resolve, 1));
   expect(result).toHaveBeenCalledTimes(0);
   expect(output).toHaveBeenCalledTimes(2);
   expect(init).toHaveBeenCalledTimes(2);

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -209,7 +209,7 @@ export const clearDataState = () => {
         persistData();
         clearDataState();
         data.defer = false;
-      });
+      }, 1);
     }
   }
 };

--- a/packages/core/src/exchanges/fetch.test.ts
+++ b/packages/core/src/exchanges/fetch.test.ts
@@ -163,7 +163,7 @@ describe('on teardown', () => {
     unsubscribe();
 
     // NOTE: We can only observe the async iterator's final run after a macro tick
-    await new Promise(resolve => setTimeout(resolve));
+    await new Promise(resolve => setTimeout(resolve, 1));
     expect(fetch).toHaveBeenCalledTimes(0);
     expect(abort).toHaveBeenCalledTimes(1);
   });
@@ -183,11 +183,11 @@ describe('on teardown', () => {
       })
     );
 
-    await new Promise(resolve => setTimeout(resolve));
+    await new Promise(resolve => setTimeout(resolve, 1));
     unsubscribe();
 
     // NOTE: We can only observe the async iterator's final run after a macro tick
-    await new Promise(resolve => setTimeout(resolve));
+    await new Promise(resolve => setTimeout(resolve, 1));
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(abort).toHaveBeenCalledTimes(1);
   });

--- a/packages/core/src/internal/fetchSource.test.ts
+++ b/packages/core/src/internal/fetchSource.test.ts
@@ -214,7 +214,7 @@ describe('on teardown', () => {
 
     // NOTE: We can only observe the async iterator's final run after a macro tick
 
-    await new Promise(resolve => setTimeout(resolve));
+    await new Promise(resolve => setTimeout(resolve, 1));
     expect(fetch).toHaveBeenCalledTimes(0);
     expect(abort).toHaveBeenCalledTimes(1);
   });
@@ -233,11 +233,11 @@ describe('on teardown', () => {
       })
     );
 
-    await new Promise(resolve => setTimeout(resolve));
+    await new Promise(resolve => setTimeout(resolve, 1));
     unsubscribe();
 
     // NOTE: We can only observe the async iterator's final run after a macro tick
-    await new Promise(resolve => setTimeout(resolve));
+    await new Promise(resolve => setTimeout(resolve, 1));
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(abort).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
## Summary
There were multiple occurrences of `setTimeout` calls without an actual value for the delay. [According to the Node.js docs](https://nodejs.org/api/timers.html#settimeoutcallback-delay-args), this will default to 1. In the bun runtime this will also apply but issue a warning to notify of the behavior: 

```
TimeoutNaNWarning: NaN is not a number.
Timeout duration was set to 1.
```

## Set of changes
I changed all uses of the `setTimeout` without a specified delay to a delay of 1. This does not change any behavior but will silence the warnings.
