### PR TITLE
Fix async mapExchange teardown handling

### DIFF
--- a/.changeset/calm-maps-smile.md
+++ b/.changeset/calm-maps-smile.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Prevent `mapExchange` from forwarding async-mapped operations after their teardown has already been received.

--- a/packages/core/src/exchanges/map.test.ts
+++ b/packages/core/src/exchanges/map.test.ts
@@ -1,4 +1,13 @@
-import { map, tap, pipe, fromValue, toArray, toPromise } from 'wonka';
+import {
+  map,
+  tap,
+  pipe,
+  fromValue,
+  makeSubject,
+  subscribe,
+  toArray,
+  toPromise,
+} from 'wonka';
 import { vi, expect, describe, it } from 'vitest';
 
 import { Client } from '../client';
@@ -103,6 +112,53 @@ describe('onOperation', () => {
     expect(onOperation).toBeCalledWith(queryOperation);
     expect(onExchangeResult).toBeCalledTimes(1);
     expect(onExchangeResult).toBeCalledWith(mockOperation);
+  });
+
+  it('does not delay teardowns or forward operations cancelled while mapping', async () => {
+    const teardownOperation = makeOperation(
+      'teardown',
+      queryOperation,
+      queryOperation.context
+    );
+    const onOperation = vi.fn(
+      operation =>
+        new Promise<Operation>(resolve => {
+          setTimeout(() => resolve(operation), 0);
+        })
+    );
+    const onExchangeResult = vi.fn();
+    const onResult = vi.fn();
+    const { source, next } = makeSubject<Operation>();
+
+    const exchangeArgs = {
+      forward: op$ =>
+        pipe(
+          op$,
+          tap(onExchangeResult),
+          map((operation: Operation) => makeResult(operation, { data: null }))
+        ),
+      client: {} as Client,
+      dispatchDebug: () => null,
+    };
+
+    pipe(
+      source,
+      mapExchange({ onOperation })(exchangeArgs),
+      subscribe(onResult)
+    );
+
+    next(queryOperation);
+    next(teardownOperation);
+
+    expect(onOperation).toBeCalledTimes(1);
+    expect(onOperation).toBeCalledWith(queryOperation);
+    expect(onExchangeResult).toBeCalledTimes(1);
+    expect(onExchangeResult).toBeCalledWith(teardownOperation);
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(onExchangeResult).toBeCalledTimes(1);
+    expect(onResult).toBeCalledTimes(1);
   });
 });
 

--- a/packages/core/src/exchanges/map.ts
+++ b/packages/core/src/exchanges/map.ts
@@ -1,4 +1,11 @@
-import { mergeMap, fromValue, fromPromise, pipe } from 'wonka';
+import {
+  filter,
+  mergeMap,
+  fromValue,
+  fromPromise,
+  pipe,
+  takeUntil,
+} from 'wonka';
 import type { Operation, OperationResult, Exchange } from '../types';
 import type { CombinedError } from '../utils';
 
@@ -18,6 +25,8 @@ export interface MapExchangeOpts {
    * Hint: The callback may also be promisified and return a new {@link Operation} asynchronously,
    * provided you place your {@link mapExchange} after all synchronous {@link Exchange | Exchanges},
    * like after your `cacheExchange`.
+   *
+   * Teardown operations are forwarded immediately and don't invoke this callback.
    */
   onOperation?(operation: Operation): Promise<Operation> | Operation | void;
   /** Accepts a callback for incoming `OperationResult`s.
@@ -77,10 +86,22 @@ export const mapExchange = ({
         pipe(
           ops$,
           mergeMap(operation => {
+            if (operation.kind === 'teardown') return fromValue(operation);
+
             const newOperation =
               (onOperation && onOperation(operation)) || operation;
             return 'then' in newOperation
-              ? fromPromise(newOperation)
+              ? pipe(
+                  fromPromise(newOperation),
+                  takeUntil(
+                    pipe(
+                      ops$,
+                      filter(
+                        op => op.kind === 'teardown' && op.key === operation.key
+                      )
+                    )
+                  )
+                )
               : fromValue(newOperation);
           })
         ),


### PR DESCRIPTION
## Summary

- Forward teardown operations immediately in `mapExchange`
- Drop async-mapped operations when a teardown for the same operation key arrives first
- Add a patch changeset for `@urql/core`

Fixes #3873.
