### PR TITLE
Prevent awaited Vue queries from re-executing during SSR hydration

### DIFF
--- a/.changeset/spotty-points-bake.md
+++ b/.changeset/spotty-points-bake.md
@@ -1,0 +1,5 @@
+---
+'@urql/vue': patch
+---
+
+Stop `useQuery` from re-executing (and hitting the network) during SSR hydration when it's awaited for Suspense. Awaiting the query subscribed to the operation a second time, which re-dispatched it after the `ssrExchange` result had already been consumed, triggering a redundant network request even with `staleWhileRevalidate: false`. The awaited promise now resolves with the already-settled result instead of re-subscribing.

--- a/packages/vue-urql/src/ssr-hydration.test.ts
+++ b/packages/vue-urql/src/ssr-hydration.test.ts
@@ -1,0 +1,88 @@
+import { ref } from 'vue';
+import { expect, it } from 'vitest';
+
+import { pipe, filter, fromValue, mergeMap } from 'wonka';
+import {
+  createClient,
+  createRequest,
+  ssrExchange,
+  gql,
+  Exchange,
+} from '@urql/core';
+
+import { callUseQuery } from './useQuery';
+
+const query = gql`
+  query ($name: String!) {
+    character(name: $name)
+  }
+`;
+
+const makeNetworkExchange = () => {
+  const state = { calls: 0 };
+  const exchange: Exchange = () => ops$ =>
+    pipe(
+      ops$,
+      filter(op => op.kind !== 'teardown'),
+      mergeMap(op => {
+        state.calls++;
+        return fromValue({
+          operation: op,
+          data: { character: 'from network' },
+          stale: false,
+          hasNext: false,
+        } as any);
+      })
+    );
+  return { exchange, state };
+};
+
+it('does not re-execute on hydration when staleWhileRevalidate is false', async () => {
+  const variables = { name: 'no-revalidate' };
+  const { exchange: network, state } = makeNetworkExchange();
+  const ssr = ssrExchange({ isClient: true, staleWhileRevalidate: false });
+
+  const request = createRequest(query, variables);
+  ssr.restoreData({
+    [request.key]: {
+      data: JSON.stringify({ character: 'from ssr' }),
+      hasNext: false,
+    },
+  });
+
+  const client = createClient({
+    url: '/graphql',
+    exchanges: [ssr, network],
+  });
+
+  const query$ = callUseQuery({ query, variables }, ref(client));
+  await query$;
+
+  expect(query$.data.value).toEqual({ character: 'from ssr' });
+  expect(state.calls).toBe(0);
+});
+
+it('still revalidates on hydration when staleWhileRevalidate is true', async () => {
+  const variables = { name: 'revalidate' };
+  const { exchange: network, state } = makeNetworkExchange();
+  const ssr = ssrExchange({ isClient: true, staleWhileRevalidate: true });
+
+  const request = createRequest(query, variables);
+  ssr.restoreData({
+    [request.key]: {
+      data: JSON.stringify({ character: 'from ssr' }),
+      hasNext: false,
+    },
+  });
+
+  const client = createClient({
+    url: '/graphql',
+    exchanges: [ssr, network],
+  });
+
+  const query$ = callUseQuery({ query, variables }, ref(client));
+  await query$;
+
+  expect(query$.data.value).toEqual({ character: 'from network' });
+  expect(state.calls).toBe(1);
+});

--- a/packages/vue-urql/src/useQuery.ts
+++ b/packages/vue-urql/src/useQuery.ts
@@ -295,7 +295,14 @@ export function callUseQuery<T = any, V extends AnyVariables = AnyVariables>(
     let sub: Subscription | void;
 
     const promise = new Promise<UseQueryState<T, V>>(resolve => {
-      if (!source.value) {
+      // If there's no source (e.g. the query is paused) or we already hold a
+      // settled result — for instance one that the `ssrExchange` replayed
+      // synchronously during hydration — resolve without subscribing again.
+      // Subscribing here would re-dispatch the operation, and since the SSR
+      // result has already been consumed by the ongoing subscription, that
+      // would trigger a redundant network request.
+      // See: https://github.com/urql-graphql/urql/issues/3722
+      if (!source.value || (!fetching.value && !stale.value)) {
         return resolve(state);
       }
       let hasResult = false;


### PR DESCRIPTION
## Summary

- When a `useQuery` is awaited for Suspense, the awaitable `then` subscribed to the operation a second time, re-dispatching it after the `ssrExchange` result had already been consumed — triggering a needless network request on hydration even with `staleWhileRevalidate: false`
- Resolve the awaited promise with the already-settled result instead of re-subscribing
- Add a patch changeset for `@urql/vue`

Fixes #3722.