### PR TITLE
Fix subscription teardown race

### DIFF
--- a/.changeset/smart-buckets-rest.md
+++ b/.changeset/smart-buckets-rest.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Emit terminal subscription results before ending completed subscriptions, preventing teardown races from dropping GraphQL errors.

--- a/packages/core/src/exchanges/subscription.test.ts
+++ b/packages/core/src/exchanges/subscription.test.ts
@@ -3,6 +3,7 @@ import { vi, expect, it } from 'vitest';
 import {
   empty,
   publish,
+  subscribe,
   fromValue,
   pipe,
   Source,
@@ -10,7 +11,7 @@ import {
   toPromise,
 } from 'wonka';
 
-import { Client } from '../client';
+import { Client, createClient } from '../client';
 import { subscriptionOperation, subscriptionResult } from '../test-utils';
 import { stringifyDocument } from '../utils';
 import { OperationResult } from '../types';
@@ -79,6 +80,39 @@ it('should tear down the operation if the source subscription ends', async () =>
 
   expect(unsubscribe).not.toHaveBeenCalled();
   expect(reexecuteOperation).toHaveBeenCalled();
+});
+
+it('emits terminal subscription results before ending completed subscriptions', async () => {
+  const forwardSubscription = vi.fn<SubscriptionForwarder>(() => ({
+    subscribe(observer) {
+      observer.next({ errors: [new Error('boom')] });
+      observer.complete();
+      return { unsubscribe: vi.fn() };
+    },
+  }));
+
+  const client = createClient({
+    url: 'test',
+    exchanges: [subscriptionExchange({ forwardSubscription })],
+  });
+
+  const results: OperationResult[] = [];
+  pipe(
+    client.executeRequestOperation(subscriptionOperation),
+    subscribe(result => {
+      results.push(result);
+    })
+  );
+
+  await Promise.resolve();
+  await Promise.resolve();
+
+  expect(forwardSubscription).toHaveBeenCalledTimes(1);
+  expect(results).toHaveLength(2);
+  expect(results[0]).toHaveProperty('hasNext', true);
+  expect(results[0].error?.message).toContain('boom');
+  expect(results[1]).toHaveProperty('hasNext', false);
+  expect(results[1].error?.message).toContain('boom');
 });
 
 it('should allow providing a custom isSubscriptionOperation implementation', async () => {

--- a/packages/core/src/exchanges/subscription.ts
+++ b/packages/core/src/exchanges/subscription.ts
@@ -170,13 +170,12 @@ export const subscriptionExchange =
             complete() {
               if (!isComplete) {
                 isComplete = true;
-                if (operation.kind === 'subscription') {
+                if (result && result.hasNext) {
+                  nextResult({ hasNext: false });
+                } else if (operation.kind === 'subscription') {
                   client.reexecuteOperation(
                     makeOperation('teardown', operation, operation.context)
                   );
-                }
-                if (result && result.hasNext) {
-                  nextResult({ hasNext: false });
                 }
                 observer.complete();
               }


### PR DESCRIPTION
## Summary

- Emit terminal subscription results before ending completed subscriptions
- Prevent teardown races from dropping GraphQL errors
- Add a patch changeset for `@urql/core`

Fixes #3823.
