### PR TITLE
Fix invalid exports field in generated subpath package.json

### DIFF
--- a/.changeset/tame-mugs-fail.md
+++ b/.changeset/tame-mugs-fail.md
@@ -1,0 +1,7 @@
+---
+'@urql/exchange-graphcache': patch
+'@urql/core': patch
+'@urql/next': patch
+---
+
+Remove the invalid `exports` field from the generated subpath `package.json` files (e.g. `@urql/exchange-graphcache/extras`, `@urql/exchange-graphcache/default-storage`, `@urql/core/internal`, `@urql/next/rsc`). These targets pointed at the parent `dist/` directory (`../dist/...`), which violates the Node.js package-exports spec requirement that every `exports` target begin with `./`. Metro (Expo 53 / React Native 0.79) validates this and logged a warning for every affected package. Subpath resolution continues to work: `exports`-aware bundlers resolve through the root `package.json`, while legacy resolution relies on the `main`/`module`/`types` fields that remain in place.

--- a/scripts/rollup/config.mjs
+++ b/scripts/rollup/config.mjs
@@ -34,6 +34,14 @@ const input = settings.sources.reduce((acc, source) => {
     const rel = relative(source.dir, process.cwd());
     plugins.push({
       async writeBundle() {
+        // NOTE: This package.json only exists to support legacy, file-based
+        // resolution for the subpath (e.g. `@urql/exchange-graphcache/extras`).
+        // Bundlers and runtimes that understand the `exports` field resolve the
+        // subpath through the root package.json's `exports` map instead. We must
+        // not emit an `exports` field here, since its targets point at the parent
+        // `dist/` directory (`../dist/...`) and the spec requires every `exports`
+        // target to begin with `./`. Metro (Expo/React Native) validates this and
+        // warns otherwise. See https://github.com/urql-graphql/urql/issues/3779
         const packageJson = JSON.stringify(
           {
             name: source.name,
@@ -43,15 +51,6 @@ const input = settings.sources.reduce((acc, source) => {
             module: join(rel, source.module),
             types: join(rel, source.types),
             source: join(rel, source.source),
-            exports: {
-              '.': {
-                types: join(rel, source.types),
-                import: join(rel, source.module),
-                require: join(rel, source.main),
-                source: join(rel, source.source),
-              },
-              './package.json': './package.json',
-            },
           },
           null,
           2


### PR DESCRIPTION
## Summary

- Stop emitting an `exports` field in the build-generated subpath `package.json` files (e.g. `@urql/exchange-graphcache/extras`, `default-storage`, `@urql/core/internal`, `@urql/next/rsc`)
- Their `exports` targets pointed at the parent `dist/` directory (`../dist/...`), which violates the package-exports spec requirement that every target begin with `./` — Metro (Expo 53 / RN 0.79) flags this and warns for each affected package
- Subpath resolution is unaffected: `exports`-aware tooling resolves through the root `package.json`, while legacy resolution keeps using the `main`/`module`/`types` fields that remain
- Add a patch changeset for `@urql/exchange-graphcache`, `@urql/core`, and `@urql/next`

Fixes #3779.