### PR TITLE
Unwrap payload property when parsing the first result

### DIFF
--- a/.changeset/late-melons-attack.md
+++ b/.changeset/late-melons-attack.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Unwrap the `payload` property in `makeResult` so that the first incremental/multipart response is parsed correctly. Previously, transports that wrap each result in a `payload` property (e.g. Apollo Federation's multipart subscriptions) would have their first response dropped as "No Content", while subsequent responses were handled correctly by `mergeResultPatch`.

--- a/packages/core/src/internal/fetchSource.test.ts
+++ b/packages/core/src/internal/fetchSource.test.ts
@@ -371,6 +371,96 @@ describe('on multipart/mixed', () => {
       },
     });
   });
+
+  it('unwraps the payload property on the first streamed response', async () => {
+    // Reproduction for https://github.com/urql-graphql/urql/issues/3763
+    // Some servers (e.g. Apollo Federation's multipart subscriptions) wrap each
+    // response in a `payload` property. The first response should be parsed
+    // correctly rather than being dropped as "No Content".
+    fetch.mockResolvedValue({
+      status: 200,
+      headers: {
+        get() {
+          return 'multipart/mixed';
+        },
+      },
+      body: {
+        getReader: function () {
+          let cancelled = false;
+          const results = [
+            {
+              done: false,
+              value: Buffer.from('\r\n---'),
+            },
+            {
+              done: false,
+              value: Buffer.from(
+                wrap({
+                  payload: {
+                    data: { count: 0, __typename: 'Subscription' },
+                  },
+                })
+              ),
+            },
+            {
+              done: false,
+              value: Buffer.from(
+                wrap({
+                  payload: {
+                    data: { count: 1, __typename: 'Subscription' },
+                  },
+                })
+              ),
+            },
+            {
+              done: false,
+              value: Buffer.from(wrap({ hasNext: false }) + '--'),
+            },
+            { done: true },
+          ];
+          let count = 0;
+          return {
+            cancel: function () {
+              cancelled = true;
+            },
+            read: function () {
+              if (cancelled) throw new Error('No');
+
+              return Promise.resolve(results[count++]);
+            },
+          };
+        },
+      },
+    });
+
+    const subscriptionOperation: Operation = makeOperation(
+      'subscription',
+      {
+        query: gql`
+          subscription {
+            count
+          }
+        `,
+        variables: {},
+        key: 1,
+      },
+      context
+    );
+
+    const chunks: OperationResult[] = await pipe(
+      makeFetchSource(subscriptionOperation, 'https://test.com/graphql', {}),
+      scan((prev: OperationResult[], item) => [...prev, item], []),
+      toPromise
+    );
+
+    expect(chunks.length).toEqual(3);
+
+    expect(chunks[0].data).toEqual({ count: 0, __typename: 'Subscription' });
+    expect(chunks[0].error).toBeUndefined();
+
+    expect(chunks[1].data).toEqual({ count: 1, __typename: 'Subscription' });
+    expect(chunks[2].hasNext).toBe(false);
+  });
 });
 
 describe('on text/event-stream', () => {

--- a/packages/core/src/utils/result.test.ts
+++ b/packages/core/src/utils/result.test.ts
@@ -38,6 +38,41 @@ describe('makeResult', () => {
     const result = makeResult(subscriptionOperation, origResult);
     expect(result.hasNext).toBe(true);
   });
+
+  it('unwraps the payload property on the first result', () => {
+    const origResult = {
+      payload: {
+        data: {
+          __typename: 'Subscription',
+          event: 1,
+        },
+        errors: ['error message'],
+        extensions: {
+          extensionKey: 'extensionValue',
+        },
+      },
+    };
+
+    const result = makeResult(subscriptionOperation, origResult);
+
+    expect(result.data).toEqual({
+      __typename: 'Subscription',
+      event: 1,
+    });
+    expect(result.extensions).toEqual({
+      extensionKey: 'extensionValue',
+    });
+    expect(result.error).toMatchInlineSnapshot(
+      `[CombinedError: [GraphQL] error message]`
+    );
+    expect(result.hasNext).toBe(true);
+  });
+
+  it('throws "No Content" for an empty payload property', () => {
+    expect(() =>
+      makeResult(subscriptionOperation, { payload: {} })
+    ).toThrowError('No Content');
+  });
 });
 
 describe('mergeResultPatch (defer/stream latest', () => {

--- a/packages/core/src/utils/result.ts
+++ b/packages/core/src/utils/result.ts
@@ -28,9 +28,14 @@ export const makeResult = (
   result: ExecutionResult,
   response?: any
 ): OperationResult => {
+  // NOTE: Some transports (e.g. Apollo Federation's multipart subscriptions) wrap
+  // the actual result in a `payload` property. We unwrap it here, mirroring the
+  // handling in `mergeResultPatch`, so that the first delivered result is parsed
+  // correctly rather than being treated as "No Content".
+  const json = result.payload || result;
   if (
-    !('data' in result) &&
-    (!('errors' in result) || !Array.isArray(result.errors))
+    !('data' in json) &&
+    (!('errors' in json) || !Array.isArray(json.errors))
   ) {
     throw new Error('No Content');
   }
@@ -38,14 +43,14 @@ export const makeResult = (
   const defaultHasNext = operation.kind === 'subscription';
   return {
     operation,
-    data: result.data,
-    error: Array.isArray(result.errors)
+    data: json.data,
+    error: Array.isArray(json.errors)
       ? new CombinedError({
-          graphQLErrors: result.errors,
+          graphQLErrors: json.errors,
           response,
         })
       : undefined,
-    extensions: result.extensions ? { ...result.extensions } : undefined,
+    extensions: json.extensions ? { ...json.extensions } : undefined,
     hasNext: result.hasNext == null ? defaultHasNext : result.hasNext,
     stale: false,
   };


### PR DESCRIPTION
## Summary

- Unwrap the `payload` property in `makeResult` so the first incremental/multipart response is parsed correctly, mirroring the handling already present in `mergeResultPatch`. Previously transports that wrap each result in a `payload` property (e.g. Apollo Federation's multipart subscriptions) had their first response dropped as "No Content", while subsequent responses worked.
- Add tests for the unwrapped first result and for a multipart subscription whose first chunk is wrapped in `payload`.
- Add a patch changeset for `@urql/core`.

Fixes #3763.