### PR TITLE
fix: add error logging to AsyncStorage catch blocks

### DIFF
--- a/packages/storage-rn/src/makeAsyncStorage.ts
+++ b/packages/storage-rn/src/makeAsyncStorage.ts
@@ -23,7 +23,8 @@ const parseData = (persistedData: any, fallback: any) => {
       return JSON.parse(persistedData);
     }
   } catch (_err) {
-    if (process.env.NODE_ENV !== 'production') console.warn('[urql] AsyncStorage error:', _err);
+    if (process.env.NODE_ENV !== 'production')
+      console.warn('[urql] AsyncStorage error:', _err);
   }
 
   return fallback;
@@ -69,7 +70,8 @@ export const makeAsyncStorage: (
         try {
           persistedData = await AsyncStorage.getItem(dataKey);
         } catch (_err) {
-          if (process.env.NODE_ENV !== 'production') console.warn('[urql] AsyncStorage error:', _err);
+          if (process.env.NODE_ENV !== 'production')
+            console.warn('[urql] AsyncStorage error:', _err);
         }
         const parsed = parseData(persistedData, {});
 
@@ -89,7 +91,8 @@ export const makeAsyncStorage: (
         try {
           await AsyncStorage.setItem(dataKey, JSON.stringify(allData));
         } catch (_err) {
-          if (process.env.NODE_ENV !== 'production') console.warn('[urql] AsyncStorage error:', _err);
+          if (process.env.NODE_ENV !== 'production')
+            console.warn('[urql] AsyncStorage error:', _err);
         }
       }
 
@@ -105,7 +108,8 @@ export const makeAsyncStorage: (
         try {
           persistedData = await AsyncStorage.getItem(dataKey);
         } catch (_err) {
-          if (process.env.NODE_ENV !== 'production') console.warn('[urql] AsyncStorage error:', _err);
+          if (process.env.NODE_ENV !== 'production')
+            console.warn('[urql] AsyncStorage error:', _err);
         }
         const parsed = parseData(persistedData, {});
         Object.assign(allData, parsed);
@@ -130,7 +134,8 @@ export const makeAsyncStorage: (
       try {
         await AsyncStorage.setItem(dataKey, JSON.stringify(allData));
       } catch (_err) {
-        if (process.env.NODE_ENV !== 'production') console.warn('[urql] AsyncStorage error:', _err);
+        if (process.env.NODE_ENV !== 'production')
+          console.warn('[urql] AsyncStorage error:', _err);
       }
     },
 
@@ -138,7 +143,8 @@ export const makeAsyncStorage: (
       try {
         await AsyncStorage.setItem(metadataKey, JSON.stringify(data));
       } catch (_err) {
-        if (process.env.NODE_ENV !== 'production') console.warn('[urql] AsyncStorage error:', _err);
+        if (process.env.NODE_ENV !== 'production')
+          console.warn('[urql] AsyncStorage error:', _err);
       }
     },
 
@@ -147,7 +153,8 @@ export const makeAsyncStorage: (
       try {
         persistedData = await AsyncStorage.getItem(metadataKey);
       } catch (_err) {
-        if (process.env.NODE_ENV !== 'production') console.warn('[urql] AsyncStorage error:', _err);
+        if (process.env.NODE_ENV !== 'production')
+          console.warn('[urql] AsyncStorage error:', _err);
       }
       return parseData(persistedData, []);
     },
@@ -171,7 +178,8 @@ export const makeAsyncStorage: (
         await AsyncStorage.removeItem(dataKey);
         await AsyncStorage.removeItem(metadataKey);
       } catch (_err) {
-        if (process.env.NODE_ENV !== 'production') console.warn('[urql] AsyncStorage error:', _err);
+        if (process.env.NODE_ENV !== 'production')
+          console.warn('[urql] AsyncStorage error:', _err);
       }
     },
   };

--- a/packages/storage-rn/src/makeAsyncStorage.ts
+++ b/packages/storage-rn/src/makeAsyncStorage.ts
@@ -22,7 +22,9 @@ const parseData = (persistedData: any, fallback: any) => {
     if (persistedData) {
       return JSON.parse(persistedData);
     }
-  } catch (_err) {}
+  } catch (_err) {
+    if (__DEV__) console.warn('[urql] AsyncStorage error:', _err);
+  }
 
   return fallback;
 };
@@ -66,7 +68,9 @@ export const makeAsyncStorage: (
         let persistedData: string | null = null;
         try {
           persistedData = await AsyncStorage.getItem(dataKey);
-        } catch (_err) {}
+        } catch (_err) {
+          if (__DEV__) console.warn('[urql] AsyncStorage error:', _err);
+        }
         const parsed = parseData(persistedData, {});
 
         Object.assign(allData, parsed);
@@ -84,7 +88,9 @@ export const makeAsyncStorage: (
       if (syncNeeded) {
         try {
           await AsyncStorage.setItem(dataKey, JSON.stringify(allData));
-        } catch (_err) {}
+        } catch (_err) {
+          if (__DEV__) console.warn('[urql] AsyncStorage error:', _err);
+        }
       }
 
       return Object.assign(
@@ -98,7 +104,9 @@ export const makeAsyncStorage: (
         let persistedData: string | null = null;
         try {
           persistedData = await AsyncStorage.getItem(dataKey);
-        } catch (_err) {}
+        } catch (_err) {
+          if (__DEV__) console.warn('[urql] AsyncStorage error:', _err);
+        }
         const parsed = parseData(persistedData, {});
         Object.assign(allData, parsed);
       }
@@ -121,20 +129,26 @@ export const makeAsyncStorage: (
 
       try {
         await AsyncStorage.setItem(dataKey, JSON.stringify(allData));
-      } catch (_err) {}
+      } catch (_err) {
+        if (__DEV__) console.warn('[urql] AsyncStorage error:', _err);
+      }
     },
 
     writeMetadata: async data => {
       try {
         await AsyncStorage.setItem(metadataKey, JSON.stringify(data));
-      } catch (_err) {}
+      } catch (_err) {
+        if (__DEV__) console.warn('[urql] AsyncStorage error:', _err);
+      }
     },
 
     readMetadata: async () => {
       let persistedData: string | null = null;
       try {
         persistedData = await AsyncStorage.getItem(metadataKey);
-      } catch (_err) {}
+      } catch (_err) {
+        if (__DEV__) console.warn('[urql] AsyncStorage error:', _err);
+      }
       return parseData(persistedData, []);
     },
 
@@ -156,7 +170,9 @@ export const makeAsyncStorage: (
         allData = {};
         await AsyncStorage.removeItem(dataKey);
         await AsyncStorage.removeItem(metadataKey);
-      } catch (_err) {}
+      } catch (_err) {
+        if (__DEV__) console.warn('[urql] AsyncStorage error:', _err);
+      }
     },
   };
 };

--- a/packages/storage-rn/src/makeAsyncStorage.ts
+++ b/packages/storage-rn/src/makeAsyncStorage.ts
@@ -23,7 +23,7 @@ const parseData = (persistedData: any, fallback: any) => {
       return JSON.parse(persistedData);
     }
   } catch (_err) {
-    if (__DEV__) console.warn('[urql] AsyncStorage error:', _err);
+    if (process.env.NODE_ENV !== 'production') console.warn('[urql] AsyncStorage error:', _err);
   }
 
   return fallback;
@@ -69,7 +69,7 @@ export const makeAsyncStorage: (
         try {
           persistedData = await AsyncStorage.getItem(dataKey);
         } catch (_err) {
-          if (__DEV__) console.warn('[urql] AsyncStorage error:', _err);
+          if (process.env.NODE_ENV !== 'production') console.warn('[urql] AsyncStorage error:', _err);
         }
         const parsed = parseData(persistedData, {});
 
@@ -89,7 +89,7 @@ export const makeAsyncStorage: (
         try {
           await AsyncStorage.setItem(dataKey, JSON.stringify(allData));
         } catch (_err) {
-          if (__DEV__) console.warn('[urql] AsyncStorage error:', _err);
+          if (process.env.NODE_ENV !== 'production') console.warn('[urql] AsyncStorage error:', _err);
         }
       }
 
@@ -105,7 +105,7 @@ export const makeAsyncStorage: (
         try {
           persistedData = await AsyncStorage.getItem(dataKey);
         } catch (_err) {
-          if (__DEV__) console.warn('[urql] AsyncStorage error:', _err);
+          if (process.env.NODE_ENV !== 'production') console.warn('[urql] AsyncStorage error:', _err);
         }
         const parsed = parseData(persistedData, {});
         Object.assign(allData, parsed);
@@ -130,7 +130,7 @@ export const makeAsyncStorage: (
       try {
         await AsyncStorage.setItem(dataKey, JSON.stringify(allData));
       } catch (_err) {
-        if (__DEV__) console.warn('[urql] AsyncStorage error:', _err);
+        if (process.env.NODE_ENV !== 'production') console.warn('[urql] AsyncStorage error:', _err);
       }
     },
 
@@ -138,7 +138,7 @@ export const makeAsyncStorage: (
       try {
         await AsyncStorage.setItem(metadataKey, JSON.stringify(data));
       } catch (_err) {
-        if (__DEV__) console.warn('[urql] AsyncStorage error:', _err);
+        if (process.env.NODE_ENV !== 'production') console.warn('[urql] AsyncStorage error:', _err);
       }
     },
 
@@ -147,7 +147,7 @@ export const makeAsyncStorage: (
       try {
         persistedData = await AsyncStorage.getItem(metadataKey);
       } catch (_err) {
-        if (__DEV__) console.warn('[urql] AsyncStorage error:', _err);
+        if (process.env.NODE_ENV !== 'production') console.warn('[urql] AsyncStorage error:', _err);
       }
       return parseData(persistedData, []);
     },
@@ -171,7 +171,7 @@ export const makeAsyncStorage: (
         await AsyncStorage.removeItem(dataKey);
         await AsyncStorage.removeItem(metadataKey);
       } catch (_err) {
-        if (__DEV__) console.warn('[urql] AsyncStorage error:', _err);
+        if (process.env.NODE_ENV !== 'production') console.warn('[urql] AsyncStorage error:', _err);
       }
     },
   };


### PR DESCRIPTION
## Problem

`makeAsyncStorage.ts` has 8 empty catch blocks that silently swallow all AsyncStorage errors:

```typescript
try {
  persistedData = await AsyncStorage.getItem(dataKey);
} catch (_err) {} // all errors silently lost
```

If AsyncStorage fails (permissions, full disk, corrupted data), persisted data is silently lost with no indication to the developer.

## Fix

Add `console.warn` guarded by `__DEV__` — errors are logged during development, production behavior unchanged:

```typescript
} catch (_err) {
  if (__DEV__) console.warn("[urql] AsyncStorage error:", _err);
}
```

- **8 catch blocks** updated in `packages/storage-rn/src/makeAsyncStorage.ts`
- **Production safe** — no logging in release builds
- **Behavior unchanged** — still fails silently, but developers can now see why

Found during a [static analysis sweep of 97 popular open source projects](https://dev.to/_1353e04f14b156240b/i-scanned-50-popular-open-source-projects-for-security-patterns-heres-what-i-found-8l5).