### PR TITLE
Preserve Graphcache query updates before refetch

### DIFF
--- a/exchanges/graphcache/src/cacheExchange.test.ts
+++ b/exchanges/graphcache/src/cacheExchange.test.ts
@@ -480,6 +480,175 @@ describe('data dependencies', () => {
     );
   });
 
+  it('preserves same-transaction updates while invalidating for refetch', () => {
+    const eventsQuery = gql`
+      {
+        calendarEvents {
+          id
+          name
+        }
+      }
+    `;
+
+    const mutation = gql`
+      mutation {
+        createCalendarEvent {
+          calendarEventInstance {
+            id
+            name
+          }
+        }
+      }
+    `;
+
+    const initialEventsData = {
+      __typename: 'Query',
+      calendarEvents: [
+        {
+          __typename: 'CalendarEvent',
+          id: '1',
+          name: 'Existing event',
+        },
+      ],
+    };
+
+    const refetchedEventsData = {
+      __typename: 'Query',
+      calendarEvents: [
+        ...initialEventsData.calendarEvents,
+        {
+          __typename: 'CalendarEvent',
+          id: '2',
+          name: 'Created event',
+        },
+        {
+          __typename: 'CalendarEvent',
+          id: '3',
+          name: 'Background event',
+        },
+      ],
+    };
+
+    const mutationData = {
+      __typename: 'Mutation',
+      createCalendarEvent: {
+        __typename: 'CreateCalendarEventResult',
+        calendarEventInstance: {
+          __typename: 'CalendarEvent',
+          id: '2',
+          name: 'Created event',
+        },
+      },
+    };
+
+    const client = createClient({
+      url: 'http://0.0.0.0',
+      exchanges: [],
+    });
+    const { source: ops$, next } = makeSubject<Operation>();
+
+    const reexec = vi
+      .spyOn(client, 'reexecuteOperation')
+      .mockImplementation(next);
+
+    const opQuery = client.createRequestOperation('query', {
+      key: 1,
+      query: eventsQuery,
+      variables: undefined,
+    });
+
+    const opMutation = client.createRequestOperation('mutation', {
+      key: 2,
+      query: mutation,
+      variables: undefined,
+    });
+
+    let queryResponses = 0;
+    const response = vi.fn((forwardOp: Operation): OperationResult => {
+      if (forwardOp.key === 1) {
+        queryResponses++;
+        return {
+          ...queryResponse,
+          operation: forwardOp,
+          data: queryResponses === 1 ? initialEventsData : refetchedEventsData,
+        };
+      } else if (forwardOp.key === 2) {
+        return {
+          ...queryResponse,
+          operation: forwardOp,
+          data: mutationData,
+        };
+      }
+
+      return undefined as any;
+    });
+
+    const updates = {
+      Mutation: {
+        createCalendarEvent: vi.fn((result, _args, cache) => {
+          const created = result.createCalendarEvent.calendarEventInstance;
+          const events = cache.resolve('Query', 'calendarEvents');
+          if (Array.isArray(events)) {
+            cache.link('Query', 'calendarEvents', [...events, created]);
+          }
+
+          cache.invalidate('Query', 'calendarEvents');
+        }),
+      },
+    };
+
+    const result = vi.fn();
+    const forward: ExchangeIO = ops$ => pipe(ops$, map(response), share);
+
+    pipe(
+      cacheExchange({ updates })({ forward, client, dispatchDebug })(ops$),
+      tap(result),
+      publish
+    );
+
+    next(opQuery);
+    next(opMutation);
+
+    const queryResults = result.mock.calls
+      .map(([res]) => res)
+      .filter(res => res.operation.key === opQuery.key);
+
+    expect(response).toHaveBeenCalledTimes(3);
+    expect(reexec.mock.calls[0][0]).toHaveProperty(
+      'context.requestPolicy',
+      'cache-and-network'
+    );
+    expect(reexec.mock.calls[1][0]).toHaveProperty(
+      'context.requestPolicy',
+      'network-only'
+    );
+
+    expect(queryResults).toHaveLength(3);
+    expect(queryResults).toContainEqual(
+      expect.objectContaining({
+        stale: true,
+        data: expect.objectContaining({
+          calendarEvents: [
+            expect.objectContaining({ id: '1' }),
+            expect.objectContaining({ id: '2' }),
+          ],
+        }),
+      })
+    );
+    expect(queryResults).toContainEqual(
+      expect.objectContaining({
+        stale: false,
+        data: expect.objectContaining({
+          calendarEvents: [
+            expect.objectContaining({ id: '1' }),
+            expect.objectContaining({ id: '2' }),
+            expect.objectContaining({ id: '3' }),
+          ],
+        }),
+      })
+    );
+  });
+
   it('does not notify related queries when a mutation update does not change the data', () => {
     vi.useFakeTimers();
 

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -110,6 +110,23 @@ export const cacheExchange =
       }
     };
 
+    const collectRefetchOperations = (
+      pendingOperations: Operations,
+      dependencies: undefined | Dependencies
+    ) => {
+      if (dependencies) {
+        for (const dep of dependencies.values()) {
+          const keys = deps.get(dep);
+          if (keys) {
+            for (const key of keys.values()) {
+              requestedRefetch.add(key);
+              pendingOperations.add(key);
+            }
+          }
+        }
+      }
+    };
+
     const executePendingOperations = (
       operation: Operation,
       pendingOperations: Operations,
@@ -166,7 +183,7 @@ export const cacheExchange =
         operations.set(operation.key, operation);
         // This executes an optimistic update for mutations and registers it if necessary
         initDataState('write', store.data, operation.key, true, false);
-        const { dependencies } = _write(
+        const { dependencies, refetchDependencies } = _write(
           store,
           operation as any,
           undefined,
@@ -181,6 +198,7 @@ export const cacheExchange =
           // Update related queries
           const pendingOperations: Operations = new Set();
           collectPendingOperations(pendingOperations, dependencies);
+          collectRefetchOperations(pendingOperations, refetchDependencies);
           executePendingOperations(operation, pendingOperations, true);
           // Mark operation as optimistic
           optimistic = true;
@@ -268,14 +286,15 @@ export const cacheExchange =
         // Write the result to cache and collect all dependencies that need to be
         // updated
         initDataState('write', store.data, operation.key, false, false);
-        const writeDependencies = _write(
+        const { dependencies: writeDependencies, refetchDependencies } = _write(
           store,
           operation,
           data,
           result.error
-        ).dependencies;
+        );
         clearDataState();
         collectPendingOperations(pendingOperations, writeDependencies);
+        collectRefetchOperations(pendingOperations, refetchDependencies);
         const prevData =
           operation.kind === 'query' ? results.get(operation.key) : null;
         initDataState(

--- a/exchanges/graphcache/src/operations/invalidate.ts
+++ b/exchanges/graphcache/src/operations/invalidate.ts
@@ -17,6 +17,15 @@ export const invalidateEntity = (
 
   for (let i = 0, l = fields.length; i < l; i++) {
     const { fieldKey } = fields[i];
+    if (
+      !InMemoryData.currentOptimistic &&
+      InMemoryData.isQueryRoot(entityKey) &&
+      InMemoryData.hasCurrentDataChange(entityKey, fieldKey)
+    ) {
+      InMemoryData.markDependencyForRefetch(entityKey, fieldKey);
+      continue;
+    }
+
     if (InMemoryData.readLink(entityKey, fieldKey) !== undefined) {
       InMemoryData.writeLink(entityKey, fieldKey, undefined);
     } else {

--- a/exchanges/graphcache/src/operations/write.ts
+++ b/exchanges/graphcache/src/operations/write.ts
@@ -51,6 +51,7 @@ import { invalidateType } from './invalidate';
 export interface WriteResult {
   data: null | Data;
   dependencies: Dependencies;
+  refetchDependencies: Dependencies;
 }
 
 /** Writes a GraphQL response to the cache.
@@ -104,6 +105,7 @@ export const _write = (
   const result: WriteResult = {
     data: data || InMemoryData.makeData(),
     dependencies: InMemoryData.currentDependencies!,
+    refetchDependencies: InMemoryData.currentRefetchDependencies!,
   };
   const kind = store.rootFields[operation.operation];
 

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -67,8 +67,10 @@ let currentOwnership: null | WeakSet<any> = null;
 let currentDataMapping: null | WeakMap<any, any> = null;
 let currentData: null | InMemoryData = null;
 let currentOptimisticKey: null | number = null;
+let currentDataChanges: null | Dependencies = null;
 export let currentOperation: null | OperationType = null;
 export let currentDependencies: null | Dependencies = null;
+export let currentRefetchDependencies: null | Dependencies = null;
 export let currentForeignData = false;
 export let currentOptimistic = false;
 
@@ -111,6 +113,8 @@ export const initDataState = (
   currentOperation = operationType;
   currentData = data;
   currentDependencies = new Set();
+  currentRefetchDependencies = new Set();
+  currentDataChanges = new Set();
   currentOptimistic = !!isOptimistic;
   currentForeignData = !!isForeignData;
   if (process.env.NODE_ENV !== 'production') {
@@ -194,6 +198,8 @@ export const clearDataState = () => {
   currentOperation = null;
   currentData = null;
   currentDependencies = null;
+  currentRefetchDependencies = null;
+  currentDataChanges = null;
   if (process.env.NODE_ENV !== 'production') {
     currentDebugStack.length = 0;
   }
@@ -447,6 +453,25 @@ const updateDependencies = (entityKey: string, fieldKey?: string) => {
   }
 };
 
+export const markDependencyForRefetch = (
+  entityKey: string,
+  fieldKey?: string
+) => {
+  if (entityKey !== currentData!.queryRootKey) {
+    currentRefetchDependencies!.add(entityKey);
+  } else if (fieldKey !== undefined && fieldKey !== '__typename') {
+    currentRefetchDependencies!.add(joinKeys(entityKey, fieldKey));
+  }
+};
+
+export const hasCurrentDataChange = (
+  entityKey: string,
+  fieldKey: string
+): boolean => currentDataChanges!.has(serializeKeys(entityKey, fieldKey));
+
+export const isQueryRoot = (entityKey: string): boolean =>
+  entityKey === currentData!.queryRootKey;
+
 const updatePersist = (entityKey: string, fieldKey: string) => {
   if (!currentOptimistic && currentData!.storage) {
     currentData!.persist.add(serializeKeys(entityKey, fieldKey));
@@ -518,6 +543,7 @@ export const writeRecord = (
   const existing = getNode(currentData!.records, entityKey, fieldKey);
   if (!isEqualLinkOrScalar(existing, value)) {
     updateDependencies(entityKey, fieldKey);
+    currentDataChanges!.add(serializeKeys(entityKey, fieldKey));
     updatePersist(entityKey, fieldKey);
   }
 
@@ -547,6 +573,7 @@ export const writeLink = (
   const existing = getNode(currentData!.links, entityKey, fieldKey);
   if (!isEqualLinkOrScalar(existing, link)) {
     updateDependencies(entityKey, fieldKey);
+    currentDataChanges!.add(serializeKeys(entityKey, fieldKey));
     updatePersist(entityKey, fieldKey);
   }
 


### PR DESCRIPTION
## Summary

- Preserve same-transaction `Query` field updates when they are invalidated for refetch
- Reexecute affected queries with `cache-and-network` instead of clearing the updated field
- Add regression coverage for update plus invalidate flows

Fixes #3618.
