### PR TITLE
fix: (graphcache) keep relayPagination pages in cursor order

### DIFF
--- a/.changeset/relay-pagination-page-order.md
+++ b/.changeset/relay-pagination-page-order.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix `relayPagination` merging pages in the order they were written to the cache rather than in their cursor order. When multiple pages were requested concurrently and a later page's response was written before an earlier one's, the combined `edges`/`nodes` could transiently end up in the wrong order. Pages are now reordered along their cursor chain (via `after`/`endCursor` and `before`/`startCursor`) before being concatenated, while pages without a known predecessor keep their original order.

--- a/exchanges/graphcache/src/extras/relayPagination.test.ts
+++ b/exchanges/graphcache/src/extras/relayPagination.test.ts
@@ -262,6 +262,194 @@ describe('as resolver', () => {
     });
   });
 
+  it('keeps pages in cursor order even when a later page is written first', () => {
+    const Pagination = gql`
+      query ($cursor: String) {
+        __typename
+        items(first: 1, after: $cursor) {
+          __typename
+          edges {
+            __typename
+            node {
+              __typename
+              id
+            }
+          }
+          nodes {
+            __typename
+            id
+          }
+          pageInfo {
+            __typename
+            hasNextPage
+            endCursor
+          }
+        }
+      }
+    `;
+
+    const store = new Store({
+      resolvers: {
+        Query: {
+          items: relayPagination(),
+        },
+      },
+    });
+
+    const pageOne = {
+      __typename: 'Query',
+      items: {
+        __typename: 'ItemsConnection',
+        edges: [itemEdge(1)],
+        nodes: [itemNode(1)],
+        pageInfo: {
+          __typename: 'PageInfo',
+          hasNextPage: true,
+          endCursor: '1',
+        },
+      },
+    };
+
+    const pageTwo = {
+      __typename: 'Query',
+      items: {
+        __typename: 'ItemsConnection',
+        edges: [itemEdge(2)],
+        nodes: [itemNode(2)],
+        pageInfo: {
+          __typename: 'PageInfo',
+          hasNextPage: false,
+          endCursor: null,
+        },
+      },
+    };
+
+    // The second page's response is written to the cache before the first
+    // page's, as can happen when both requests are in flight at the same time.
+    write(store, { query: Pagination, variables: { cursor: '1' } }, pageTwo);
+    write(store, { query: Pagination, variables: { cursor: null } }, pageOne);
+
+    const res = query(store, { query: Pagination });
+
+    expect(res.partial).toBe(false);
+    expect(res.data).toEqual({
+      ...pageTwo,
+      items: {
+        ...pageTwo.items,
+        edges: [pageOne.items.edges[0], pageTwo.items.edges[0]],
+        nodes: [pageOne.items.nodes[0], pageTwo.items.nodes[0]],
+      },
+    });
+  });
+
+  it('keeps an orphaned page (uncached predecessor) in its original position', () => {
+    const Pagination = gql`
+      query ($cursor: String) {
+        __typename
+        items(first: 2, after: $cursor) {
+          __typename
+          edges {
+            __typename
+            node {
+              __typename
+              id
+            }
+          }
+          nodes {
+            __typename
+            id
+          }
+          pageInfo {
+            __typename
+            hasNextPage
+            endCursor
+          }
+        }
+      }
+    `;
+
+    const store = new Store({
+      resolvers: {
+        Query: {
+          items: relayPagination(),
+        },
+      },
+    });
+
+    const pageOne = {
+      __typename: 'Query',
+      items: {
+        __typename: 'ItemsConnection',
+        edges: [itemEdge(1), itemEdge(2)],
+        nodes: [itemNode(1), itemNode(2)],
+        pageInfo: {
+          __typename: 'PageInfo',
+          hasNextPage: true,
+          endCursor: '2',
+        },
+      },
+    };
+
+    // Continues pageOne: `after: '2'` matches pageOne's endCursor.
+    const pageTwo = {
+      __typename: 'Query',
+      items: {
+        __typename: 'ItemsConnection',
+        edges: [itemEdge(3), itemEdge(4)],
+        nodes: [itemNode(3), itemNode(4)],
+        pageInfo: {
+          __typename: 'PageInfo',
+          hasNextPage: true,
+          endCursor: '4',
+        },
+      },
+    };
+
+    // Orphan: its predecessor (endCursor '100') was never cached, so its
+    // position can't be derived and it must stay where it was written.
+    const pageThree = {
+      __typename: 'Query',
+      items: {
+        __typename: 'ItemsConnection',
+        edges: [itemEdge(5), itemEdge(6)],
+        nodes: [itemNode(5), itemNode(6)],
+        pageInfo: {
+          __typename: 'PageInfo',
+          hasNextPage: false,
+          endCursor: null,
+        },
+      },
+    };
+
+    write(store, { query: Pagination, variables: { cursor: null } }, pageOne);
+    write(store, { query: Pagination, variables: { cursor: '2' } }, pageTwo);
+    write(
+      store,
+      { query: Pagination, variables: { cursor: '100' } },
+      pageThree
+    );
+
+    const res = query(store, { query: Pagination });
+
+    expect(res.partial).toBe(false);
+    expect(res.data).toHaveProperty('items.edges', [
+      pageOne.items.edges[0],
+      pageOne.items.edges[1],
+      pageTwo.items.edges[0],
+      pageTwo.items.edges[1],
+      pageThree.items.edges[0],
+      pageThree.items.edges[1],
+    ]);
+    expect(res.data).toHaveProperty('items.nodes', [
+      pageOne.items.nodes[0],
+      pageOne.items.nodes[1],
+      pageTwo.items.nodes[0],
+      pageTwo.items.nodes[1],
+      pageThree.items.nodes[0],
+      pageThree.items.nodes[1],
+    ]);
+  });
+
   it('works with simultaneous forward and backward pagination (outwards merging)', () => {
     const Pagination = gql`
       query ($first: Int, $last: Int, $before: String, $after: String) {

--- a/exchanges/graphcache/src/extras/relayPagination.ts
+++ b/exchanges/graphcache/src/extras/relayPagination.ts
@@ -192,6 +192,76 @@ const getPage = (
   return page;
 };
 
+/** Reorders cached pages into their logical cursor order.
+ *
+ * @remarks
+ * `inspectFields` returns a connection's pages in the order they were written
+ * to the cache, which isn't guaranteed to match the order they should be
+ * concatenated in. When two pages are in flight at the same time and the later
+ * page's response is written first, the pages would otherwise be merged in the
+ * wrong order.
+ *
+ * Each forward page continues the page whose `endCursor` equals its `after`
+ * (and each backward page the one whose `startCursor` equals its `before`), so
+ * we can place every linked page directly after the page it continues from.
+ * Pages without a known predecessor — including the base page and any page
+ * whose predecessor isn't cached — keep their original order, so this only ever
+ * corrects pages that have a resolvable place in the chain.
+ */
+type PageEntry = { args: Variables; page: Page };
+
+const sortPages = (pages: Array<PageEntry>): Array<PageEntry> => {
+  if (pages.length < 2) return pages;
+
+  // Index pages by the cursor at each of their boundaries so a page can find
+  // the page it directly continues from.
+  const byEndCursor = new Map<string, number>();
+  const byStartCursor = new Map<string, number>();
+  for (let i = 0; i < pages.length; i++) {
+    const { endCursor, startCursor } = pages[i].page.pageInfo;
+    if (typeof endCursor === 'string') byEndCursor.set(endCursor, i);
+    if (typeof startCursor === 'string') byStartCursor.set(startCursor, i);
+  }
+
+  const predecessors = new Array<number | undefined>(pages.length);
+  const children: number[][] = pages.map(() => []);
+  let hasLink = false;
+  for (let i = 0; i < pages.length; i++) {
+    const { args } = pages[i];
+    let predecessor: number | undefined;
+    if (typeof args.after === 'string') {
+      predecessor = byEndCursor.get(args.after);
+    } else if (typeof args.before === 'string') {
+      predecessor = byStartCursor.get(args.before);
+    }
+    if (predecessor !== undefined && predecessor !== i) {
+      predecessors[i] = predecessor;
+      children[predecessor].push(i);
+      hasLink = true;
+    }
+  }
+
+  if (!hasLink) return pages;
+
+  // Emit each root (a page without a known predecessor) at its original
+  // position, immediately followed by the chain of pages that continue from it.
+  const sorted: Array<PageEntry> = [];
+  const seen = new Set<number>();
+  const emit = (index: number): void => {
+    if (seen.has(index)) return;
+    seen.add(index);
+    sorted.push(pages[index]);
+    for (let i = 0; i < children[index].length; i++) emit(children[index][i]);
+  };
+  for (let i = 0; i < pages.length; i++) {
+    if (predecessors[i] === undefined) emit(i);
+  }
+  // Emit any pages left out by a cursor cycle, preserving their original order.
+  for (let i = 0; i < pages.length; i++) emit(i);
+
+  return sorted;
+};
+
 /** Creates a {@link Resolver} that combines pages that comply to the Relay pagination spec.
  *
  * @param params - A {@link PaginationParams} configuration object.
@@ -226,13 +296,7 @@ export const relayPagination = (
       return undefined;
     }
 
-    let typename: string | null = null;
-    let startEdges: NullArray<string> = [];
-    let endEdges: NullArray<string> = [];
-    let startNodes: NullArray<string> = [];
-    let endNodes: NullArray<string> = [];
-    let pageInfo: PageInfo = { ...defaultPageInfo };
-
+    const unsortedPages: Array<PageEntry> = [];
     for (let i = 0; i < size; i++) {
       const { fieldKey, arguments: args } = fieldInfos[i];
       if (args === null || !compareArgs(fieldArgs, args)) {
@@ -240,9 +304,22 @@ export const relayPagination = (
       }
 
       const page = getPage(cache, entityKey, fieldKey);
-      if (page === null) {
-        continue;
+      if (page !== null) {
+        unsortedPages.push({ args, page });
       }
+    }
+
+    const pages = sortPages(unsortedPages);
+
+    let typename: string | null = null;
+    let startEdges: NullArray<string> = [];
+    let endEdges: NullArray<string> = [];
+    let startNodes: NullArray<string> = [];
+    let endNodes: NullArray<string> = [];
+    let pageInfo: PageInfo = { ...defaultPageInfo };
+
+    for (let i = 0; i < pages.length; i++) {
+      const { args, page } = pages[i];
       if (page.nodes.length === 0 && page.edges.length === 0 && typename) {
         continue;
       }


### PR DESCRIPTION
## Summary

`relayPagination` concatenated cached pages in the order `cache.inspectFields()` returns them — i.e. the order they were **written to the cache** — without reordering them by their cursor chain. When several pages are in flight at the same time and a **later page's response is written before an earlier one's**, the combined `edges`/`nodes` came out in the wrong order until the cache settled and the resolver re-ran (a brief flicker of mis-ordered items).

Observed node-id order with `first: 2` right after mount (two pages auto-fetched in quick succession):

```
edges: [C, D, A, B]   ← page 2 (C, D) ends up first
(a moment later)
edges: [A, B, C, D]   ← correct order (A, B = page 1)
```

This affects both forward (`after`) and backward (`before`) pagination, and is most visible when `first`/`last` is small and pages are fetched automatically in quick succession (e.g. `onEndReached` firing right after mount).

Resolves #3876

## Set of changes

- `exchanges/graphcache/src/extras/relayPagination.ts`
  - Add a `sortPages` helper that reorders the matching pages into their logical cursor order before merging. Each forward page continues the page whose `endCursor` equals its `after` (and each backward page the one whose `startCursor` equals its `before`), so every linked page is placed directly after the page it continues from. Pages without a known predecessor — the base page and any page whose predecessor isn't cached — keep their original order, so this only ever corrects pages that have a resolvable place in the chain.
  - The resolver now collects the matching pages first, runs them through `sortPages`, then merges as before. The merge/dispatch logic (`startEdges`/`endEdges`, `mergeMode`) is unchanged.
  - No additional cache reads: `getPage`/`concatEdges` are called the same number of times as before; the reordering is in-memory bookkeeping over the page count only, with early exits for single-page connections and connections whose pages don't link.
- `exchanges/graphcache/src/extras/relayPagination.test.ts`
  - Add a test that writes a later page before an earlier one and expects cursor order.
  - Add a test that an orphaned page (whose predecessor isn't cached) keeps its original position.

This is not a breaking change.
