### PR TITLE
ci: harden trusted publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
+          package-manager-cache: false
           node-version: 22
           registry-url: "https://registry.npmjs.org"
 


### PR DESCRIPTION
## Summary
- Explicitly disables setup-node package-manager auto-caching in the trusted publishing workflow.
- Removes existing publish-workflow dependency cache usage where present.
- Pins external GitHub Actions in the trusted publish workflow to full commit SHAs, keeping the original tag as a comment breadcrumb.

## Why
Trusted publishing/OIDC workflows should not restore shared dependency caches, and tag-based action references can be retargeted after compromise. The StepSecurity advisory for `actions-cool/issues-helper` is the concrete failure mode: tags were moved to an imposter commit, while full-SHA pinned workflows were unaffected.

## Verification
- Parsed the edited workflow YAML locally with PyYAML.
- Re-scanned release workflows for `actions/setup-node` without `package-manager-cache: false` and for `actions/cache` usage.
- Re-scanned trusted publish workflow `uses:` entries and confirmed all external actions are pinned to 40-character commit SHAs.
