### PR TITLE
ci: use staged npm publishing

### DIFF
--- a/.github/scripts/has-unpublished-packages.mjs
+++ b/.github/scripts/has-unpublished-packages.mjs
@@ -1,0 +1,118 @@
+import { appendFileSync } from 'node:fs';
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+async function readWorkspacePatterns() {
+  const workspace = await readFile('pnpm-workspace.yaml', 'utf8');
+  const patterns = [];
+  let inPackages = false;
+
+  for (const line of workspace.split('\n')) {
+    if (line === 'packages:') {
+      inPackages = true;
+      continue;
+    }
+
+    if (inPackages && line && !line.startsWith(' ')) {
+      break;
+    }
+
+    const match = line.match(/^\s+-\s+['"]?([^'"]+)['"]?\s*$/);
+
+    if (inPackages && match) {
+      patterns.push(match[1]);
+    }
+  }
+
+  return patterns.filter(pattern => !pattern.startsWith('!'));
+}
+
+async function expandWorkspacePattern(pattern) {
+  const normalized = pattern.replace(/^\.\//, '');
+
+  if (normalized === '.') {
+    return [process.cwd()];
+  }
+
+  if (!normalized.endsWith('/*')) {
+    return [];
+  }
+
+  const directory = normalized.slice(0, -2);
+  const entries = await readdir(directory, { withFileTypes: true });
+
+  return entries
+    .filter(entry => entry.isDirectory())
+    .map(entry => path.join(process.cwd(), directory, entry.name));
+}
+
+async function getWorkspacePackages() {
+  const directories = (await Promise.all((await readWorkspacePatterns()).map(expandWorkspacePattern)))
+    .flat();
+  const packages = [];
+
+  for (const directory of directories) {
+    try {
+      const pkg = JSON.parse(await readFile(path.join(directory, 'package.json'), 'utf8'));
+
+      if (!pkg.private && pkg.name && pkg.version) {
+        packages.push({ name: pkg.name, version: pkg.version });
+      }
+    } catch (error) {
+      if (error.code !== 'ENOENT') {
+        throw error;
+      }
+    }
+  }
+
+  return packages.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+async function hasPublishedVersion(pkg) {
+  const response = await fetch(`https://registry.npmjs.org/${encodeURIComponent(pkg.name)}`, {
+    headers: { accept: 'application/vnd.npm.install-v1+json' },
+  });
+
+  if (response.status === 404) {
+    return false;
+  }
+
+  if (!response.ok) {
+    throw new Error(`Failed to query ${pkg.name}: ${response.status} ${response.statusText}`);
+  }
+
+  const metadata = await response.json();
+  return Object.prototype.hasOwnProperty.call(metadata.versions ?? {}, pkg.version);
+}
+
+async function main() {
+  const packages = await getWorkspacePackages();
+  let hasUnpublished = false;
+
+  for (const pkg of packages) {
+    const isPublished = await hasPublishedVersion(pkg);
+
+    if (isPublished) {
+      console.log(`${pkg.name}@${pkg.version} is already published`);
+    } else {
+      console.log(`${pkg.name}@${pkg.version} is not published yet`);
+      hasUnpublished = true;
+    }
+  }
+
+  const output =
+    [`has_unpublished=${String(hasUnpublished)}`, `should_publish=${String(hasUnpublished)}`].join(
+      '\n'
+    ) + '\n';
+
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(process.env.GITHUB_OUTPUT, output);
+  } else {
+    process.stdout.write(output);
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/.github/scripts/stage-packages.mjs
+++ b/.github/scripts/stage-packages.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+
+const root = process.cwd();
+const config = JSON.parse(readFileSync(join(root, ".changeset/config.json"), "utf8"));
+const ignored = new Set(config.ignore || []);
+const access = config.access || "public";
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function packageJsonPathsFromWorkspace() {
+  const paths = [];
+
+  function visit(dir) {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (
+        entry.name === ".git" ||
+        entry.name === "node_modules" ||
+        entry.name === ".pnpm" ||
+        entry.name === "dist" ||
+        entry.name === "coverage"
+      ) {
+        continue;
+      }
+
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        visit(path);
+      } else if (entry.isFile() && entry.name === "package.json") {
+        paths.push(path);
+      }
+    }
+  }
+
+  visit(root);
+  return paths;
+}
+
+function packageJsonPaths() {
+  return [...new Set(packageJsonPathsFromWorkspace())].filter(existsSync);
+}
+
+function versionExists(name, version) {
+  const result = spawnSync("npm", ["view", `${name}@${version}`, "version", "--json"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  if (result.status === 0) return true;
+  const output = `${result.stdout}
+${result.stderr}`;
+  if (output.includes("E404") || output.includes("No match found")) return false;
+
+  process.stdout.write(result.stdout);
+  process.stderr.write(result.stderr);
+  throw new Error(`Could not check npm version for ${name}@${version}`);
+}
+
+function distTag(version) {
+  const prerelease = version.match(/^[^-]+-([0-9A-Za-z-]+)/);
+  return prerelease ? prerelease[1] : "latest";
+}
+
+function runGit(args) {
+  const result = spawnSync("git", args, {
+    cwd: root,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  process.stdout.write(result.stdout);
+  process.stderr.write(result.stderr);
+  if (result.status !== 0) process.exit(result.status || 1);
+}
+
+function hasLocalGitTag(tagName) {
+  const result = spawnSync(
+    "git",
+    ["rev-parse", "--verify", "--quiet", `refs/tags/${tagName}`],
+    {
+      cwd: root,
+      stdio: "ignore",
+    }
+  );
+  return result.status === 0;
+}
+
+function createGitTag(tagName) {
+  if (hasLocalGitTag(tagName)) {
+    console.log(`Git tag ${tagName} already exists locally.`);
+  } else {
+    runGit(["tag", tagName, "-m", tagName]);
+  }
+
+  // changesets/action parses this line, then pushes the tag and creates the GitHub release.
+  console.log(`New tag: ${tagName}`);
+}
+
+const staged = [];
+for (const packageJsonPath of packageJsonPaths()) {
+  const pkg = readJson(packageJsonPath);
+  if (!pkg.name || !pkg.version || pkg.private || ignored.has(pkg.name)) continue;
+  if (versionExists(pkg.name, pkg.version)) {
+    console.log(`Skipping ${pkg.name}@${pkg.version}; already published.`);
+    continue;
+  }
+
+  const packageDir = dirname(packageJsonPath);
+  const tag = distTag(pkg.version);
+  const args = [
+    "stage",
+    "publish",
+    packageDir,
+    "--provenance",
+    "--access",
+    pkg.publishConfig?.access || access,
+    "--tag",
+    tag,
+    "--json",
+  ];
+
+  console.log(`Staging ${pkg.name}@${pkg.version} with dist-tag ${tag}...`);
+  const result = spawnSync("pnpm", args, {
+    cwd: root,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  process.stdout.write(result.stdout);
+  process.stderr.write(result.stderr);
+  if (result.status !== 0) process.exit(result.status || 1);
+
+  const stageId = result.stdout.match(/"stageId"\s*:\s*"([^"]+)"/)?.[1];
+  const tagName = `${pkg.name}@${pkg.version}`;
+  createGitTag(tagName);
+
+  staged.push({
+    name: pkg.name,
+    version: pkg.version,
+    path: relative(root, packageDir) || ".",
+    stageId,
+  });
+}
+
+if (staged.length === 0) {
+  console.log("No unpublished packages to stage.");
+} else {
+  console.log("Staged packages:");
+  for (const pkg of staged) {
+    console.log(`- ${pkg.name}@${pkg.version}${pkg.stageId ? ` (${pkg.stageId})` : ""}`);
+  }
+  console.log("Approve staged packages with `npm stage approve <stage-id>` after review.");
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          version: 9
+          version: 11
           run_install: false
 
       - name: Get pnpm store directory
@@ -73,7 +73,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          version: 9
+          version: 11
           run_install: false
 
       - name: Get pnpm store directory
@@ -122,7 +122,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          version: 9
+          version: 11
           run_install: false
 
       - name: Get pnpm store directory
@@ -177,7 +177,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          version: 9
+          version: 11
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,19 +9,71 @@ jobs:
     name: Release
     runs-on: ubuntu-24.04
     timeout-minutes: 20
+    outputs:
+      has_changesets: ${{ steps.changesets.outputs.hasChangesets }}
+      has_unpublished_packages: ${{ steps.unpublished.outputs.has_unpublished }}
     permissions:
       contents: write
-      id-token: write
       issues: write
-      repository-projects: write
-      deployments: write
-      packages: write
       pull-requests: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          version: 11
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Check for unpublished package versions
+        id: unpublished
+        run: node .github/scripts/has-unpublished-packages.mjs
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Create Release Pull Request
+        id: changesets
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
+        with:
+          version: pnpm changeset:version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    name: Publish
+    needs: release
+    if: needs.release.outputs.has_changesets == 'false' && needs.release.outputs.has_unpublished_packages == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    environment:
+      name: npm
+      url: https://www.npmjs.com/package/urql
+    permissions:
+      contents: write
+      id-token: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          version: 11
+          run_install: false
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -30,37 +82,15 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Update npm
-        run: npm install -g npm@latest
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-        with:
-          version: 9
-          run_install: false
-
-      - name: Get pnpm store directory
-        id: pnpm-store
-        run: echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - name: Use pnpm store
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        id: pnpm-cache
-        with:
-          path: |
-            ~/.cache/Cypress
-            ${{ steps.pnpm-store.outputs.pnpm_cache_dir }}
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
+        run: npm install -g npm@11.14.1
 
       - name: Install Dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
-      - name: PR or Publish
+      - name: Publish packages
         id: changesets
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
-          version: pnpm changeset:version
           publish: pnpm changeset:publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -74,12 +104,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
-
-      - name: Publish Prerelease
-        if: steps.changesets.outputs.published != 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git reset --hard origin/main
-          pnpm changeset version --no-git-tag --snapshot canary
-          pnpm changeset publish --no-git-tag --snapshot canary --tag canary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          version: 11
+          version: 11.3.0
           run_install: false
 
       - name: Setup Node
@@ -72,7 +72,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          version: 11
+          version: 11.3.0
           run_install: false
 
       - name: Setup Node
@@ -82,7 +82,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Update npm
-        run: npm install -g npm@11.14.1
+        run: npm install -g npm@11.15.0
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
@@ -91,7 +91,8 @@ jobs:
         id: changesets
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
-          publish: pnpm changeset:publish
+          publish: node .github/scripts/stage-packages.mjs && pnpm jsr
+          createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,11 +171,13 @@ changes are merged. It will always open a **"Version Packages" PR** which is kep
 documents all changes that are made and will show in its description what all new changelogs are
 going to contain for their new entries.
 
-Once a "Version Packages" PR is approved by a contributor and merged, the action will automatically
-take care of creating the release, publishing all updated packages to the npm registry, and creating
+Once a "Version Packages" PR is approved by a contributor and merged, the release workflow will
+pause at the `npm` environment approval gate. After approval, the action will automatically take care
+of creating the release, publishing all updated packages to the npm registry, and creating
 appropriate tags on GitHub too.
 
-This process is automated, but the changelog should be checked for errors.
+This process is automated, but the changelog should be checked for errors before approving the `npm`
+environment deployment.
 
 As to **when** to merge the automated PR and publish? Maybe not after every change. Typically there
 are two release batches: hotfixes and release batches. We expect that a hotfix for a single package

--- a/package.json
+++ b/package.json
@@ -33,21 +33,6 @@
       "pre-commit": "lint-staged --quiet --relative"
     }
   },
-  "pnpm": {
-    "peerDependencyRules": {
-      "ignoreMissing": [
-        "react-native"
-      ],
-      "allowedVersions": {
-        "styled-components": "5"
-      }
-    },
-    "overrides": {
-      "graphql": "^16.6.0",
-      "styled-components": "^5.2.3",
-      "wonka": "^6.3.2"
-    }
-  },
   "devDependencies": {
     "@0no-co/graphql.web": "^1.0.13",
     "@actions/artifact": "^2.3.2",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,24 @@ packages:
   - 'packages/*'
   - 'exchanges/*'
   - '!examples/*'
+
+peerDependencyRules:
+  ignoreMissing:
+    - react-native
+  allowedVersions:
+    styled-components: '5'
+
+overrides:
+  graphql: ^16.6.0
+  styled-components: ^5.2.3
+  wonka: ^6.3.2
+
+allowBuilds:
+  '@parcel/watcher': true
+  core-js: true
+  core-js-pure: true
+  cypress: true
+  ejs: true
+  esbuild: true
+  fsevents: true
+  husky-v4: true


### PR DESCRIPTION
## Summary
- Switches the trusted npm publish path to `pnpm stage publish`.
- Uses pnpm 11.3.0 and npm 11.15.0 in the publish workflow.
- Preserves Changesets tag/GitHub release creation by emitting package tags from the staging helper.
- Keeps the existing JSR publish step after npm packages are staged.

## Verification
- `node --check .github/scripts/stage-packages.mjs`
- Workflow YAML parsed locally.