### PR TITLE
Add React deferred fragment suspense

### DIFF
--- a/.changeset/curvy-melons-suspend.md
+++ b/.changeset/curvy-melons-suspend.md
@@ -1,0 +1,14 @@
+---
+'urql': minor
+---
+
+Add a BETA `useFragment` hook to the React bindings. Given a fragment document and
+a piece of `data`, it returns the data masked to that fragment. When the `Client` (or
+the hook's `context`) has `suspense` enabled, it suspends while deferred fragment data
+is still streaming in, and otherwise reports the in-progress state via its `fetching`
+flag.
+
+React `useQuery` now installs stable promises for missing fields inside `@defer`
+selections and resolves them directly from the query stream as later results arrive.
+This lets deferred fragments wake Suspense boundaries during server streams without
+depending on a parent component rerender.

--- a/.changeset/curvy-melons-suspend.md
+++ b/.changeset/curvy-melons-suspend.md
@@ -8,7 +8,7 @@ the hook's `context`) has `suspense` enabled, it suspends while deferred fragmen
 is still streaming in, and otherwise reports the in-progress state via its `fetching`
 flag.
 
-React `useQuery` now installs stable promises for missing fields inside `@defer`
-selections and resolves them directly from the query stream as later results arrive.
+React `useQuery` now associates stable sidecar promises with missing fields inside
+`@defer` selections and resolves them directly from the query stream as later results arrive.
 This lets deferred fragments wake Suspense boundaries during server streams without
 depending on a parent component rerender.

--- a/.changeset/generalise-deferred-fragments.md
+++ b/.changeset/generalise-deferred-fragments.md
@@ -1,0 +1,17 @@
+---
+'@urql/core': minor
+'@urql/preact': minor
+---
+
+Generalise the deferred-fragment and fragment-masking logic behind React's BETA `useFragment`
+hook into `@urql/core`, so other framework bindings can reuse it. `@urql/core` now exports — as
+BETA — `maskFragment`, which masks a piece of `data` against a fragment's selection set and
+reports whether it's fulfilled or still streaming in, alongside the deferred-fragment helpers
+`updateDeferredResult`, `makeDeferredState`, `resolveDeferredState`, `isDeferredPromise`, and
+`getDeferredCacheForClient`. Together these install stable promises for missing fields inside
+`@defer` selections and resolve them directly from a query stream.
+
+Add a BETA `useFragment` hook to the Preact bindings, mirroring the React hook. Given a fragment
+document and a piece of `data`, it returns the data masked to that fragment. When the `Client`
+(or the hook's `context`) has `suspense` enabled, it suspends while deferred fragment data is
+still streaming in, and otherwise reports the in-progress state via its `fetching` flag.

--- a/.changeset/generalise-deferred-fragments.md
+++ b/.changeset/generalise-deferred-fragments.md
@@ -8,8 +8,8 @@ hook into `@urql/core`, so other framework bindings can reuse it. `@urql/core` n
 BETA — `maskFragment`, which masks a piece of `data` against a fragment's selection set and
 reports whether it's fulfilled or still streaming in, alongside the deferred-fragment helpers
 `updateDeferredResult`, `makeDeferredState`, `resolveDeferredState`, `isDeferredPromise`, and
-`getDeferredCacheForClient`. Together these install stable promises for missing fields inside
-`@defer` selections and resolve them directly from a query stream.
+`getDeferredCacheForClient`. Together these associate stable sidecar promises with missing fields
+inside `@defer` selections and resolve them directly from a query stream without changing result data.
 
 Add a BETA `useFragment` hook to the Preact bindings, mirroring the React hook. Given a fragment
 document and a piece of `data`, it returns the data masked to that fragment. When the `Client`

--- a/docs/basics/typescript-integration.md
+++ b/docs/basics/typescript-integration.md
@@ -189,10 +189,10 @@ GraphQL Code Generator generates type helpers to type your component props based
 Again, here is an example with the React bindings:
 
 ```tsx
-import { FragmentType, useFragment } from './gql/fragment-masking';
+import { useFragment } from 'urql';
+import type { FragmentType } from './gql/fragment-masking';
 import { graphql } from '../src/gql';
 
-// again, we use the generated `graphql()` function to write GraphQL documents 👀
 export const FilmFragment = graphql(/* GraphQL */ `
   fragment FilmItem on Film {
     id
@@ -202,26 +202,88 @@ export const FilmFragment = graphql(/* GraphQL */ `
   }
 `);
 
-const Film = (props: {
-  // `film` property has the correct type 🎉
-  film: FragmentType<typeof FilmFragment>;
-}) => {
-  // `film` is of type `FilmFragment`, with no extraneous properties ⚡️
-  const film = useFragment(FilmFragment, props.film);
-  return (
+const Film = (props: { film: FragmentType<typeof FilmFragment> }) => {
+  const { data: film } = useFragment({
+    fragment: FilmFragment,
+    data: props.film,
+  });
+
+  return film ? (
     <div>
       <h3>{film.title}</h3>
       <p>{film.releaseDate}</p>
     </div>
-  );
+  ) : null;
 };
 
 export default Film;
 ```
 
-_Examples with Vue are available [in the GraphQL Code Generator repository](https://github.com/dotansimha/graphql-code-generator/tree/master/examples/vue/urql)_.
+The `FragmentType` reference and the fragment's result type are intentionally
+separate. `useFragment` accepts the generated reference as its input and infers
+its returned `data` from `FilmFragment`. This also allows an incremental
+fragment reference to be passed before an `@defer` patch has arrived; with
+Suspense enabled, the hook waits for that patch.
 
-You will notice that our `<Film>` component leverages 2 imports from our generated code (from `../src/gql`): the `FragmentType<T>` type helper and the `useFragment()` function.
+GraphQL Code Generator calls its generated unmasking helper `useFragment` by
+default, but that helper isn't a React hook. To avoid a naming collision, name
+it `readFragment` (or `getFragmentData`) in your Codegen configuration:
 
-- we use `FragmentType<typeof FilmFragment>` to get the corresponding Fragment TypeScript type
-- later on, we use `useFragment()` to retrieve the properly film property
+```ts
+presetConfig: {
+  fragmentMasking: {
+    unmaskFunctionName: 'readFragment',
+  },
+},
+```
+
+The generated `readFragment(Fragment, data)` helper may still be used before
+calling urql's hook for non-deferred data. It is not required: passing the
+fragment reference directly is preferred for `@defer`, since Codegen's
+incremental reference is not considered fully readable until its patch arrives.
+
+For a deferred fragment, type the component input from the parent query field so
+its incremental state is retained:
+
+```tsx
+const Film = (props: { film: NonNullable<FilmsQuery['film']> }) => {
+  const { data: film } = useFragment({
+    fragment: FilmFragment,
+    data: props.film,
+  });
+  // ...
+};
+```
+
+### Using gql.tada fragment references
+
+gql.tada's opaque `FragmentOf` references are also accepted directly:
+
+```tsx
+import { useFragment } from 'urql';
+import { graphql, type FragmentOf } from 'gql.tada';
+
+const FilmFragment = graphql(`
+  fragment FilmItem on Film {
+    id
+    title
+    releaseDate
+  }
+`);
+
+const Film = (props: { film: FragmentOf<typeof FilmFragment> }) => {
+  const { data: film } = useFragment({
+    fragment: FilmFragment,
+    data: props.film,
+  });
+  return film ? <h3>{film.title}</h3> : null;
+};
+```
+
+You may equivalently pass
+`readFragment(FilmFragment, props.film)` as `data`. Both gql.tada and GraphQL
+Code Generator's readers preserve `null` and `undefined`, which `useFragment`
+also returns unchanged. For deferred fields, pass the opaque/incremental
+reference directly so the hook can suspend until the streamed patch arrives.
+
+_Examples with Vue are available [in the GraphQL Code Generator repository](https://github.com/dotansimha/graphql-code-generator/tree/master/examples/vue/urql)._

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,3 +16,22 @@ export {
   makeOperation,
   getOperationName,
 } from './utils';
+
+export {
+  maskFragment,
+  getFragments,
+  makeDeferredState,
+  resolveDeferredState,
+  isDeferredPromise,
+  updateDeferredResult,
+  makeCache,
+  getDeferredCacheForClient,
+} from './utils';
+
+export type {
+  FragmentMap,
+  MaskFragmentResult,
+  DeferredState,
+  DeferredPromise,
+  Cache,
+} from './utils';

--- a/packages/core/src/utils/cache.ts
+++ b/packages/core/src/utils/cache.ts
@@ -1,0 +1,111 @@
+import { pipe, subscribe } from 'wonka';
+import type { Client } from '../client';
+import type { DeferredState } from './defer';
+import { resolveDeferredState } from './defer';
+
+/** A small per-operation cache attached to a {@link Client}, keyed by an
+ * operation/request `key`. (BETA)
+ *
+ * @remarks
+ * Entries can be `dispose`d, which marks them for reclamation once the matching
+ * operation is torn down (when the cache is bound to a `Client`’s
+ * `operations$`), rather than being removed immediately.
+ *
+ * @beta
+ */
+export interface Cache<Entry> {
+  get(key: number): Entry | undefined;
+  set(key: number, value: Entry): void;
+  clear(key: number): void;
+  dispose(key: number): void;
+}
+
+/** Creates a {@link Cache} that optionally reclaims entries on operation teardown. (BETA)
+ *
+ * @param client - the {@link Client} whose `operations$` drives teardown-based reclamation.
+ * @param onClear - an optional callback invoked with an entry when it’s cleared.
+ * @param deferDispose - when `true`, `dispose` marks for reclamation even without a `client`.
+ *
+ * @remarks
+ * When a `client` is passed, this subscribes to its `operations$` stream — and
+ * only then; importing this module has no side effects. Disposed entries are
+ * removed when their operation’s `teardown` is observed; otherwise `dispose`
+ * clears immediately.
+ *
+ * @beta
+ */
+export const makeCache = <Entry>(
+  client?: Client,
+  onClear?: (value: Entry) => void,
+  deferDispose?: boolean
+): Cache<Entry> => {
+  const operations$ = client && (client as Partial<Client>).operations$;
+  const reclaim = new Set<number>();
+  const map = new Map<number, Entry>();
+
+  const clear = (key: number) => {
+    const value = map.get(key);
+    if (value !== undefined && onClear) onClear(value);
+    reclaim.delete(key);
+    map.delete(key);
+  };
+
+  if (operations$ /* not available in mocks */) {
+    pipe(
+      operations$,
+      subscribe(operation => {
+        if (operation.kind === 'teardown' && reclaim.has(operation.key)) {
+          clear(operation.key);
+        }
+      })
+    );
+  }
+
+  return {
+    get(key) {
+      return map.get(key);
+    },
+    set(key, value) {
+      reclaim.delete(key);
+      map.set(key, value);
+    },
+    clear,
+    dispose(key) {
+      if (operations$ || deferDispose) {
+        reclaim.add(key);
+      } else {
+        clear(key);
+      }
+    },
+  };
+};
+
+type DeferredCacheEntry = DeferredState | undefined;
+
+interface ClientWithDeferredCache extends Client {
+  _deferred?: Cache<DeferredCacheEntry>;
+}
+
+/** Returns the per-{@link Client} cache of {@link DeferredState}, creating it lazily. (BETA)
+ *
+ * @remarks
+ * Bindings store one {@link DeferredState} per operation here (keyed by
+ * `request.key`) so that the {@link DeferredPromise}s installed by
+ * {@link updateDeferredResult} are shared between the query stream and any
+ * consumer suspending on a `@defer`-red boundary. Entries are reclaimed on
+ * teardown, resolving any still-pending promises so no boundary stays suspended.
+ *
+ * @beta
+ */
+export const getDeferredCacheForClient = (
+  client: Client
+): Cache<DeferredCacheEntry> => {
+  if (!(client as ClientWithDeferredCache)._deferred) {
+    (client as ClientWithDeferredCache)._deferred =
+      makeCache<DeferredCacheEntry>(client, state => {
+        if (state) resolveDeferredState(state);
+      });
+  }
+
+  return (client as ClientWithDeferredCache)._deferred!;
+};

--- a/packages/core/src/utils/cache.ts
+++ b/packages/core/src/utils/cache.ts
@@ -90,7 +90,7 @@ interface ClientWithDeferredCache extends Client {
  *
  * @remarks
  * Bindings store one {@link DeferredState} per operation here (keyed by
- * `request.key`) so that the {@link DeferredPromise}s installed by
+ * `request.key`) so that the {@link DeferredPromise}s associated by
  * {@link updateDeferredResult} are shared between the query stream and any
  * consumer suspending on a `@defer`-red boundary. Entries are reclaimed on
  * teardown, resolving any still-pending promises so no boundary stays suspended.

--- a/packages/core/src/utils/defer.test.ts
+++ b/packages/core/src/utils/defer.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+
+import { gql } from '../gql';
+import { createRequest } from './request';
+import {
+  isDeferredPromise,
+  makeDeferredState,
+  resolveDeferredState,
+  updateDeferredResult,
+} from './defer';
+
+const query = gql`
+  query {
+    todo {
+      id
+      __typename
+      ... on Todo @defer {
+        name
+      }
+    }
+  }
+`;
+
+const makeResult = (data: any, hasNext: boolean): any => ({
+  operation: {} as any,
+  data,
+  stale: false,
+  hasNext,
+});
+
+describe('isDeferredPromise', () => {
+  it('only matches tagged deferred promises', () => {
+    expect(isDeferredPromise(Promise.resolve())).toBe(false);
+    expect(isDeferredPromise({ then: () => {} })).toBe(false);
+    expect(isDeferredPromise(null)).toBe(false);
+    const tagged = Object.assign(Promise.resolve(), { _urqlDeferred: true });
+    expect(isDeferredPromise(tagged)).toBe(true);
+  });
+});
+
+describe('updateDeferredResult', () => {
+  it('installs a stable promise for a missing deferred field while streaming', () => {
+    const request = createRequest(query, {});
+    const state = makeDeferredState();
+
+    const result = updateDeferredResult(
+      request,
+      makeResult({ todo: { id: '1', __typename: 'Todo' } }, true),
+      state
+    );
+
+    const pending = (result.data as any).todo.name;
+    expect(isDeferredPromise(pending)).toBe(true);
+    expect(pending._resolved).toBe(false);
+    expect(state.promises.size).toBe(1);
+  });
+
+  it('resolves the same promise with the streamed-in value as patches arrive', () => {
+    const request = createRequest(query, {});
+    const state = makeDeferredState();
+
+    const first = updateDeferredResult(
+      request,
+      makeResult({ todo: { id: '1', __typename: 'Todo' } }, true),
+      state
+    );
+    const pending = (first.data as any).todo.name;
+
+    updateDeferredResult(
+      request,
+      makeResult(
+        { todo: { id: '1', __typename: 'Todo', name: 'Hello' } },
+        false
+      ),
+      state
+    );
+
+    expect(pending._resolved).toBe(true);
+    expect(pending._value).toBe('Hello');
+    // Resolved promises are removed from the state.
+    expect(state.promises.size).toBe(0);
+  });
+
+  it('does not install a promise once the stream has ended', () => {
+    const request = createRequest(query, {});
+    const state = makeDeferredState();
+
+    const result = updateDeferredResult(
+      request,
+      makeResult({ todo: { id: '1', __typename: 'Todo' } }, false),
+      state
+    );
+
+    expect((result.data as any).todo.name).toBeUndefined();
+    expect(state.promises.size).toBe(0);
+  });
+
+  it('resolves all remaining promises when the stream ends', () => {
+    const request = createRequest(query, {});
+    const state = makeDeferredState();
+
+    const first = updateDeferredResult(
+      request,
+      makeResult({ todo: { id: '1', __typename: 'Todo' } }, true),
+      state
+    );
+    const pending = (first.data as any).todo.name;
+    expect(pending._resolved).toBe(false);
+
+    updateDeferredResult(
+      request,
+      makeResult({ todo: { id: '1', __typename: 'Todo' } }, false),
+      state
+    );
+
+    expect(pending._resolved).toBe(true);
+    expect(state.promises.size).toBe(0);
+  });
+});
+
+describe('resolveDeferredState', () => {
+  it('resolves and clears every pending promise', () => {
+    const request = createRequest(query, {});
+    const state = makeDeferredState();
+
+    const first = updateDeferredResult(
+      request,
+      makeResult({ todo: { id: '1', __typename: 'Todo' } }, true),
+      state
+    );
+    const pending = (first.data as any).todo.name;
+
+    resolveDeferredState(state);
+
+    expect(pending._resolved).toBe(true);
+    expect(state.promises.size).toBe(0);
+  });
+});

--- a/packages/core/src/utils/defer.test.ts
+++ b/packages/core/src/utils/defer.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from 'vitest';
 import { gql } from '../gql';
 import { createRequest } from './request';
 import {
+  getDeferredFieldPromise,
   isDeferredPromise,
   makeDeferredState,
   resolveDeferredState,
@@ -39,17 +40,16 @@ describe('isDeferredPromise', () => {
 });
 
 describe('updateDeferredResult', () => {
-  it('installs a stable promise for a missing deferred field while streaming', () => {
+  it('keeps a stable promise outside GraphQL data while streaming', () => {
     const request = createRequest(query, {});
     const state = makeDeferredState();
+    const data = { todo: { id: '1', __typename: 'Todo' } };
 
-    const result = updateDeferredResult(
-      request,
-      makeResult({ todo: { id: '1', __typename: 'Todo' } }, true),
-      state
-    );
+    const result = updateDeferredResult(request, makeResult(data, true), state);
 
-    const pending = (result.data as any).todo.name;
+    const pending = getDeferredFieldPromise(data.todo, 'name')!;
+    expect(result.data).toBe(data);
+    expect((result.data as any).todo.name).toBeUndefined();
     expect(isDeferredPromise(pending)).toBe(true);
     expect(pending._resolved).toBe(false);
     expect(state.promises.size).toBe(1);
@@ -59,12 +59,9 @@ describe('updateDeferredResult', () => {
     const request = createRequest(query, {});
     const state = makeDeferredState();
 
-    const first = updateDeferredResult(
-      request,
-      makeResult({ todo: { id: '1', __typename: 'Todo' } }, true),
-      state
-    );
-    const pending = (first.data as any).todo.name;
+    const data = { todo: { id: '1', __typename: 'Todo' } };
+    updateDeferredResult(request, makeResult(data, true), state);
+    const pending = getDeferredFieldPromise(data.todo, 'name')!;
 
     updateDeferredResult(
       request,
@@ -99,12 +96,9 @@ describe('updateDeferredResult', () => {
     const request = createRequest(query, {});
     const state = makeDeferredState();
 
-    const first = updateDeferredResult(
-      request,
-      makeResult({ todo: { id: '1', __typename: 'Todo' } }, true),
-      state
-    );
-    const pending = (first.data as any).todo.name;
+    const data = { todo: { id: '1', __typename: 'Todo' } };
+    updateDeferredResult(request, makeResult(data, true), state);
+    const pending = getDeferredFieldPromise(data.todo, 'name')!;
     expect(pending._resolved).toBe(false);
 
     updateDeferredResult(
@@ -123,12 +117,9 @@ describe('resolveDeferredState', () => {
     const request = createRequest(query, {});
     const state = makeDeferredState();
 
-    const first = updateDeferredResult(
-      request,
-      makeResult({ todo: { id: '1', __typename: 'Todo' } }, true),
-      state
-    );
-    const pending = (first.data as any).todo.name;
+    const data = { todo: { id: '1', __typename: 'Todo' } };
+    updateDeferredResult(request, makeResult(data, true), state);
+    const pending = getDeferredFieldPromise(data.todo, 'name')!;
 
     resolveDeferredState(state);
 

--- a/packages/core/src/utils/defer.ts
+++ b/packages/core/src/utils/defer.ts
@@ -62,7 +62,7 @@ export const isDeferredPromise = (value: any): value is DeferredPromise =>
  *
  * @beta
  */
-export const resolveDeferredState = (state: DeferredState) => {
+export const resolveDeferredState = (state: DeferredState): void => {
   state.promises.forEach(promise => promise._resolve());
   state.promises.clear();
 };

--- a/packages/core/src/utils/defer.ts
+++ b/packages/core/src/utils/defer.ts
@@ -1,6 +1,6 @@
 import type { SelectionSetNode } from '@0no-co/graphql.web';
 import { Kind } from '@0no-co/graphql.web';
-import type { AnyVariables, GraphQLRequest, OperationResult } from '@urql/core';
+import type { AnyVariables, GraphQLRequest, OperationResult } from '../types';
 import {
   getFieldKey,
   getFragments,
@@ -10,32 +10,58 @@ import {
   type FragmentMap,
 } from './selection';
 
+/** A stable {@link Promise} installed into a streamed result for a field inside
+ * a `@defer`-red selection that hasn’t arrived yet. (BETA)
+ *
+ * @remarks
+ * Framework bindings can throw this promise to suspend (or read its resolved
+ * `_value`) so a `@defer`-red boundary can resolve directly from the query
+ * stream — without depending on a parent component re-render to hand fresh data
+ * down via props (which doesn’t happen during server streams).
+ *
+ * @beta
+ */
 export type DeferredPromise = Promise<unknown> & {
   _resolve: (value?: unknown) => void;
   _resolved?: boolean;
-  /** The streamed-in value, once the deferred patch has arrived.
-   *
-   * @remarks
-   * `useFragment` reads this directly when re-masking after the promise has
-   * resolved. This is what allows a deferred boundary to resolve during a
-   * server stream, where the parent component holding `useQuery` won't
-   * re-render to hand down fresh data via props.
-   */
+  /** The streamed-in value, once the deferred patch has arrived. */
   _value?: unknown;
   _urqlDeferred: true;
 };
 
+/** Per-operation state tracking the {@link DeferredPromise}s installed for a
+ * streamed result, keyed by their path in the result data. (BETA)
+ *
+ * @beta
+ */
 export interface DeferredState {
   promises: Map<string, DeferredPromise>;
 }
 
+/** Creates an empty {@link DeferredState}. (BETA)
+ *
+ * @beta
+ */
 export const makeDeferredState = (): DeferredState => ({
   promises: new Map(),
 });
 
+/** Returns whether a value is a {@link DeferredPromise}. (BETA)
+ *
+ * @beta
+ */
 export const isDeferredPromise = (value: any): value is DeferredPromise =>
   !!value && value._urqlDeferred === true && typeof value.then === 'function';
 
+/** Resolves and clears every pending {@link DeferredPromise} in a
+ * {@link DeferredState}. (BETA)
+ *
+ * @remarks
+ * This is called when a stream ends (`hasNext` becomes falsy) or when the
+ * operation is torn down, so no boundary stays suspended indefinitely.
+ *
+ * @beta
+ */
 export const resolveDeferredState = (state: DeferredState) => {
   state.promises.forEach(promise => promise._resolve());
   state.promises.clear();
@@ -182,8 +208,8 @@ const updateSelectionSet = (
         }
 
         // Resolve the deferred promise for this path with the streamed-in
-        // value (already processed for nested defers) so a suspended
-        // `useFragment` can read it without waiting on a parent rerender.
+        // value (already processed for nested defers) so a suspended consumer
+        // can read it without waiting on a parent rerender.
         resolveDeferredPath(state, fieldPath, resolvedValue);
       }
     } else if (selection.kind === Kind.INLINE_FRAGMENT) {
@@ -230,6 +256,21 @@ const updateSelectionSet = (
   return next || data;
 };
 
+/** Installs and resolves {@link DeferredPromise}s on a streamed
+ * {@link OperationResult} for fields inside `@defer`-red selections. (BETA)
+ *
+ * @remarks
+ * While `result.hasNext` is `true`, missing non-optional fields inside a
+ * `@defer`-red selection are replaced by stable {@link DeferredPromise}s stored
+ * on the passed {@link DeferredState}. As later patches arrive, the promises are
+ * resolved with the streamed-in value (and removed). When the stream ends, all
+ * remaining promises are resolved.
+ *
+ * Bindings call this on each result of a suspense-enabled query stream so that
+ * `@defer`-red fragment boundaries can resolve directly from the stream.
+ *
+ * @beta
+ */
 export const updateDeferredResult = <
   Data = any,
   Variables extends AnyVariables = AnyVariables,

--- a/packages/core/src/utils/defer.ts
+++ b/packages/core/src/utils/defer.ts
@@ -10,14 +10,17 @@ import {
   type FragmentMap,
 } from './selection';
 
-/** A stable {@link Promise} installed into a streamed result for a field inside
- * a `@defer`-red selection that hasn’t arrived yet. (BETA)
+/** A stable {@link Promise} associated with a field inside a `@defer`-red
+ * selection that hasn’t arrived yet. (BETA)
  *
  * @remarks
  * Framework bindings can throw this promise to suspend (or read its resolved
  * `_value`) so a `@defer`-red boundary can resolve directly from the query
  * stream — without depending on a parent component re-render to hand fresh data
  * down via props (which doesn’t happen during server streams).
+ *
+ * The promise is stored in sidecar metadata rather than in GraphQL result data,
+ * so an {@link OperationResult} always retains its declared data shape.
  *
  * @beta
  */
@@ -29,7 +32,7 @@ export type DeferredPromise = Promise<unknown> & {
   _urqlDeferred: true;
 };
 
-/** Per-operation state tracking the {@link DeferredPromise}s installed for a
+/** Per-operation state tracking the {@link DeferredPromise}s associated with a
  * streamed result, keyed by their path in the result data. (BETA)
  *
  * @beta
@@ -52,6 +55,55 @@ export const makeDeferredState = (): DeferredState => ({
  */
 export const isDeferredPromise = (value: any): value is DeferredPromise =>
   !!value && value._urqlDeferred === true && typeof value.then === 'function';
+
+/** Sidecar metadata for missing deferred fields.
+ *
+ * @remarks
+ * A WeakMap keeps internal promises out of user-visible GraphQL data and lets
+ * abandoned result objects and their promises be garbage-collected.
+ *
+ * @internal
+ */
+const deferredFields = new WeakMap<object, Map<string, DeferredPromise>>();
+
+/** Returns the deferred promise associated with a response field, if any.
+ *
+ * @internal
+ */
+export const getDeferredFieldPromise = (
+  data: object,
+  fieldKey: string
+): DeferredPromise | undefined => {
+  const fields = deferredFields.get(data);
+  return fields ? fields.get(fieldKey) : undefined;
+};
+
+/** Associates a deferred promise with a response field without changing data.
+ *
+ * @internal
+ */
+export const setDeferredFieldPromise = (
+  data: object,
+  fieldKey: string,
+  promise: DeferredPromise
+): void => {
+  let fields = deferredFields.get(data);
+  if (!fields) deferredFields.set(data, (fields = new Map()));
+  fields.set(fieldKey, promise);
+};
+
+/** Copies deferred field associations while merging masked selections.
+ *
+ * @internal
+ */
+export const copyDeferredFields = (source: object, target: object): void => {
+  const fields = deferredFields.get(source);
+  if (fields) {
+    fields.forEach((promise, fieldKey) => {
+      setDeferredFieldPromise(target, fieldKey, promise);
+    });
+  }
+};
 
 /** Resolves and clears every pending {@link DeferredPromise} in a
  * {@link DeferredState}. (BETA)
@@ -127,13 +179,10 @@ const updateArray = (
   path: readonly (string | number)[],
   isDeferred: boolean,
   hasNext: boolean
-) => {
-  let next: any[] | undefined;
-
+): void => {
   for (let i = 0, l = data.length; i < l; i++) {
-    const item = data[i];
-    const nextItem = updateSelectionSet(
-      item,
+    updateSelectionSet(
+      data[i],
       selectionSet,
       fragments,
       state,
@@ -141,14 +190,7 @@ const updateArray = (
       isDeferred,
       hasNext
     );
-
-    if (nextItem !== item) {
-      if (!next) next = [...data];
-      next[i] = nextItem;
-    }
   }
-
-  return next || data;
 };
 
 const updateSelectionSet = (
@@ -159,10 +201,8 @@ const updateSelectionSet = (
   path: readonly (string | number)[],
   isDeferred: boolean,
   hasNext: boolean
-): any => {
-  if (!isObjectLike(data)) return data;
-
-  let next: Record<string, any> | undefined;
+): void => {
+  if (!isObjectLike(data)) return;
 
   selectionSet.selections.forEach(selection => {
     if (selection.kind === Kind.FIELD) {
@@ -172,53 +212,48 @@ const updateSelectionSet = (
 
       if (value === undefined) {
         if (isDeferred && hasNext && !isOptionalSelection(selection)) {
-          if (!next) next = { ...data };
-          next[fieldKey] = getDeferredPromise(state, fieldPath);
+          setDeferredFieldPromise(
+            data,
+            fieldKey,
+            getDeferredPromise(state, fieldPath)
+          );
         } else if (!hasNext) {
           resolveDeferredPath(state, fieldPath);
         }
       } else {
-        let resolvedValue = value;
-
         if (selection.selectionSet && value !== null) {
-          resolvedValue = Array.isArray(value)
-            ? updateArray(
-                value,
-                selection.selectionSet,
-                fragments,
-                state,
-                fieldPath,
-                isDeferred,
-                hasNext
-              )
-            : updateSelectionSet(
-                value,
-                selection.selectionSet,
-                fragments,
-                state,
-                fieldPath,
-                isDeferred,
-                hasNext
-              );
-
-          if (resolvedValue !== value) {
-            if (!next) next = { ...data };
-            next[fieldKey] = resolvedValue;
+          if (Array.isArray(value)) {
+            updateArray(
+              value,
+              selection.selectionSet,
+              fragments,
+              state,
+              fieldPath,
+              isDeferred,
+              hasNext
+            );
+          } else {
+            updateSelectionSet(
+              value,
+              selection.selectionSet,
+              fragments,
+              state,
+              fieldPath,
+              isDeferred,
+              hasNext
+            );
           }
         }
 
-        // Resolve the deferred promise for this path with the streamed-in
-        // value (already processed for nested defers) so a suspended consumer
-        // can read it without waiting on a parent rerender.
-        resolveDeferredPath(state, fieldPath, resolvedValue);
+        // Resolve the deferred promise for this path with the streamed-in value
+        // so a suspended consumer can read it without a parent rerender.
+        resolveDeferredPath(state, fieldPath, value);
       }
     } else if (selection.kind === Kind.INLINE_FRAGMENT) {
-      if (!isHeuristicFragmentMatch(selection, data, fragments)) {
-        return;
-      }
+      if (!isHeuristicFragmentMatch(selection, data, fragments)) return;
 
-      const nextValue = updateSelectionSet(
-        next || data,
+      updateSelectionSet(
+        data,
         selection.selectionSet,
         fragments,
         state,
@@ -226,19 +261,14 @@ const updateSelectionSet = (
         isDeferred || hasDirective(selection, 'defer'),
         hasNext
       );
-
-      if (nextValue !== (next || data)) {
-        next = nextValue;
-      }
     } else if (selection.kind === Kind.FRAGMENT_SPREAD) {
       const fragment = fragments[selection.name.value];
-
       if (!fragment || !isHeuristicFragmentMatch(fragment, data, fragments)) {
         return;
       }
 
-      const nextValue = updateSelectionSet(
-        next || data,
+      updateSelectionSet(
+        data,
         fragment.selectionSet,
         fragments,
         state,
@@ -246,28 +276,23 @@ const updateSelectionSet = (
         isDeferred || hasDirective(selection, 'defer'),
         hasNext
       );
-
-      if (nextValue !== (next || data)) {
-        next = nextValue;
-      }
     }
   });
-
-  return next || data;
 };
 
-/** Installs and resolves {@link DeferredPromise}s on a streamed
- * {@link OperationResult} for fields inside `@defer`-red selections. (BETA)
+/** Associates and resolves {@link DeferredPromise}s for fields in a streamed
+ * {@link OperationResult} without changing its GraphQL data. (BETA)
  *
  * @remarks
  * While `result.hasNext` is `true`, missing non-optional fields inside a
- * `@defer`-red selection are replaced by stable {@link DeferredPromise}s stored
- * on the passed {@link DeferredState}. As later patches arrive, the promises are
- * resolved with the streamed-in value (and removed). When the stream ends, all
- * remaining promises are resolved.
+ * `@defer`-red selection are associated with stable {@link DeferredPromise}s in
+ * sidecar metadata. As later patches arrive, the promises are resolved with the
+ * streamed-in value and removed from the operation state. When the stream ends,
+ * all remaining promises are resolved.
  *
  * Bindings call this on each result of a suspense-enabled query stream so that
- * `@defer`-red fragment boundaries can resolve directly from the stream.
+ * `@defer`-red fragment boundaries can resolve directly from the stream while
+ * `result.data` remains safe for ordinary consumers.
  *
  * @beta
  */
@@ -293,12 +318,10 @@ export const updateDeferredResult = <
     return result;
   }
 
-  const fragments = getFragments(request.query.definitions);
-
-  const data = updateSelectionSet(
+  updateSelectionSet(
     result.data,
     operation.selectionSet,
-    fragments,
+    getFragments(request.query.definitions),
     state,
     [],
     false,
@@ -306,6 +329,5 @@ export const updateDeferredResult = <
   );
 
   if (!result.hasNext) resolveDeferredState(state);
-
-  return data === result.data ? result : { ...result, data };
+  return result;
 };

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -6,6 +6,10 @@ export * from './collectTypenames';
 export * from './formatDocument';
 export * from './streamUtils';
 export * from './operation';
+export * from './selection';
+export * from './defer';
+export * from './maskFragment';
+export * from './cache';
 
 export const noop = () => {
   /* noop */

--- a/packages/core/src/utils/maskFragment.test.ts
+++ b/packages/core/src/utils/maskFragment.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from 'vitest';
+import type {
+  FragmentDefinitionNode,
+  SelectionSetNode,
+} from '@0no-co/graphql.web';
+import { Kind } from '@0no-co/graphql.web';
+
+import { gql } from '../gql';
+import { getFragments, type FragmentMap } from './selection';
+import { maskFragment } from './maskFragment';
+
+const fromDocument = (
+  source: string,
+  name?: string
+): { selectionSet: SelectionSetNode; fragments: FragmentMap } => {
+  const document = gql(source);
+  const fragments = getFragments(document.definitions);
+  const fragment = document.definitions.find(
+    definition =>
+      definition.kind === Kind.FRAGMENT_DEFINITION &&
+      (!name || definition.name.value === name)
+  ) as FragmentDefinitionNode;
+  return { selectionSet: fragment.selectionSet, fragments };
+};
+
+const mask = (source: string, data: any, name?: string) => {
+  const { selectionSet, fragments } = fromDocument(source, name);
+  return maskFragment(data, selectionSet, fragments);
+};
+
+describe('maskFragment', () => {
+  it('masks data to the selected fields', () => {
+    const result = mask(`fragment TodoFields on Todo { id name __typename }`, {
+      __typename: 'Todo',
+      id: '1',
+      name: 'Learn urql',
+      completed: true,
+    });
+
+    expect(result.fulfilled).toBe(true);
+    expect(result.data).toEqual({
+      __typename: 'Todo',
+      id: '1',
+      name: 'Learn urql',
+    });
+  });
+
+  it('preserves null fields', () => {
+    const result = mask(`fragment TodoFields on Todo { id name __typename }`, {
+      __typename: 'Todo',
+      id: '1',
+      name: null,
+      completed: true,
+    });
+
+    expect(result.fulfilled).toBe(true);
+    expect(result.data).toEqual({ __typename: 'Todo', id: '1', name: null });
+  });
+
+  it('reports an unfulfilled result for an undefined non-optional field', () => {
+    const result = mask(`fragment TodoFields on Todo { id name __typename }`, {
+      __typename: 'Todo',
+      id: '1',
+      name: undefined,
+      completed: true,
+    });
+
+    expect(result.fulfilled).toBe(false);
+    expect(result.data).toEqual({ __typename: 'Todo', id: '1' });
+  });
+
+  it('masks nested objects', () => {
+    const result = mask(
+      `fragment TodoFields on Todo { id __typename author { id name __typename } }`,
+      {
+        __typename: 'Todo',
+        id: '1',
+        author: {
+          __typename: 'Author',
+          id: '1',
+          name: 'Jovi',
+          awardWinner: true,
+        },
+      }
+    );
+
+    expect(result.fulfilled).toBe(true);
+    expect(result.data).toEqual({
+      __typename: 'Todo',
+      id: '1',
+      author: { __typename: 'Author', id: '1', name: 'Jovi' },
+    });
+  });
+
+  it('passes through a null nested selection', () => {
+    const result = mask(
+      `fragment TodoFields on Todo { id __typename author { id __typename } }`,
+      { __typename: 'Todo', id: '1', author: null }
+    );
+
+    expect(result.fulfilled).toBe(true);
+    expect(result.data).toEqual({ __typename: 'Todo', id: '1', author: null });
+  });
+
+  it('preserves null items in nullable lists', () => {
+    const result = mask(
+      `fragment TodoFields on Todo { id __typename assignees { id name __typename } }`,
+      {
+        __typename: 'Todo',
+        id: '1',
+        assignees: [
+          null,
+          { __typename: 'User', id: '2', name: 'Jovi', role: 'admin' },
+        ],
+      }
+    );
+
+    expect(result.fulfilled).toBe(true);
+    expect(result.data).toEqual({
+      __typename: 'Todo',
+      id: '1',
+      assignees: [null, { __typename: 'User', id: '2', name: 'Jovi' }],
+    });
+  });
+
+  it('reports an unfulfilled result for an undefined nested selection', () => {
+    const result = mask(
+      `fragment TodoFields on Todo { id __typename author { id __typename } }`,
+      { __typename: 'Todo', id: '1', author: undefined }
+    );
+
+    expect(result.fulfilled).toBe(false);
+    expect(result.data).toEqual({ __typename: 'Todo', id: '1' });
+  });
+
+  it('treats a missing @defer-red fragment spread as fulfilled', () => {
+    const result = mask(
+      `
+        fragment TodoFields on Todo {
+          id name __typename
+          ...AuthorFields @defer
+        }
+
+        fragment AuthorFields on Todo { author { id name __typename } }
+      `,
+      { __typename: 'Todo', id: '1', name: null, author: undefined },
+      'TodoFields'
+    );
+
+    expect(result.fulfilled).toBe(true);
+    expect(result.data).toEqual({ __typename: 'Todo', id: '1', name: null });
+  });
+
+  it('treats a missing non-deferred fragment spread as unfulfilled', () => {
+    const result = mask(
+      `
+        fragment TodoFields on Todo {
+          id name __typename
+          ...AuthorFields
+        }
+
+        fragment AuthorFields on Todo { author { id name __typename } }
+      `,
+      { __typename: 'Todo', id: '1', name: null, author: undefined },
+      'TodoFields'
+    );
+
+    expect(result.fulfilled).toBe(false);
+    expect(result.data).toEqual({ __typename: 'Todo', id: '1', name: null });
+  });
+});

--- a/packages/core/src/utils/maskFragment.ts
+++ b/packages/core/src/utils/maskFragment.ts
@@ -1,0 +1,156 @@
+import type { SelectionSetNode } from '@0no-co/graphql.web';
+import { Kind } from '@0no-co/graphql.web';
+
+import { isDeferredPromise } from './defer';
+import {
+  getFieldKey,
+  hasDirective,
+  isHeuristicFragmentMatch,
+  isOptionalSelection,
+  type FragmentMap,
+} from './selection';
+
+/** The result of masking a piece of `data` against a selection set. (BETA)
+ *
+ * @beta
+ */
+export interface MaskFragmentResult<Data> {
+  /** The masked data, limited to the fields the selection set selects. */
+  data: Data;
+  /** Whether every selected field is present (not still streaming in). */
+  fulfilled: boolean;
+  /** A {@link DeferredPromise} that resolves once a still-missing `@defer`-red
+   * field arrives, if any. Bindings can throw this to suspend. */
+  pending?: Promise<unknown>;
+}
+
+/** Masks `data` against a fragment’s selection set. (BETA)
+ *
+ * @param data - the (super-)set of data to mask.
+ * @param selectionSet - the {@link SelectionSetNode} to mask `data` against.
+ * @param fragments - a {@link FragmentMap} of fragments referenced by the selection set.
+ * @returns a {@link MaskFragmentResult}.
+ *
+ * @remarks
+ * `maskFragment` walks the selection set and returns the subset of `data` that
+ * the selection selects. When a non-optional field is still missing — for
+ * instance while a `@defer`-red part is streaming in — `fulfilled` is `false`
+ * and, if the query stream installed a {@link DeferredPromise} for it, that
+ * promise is surfaced via `pending`.
+ *
+ * Bindings decide what to do with an incomplete result: a Suspense-based
+ * binding throws `pending`, while others surface `fetching: !fulfilled`.
+ *
+ * Note: masked data may transiently contain a still-pending
+ * {@link DeferredPromise} on a `@defer`-red field while it streams in, so that a
+ * nested consumer rendering that field can suspend on it in turn.
+ *
+ * @beta
+ */
+export const maskFragment = <Data>(
+  data: Data,
+  selectionSet: SelectionSetNode,
+  fragments: FragmentMap
+): MaskFragmentResult<Data> => {
+  const maskedData = {};
+  let isDataComplete = true;
+  let pending: Promise<unknown> | undefined;
+
+  selectionSet.selections.forEach(selection => {
+    const hasIncludeOrSkip = isOptionalSelection(selection);
+
+    if (selection.kind === Kind.FIELD) {
+      const fieldAlias = getFieldKey(selection);
+
+      let value = data[fieldAlias];
+      if (isDeferredPromise(value)) {
+        if (!value._resolved) {
+          // The deferred patch hasn't arrived yet; surface the stream-owned
+          // promise so a binding can suspend on it. The promise is preserved on
+          // the masked data so that a nested consumer rendering this field can
+          // suspend on it in turn.
+          isDataComplete = false;
+          if (!pending) pending = value;
+          maskedData[fieldAlias] = value;
+          return;
+        }
+        // The deferred patch has streamed in: read its value directly off the
+        // resolved promise, rather than relying on a parent rerender to hand
+        // down fresh data via props (which doesn't happen during SSR streams).
+        value = value._value;
+      }
+
+      if (value === undefined) {
+        if (hasIncludeOrSkip) return;
+        isDataComplete = false;
+      } else if (value === null) {
+        maskedData[fieldAlias] = null;
+      } else if (Array.isArray(value)) {
+        if (selection.selectionSet) {
+          maskedData[fieldAlias] = value.map(item => {
+            if (item === null) return null;
+
+            const result = maskFragment(
+              item,
+              selection.selectionSet as SelectionSetNode,
+              fragments
+            );
+
+            if (!result.fulfilled) {
+              isDataComplete = false;
+              if (!pending) pending = result.pending;
+            }
+
+            return result.data;
+          });
+        } else {
+          maskedData[fieldAlias] = value.map(item => item);
+        }
+      } else {
+        if (selection.selectionSet) {
+          const result = maskFragment(value, selection.selectionSet, fragments);
+
+          if (!result.fulfilled) {
+            isDataComplete = false;
+            if (!pending) pending = result.pending;
+          }
+
+          maskedData[fieldAlias] = result.data;
+        } else {
+          maskedData[fieldAlias] = value;
+        }
+      }
+    } else if (selection.kind === Kind.INLINE_FRAGMENT) {
+      if (!isHeuristicFragmentMatch(selection, data, fragments)) {
+        return;
+      }
+
+      const hasDefer = hasDirective(selection, 'defer');
+
+      const result = maskFragment(data, selection.selectionSet, fragments);
+      if (!result.fulfilled && !hasIncludeOrSkip && !hasDefer) {
+        isDataComplete = false;
+        if (!pending) pending = result.pending;
+      }
+
+      Object.assign(maskedData, result.data);
+    } else if (selection.kind === Kind.FRAGMENT_SPREAD) {
+      const fragment = fragments[selection.name.value];
+
+      const hasDefer = hasDirective(selection, 'defer');
+
+      if (!fragment || !isHeuristicFragmentMatch(fragment, data, fragments)) {
+        return;
+      }
+
+      const result = maskFragment(data, fragment.selectionSet, fragments);
+      if (!result.fulfilled && !hasIncludeOrSkip && !hasDefer) {
+        isDataComplete = false;
+        if (!pending) pending = result.pending;
+      }
+      Object.assign(maskedData, result.data);
+    }
+  });
+
+  return { data: maskedData as Data, fulfilled: isDataComplete, pending };
+};

--- a/packages/core/src/utils/maskFragment.ts
+++ b/packages/core/src/utils/maskFragment.ts
@@ -1,7 +1,11 @@
 import type { SelectionSetNode } from '@0no-co/graphql.web';
 import { Kind } from '@0no-co/graphql.web';
 
-import { isDeferredPromise } from './defer';
+import {
+  copyDeferredFields,
+  getDeferredFieldPromise,
+  setDeferredFieldPromise,
+} from './defer';
 import {
   getFieldKey,
   hasDirective,
@@ -35,15 +39,14 @@ export interface MaskFragmentResult<Data> {
  * `maskFragment` walks the selection set and returns the subset of `data` that
  * the selection selects. When a non-optional field is still missing — for
  * instance while a `@defer`-red part is streaming in — `fulfilled` is `false`
- * and, if the query stream installed a {@link DeferredPromise} for it, that
+ * and, if the query stream associated a {@link DeferredPromise} with it, that
  * promise is surfaced via `pending`.
  *
  * Bindings decide what to do with an incomplete result: a Suspense-based
  * binding throws `pending`, while others surface `fetching: !fulfilled`.
  *
- * Note: masked data may transiently contain a still-pending
- * {@link DeferredPromise} on a `@defer`-red field while it streams in, so that a
- * nested consumer rendering that field can suspend on it in turn.
+ * Deferred promises are kept in sidecar metadata, so neither the input nor the
+ * returned masked GraphQL data exposes internal promise values.
  *
  * @beta
  */
@@ -63,21 +66,22 @@ export const maskFragment = <Data>(
       const fieldAlias = getFieldKey(selection);
 
       let value = data[fieldAlias];
-      if (isDeferredPromise(value)) {
-        if (!value._resolved) {
+      const deferred =
+        value === undefined && data && typeof data === 'object'
+          ? getDeferredFieldPromise(data, fieldAlias)
+          : undefined;
+      if (deferred) {
+        if (!deferred._resolved) {
           // The deferred patch hasn't arrived yet; surface the stream-owned
-          // promise so a binding can suspend on it. The promise is preserved on
-          // the masked data so that a nested consumer rendering this field can
-          // suspend on it in turn.
+          // promise so a binding can suspend without changing GraphQL data.
           isDataComplete = false;
-          if (!pending) pending = value;
-          maskedData[fieldAlias] = value;
+          if (!pending) pending = deferred;
+          setDeferredFieldPromise(maskedData, fieldAlias, deferred);
           return;
         }
-        // The deferred patch has streamed in: read its value directly off the
-        // resolved promise, rather than relying on a parent rerender to hand
-        // down fresh data via props (which doesn't happen during SSR streams).
-        value = value._value;
+        // The deferred patch has streamed in: read its value from the sidecar
+        // promise rather than relying on a parent rerender to pass fresh props.
+        value = deferred._value;
       }
 
       if (value === undefined) {
@@ -134,6 +138,7 @@ export const maskFragment = <Data>(
       }
 
       Object.assign(maskedData, result.data);
+      copyDeferredFields(result.data as object, maskedData);
     } else if (selection.kind === Kind.FRAGMENT_SPREAD) {
       const fragment = fragments[selection.name.value];
 
@@ -149,6 +154,7 @@ export const maskFragment = <Data>(
         if (!pending) pending = result.pending;
       }
       Object.assign(maskedData, result.data);
+      copyDeferredFields(result.data as object, maskedData);
     }
   });
 

--- a/packages/core/src/utils/selection.test.ts
+++ b/packages/core/src/utils/selection.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import type { FieldNode, FragmentDefinitionNode } from '@0no-co/graphql.web';
+import { Kind } from '@0no-co/graphql.web';
+
+import { gql } from '../gql';
+import {
+  getFieldKey,
+  getFragments,
+  hasDirective,
+  isHeuristicFragmentMatch,
+  isOptionalSelection,
+} from './selection';
+
+const fieldsOf = (source: string): Record<string, FieldNode> => {
+  const document = gql(source);
+  const fragment = document.definitions.find(
+    definition => definition.kind === Kind.FRAGMENT_DEFINITION
+  ) as FragmentDefinitionNode;
+  const map: Record<string, FieldNode> = {};
+  fragment.selectionSet.selections.forEach(selection => {
+    if (selection.kind === Kind.FIELD) map[getFieldKey(selection)] = selection;
+  });
+  return map;
+};
+
+describe('getFragments', () => {
+  it('maps fragment names to their definitions', () => {
+    const document = gql`
+      fragment A on X {
+        id
+      }
+      fragment B on Y {
+        id
+      }
+    `;
+    const fragments = getFragments(document.definitions);
+    expect(Object.keys(fragments).sort()).toEqual(['A', 'B']);
+    expect(fragments.A.name.value).toBe('A');
+  });
+});
+
+describe('getFieldKey', () => {
+  it('returns the alias when present, otherwise the field name', () => {
+    const fields = fieldsOf(`fragment F on T { name alias: other }`);
+    expect(fields.name.name.value).toBe('name');
+    expect(fields.alias.name.value).toBe('other');
+  });
+});
+
+describe('hasDirective', () => {
+  it('detects a directive by name on the raw AST', () => {
+    const fields = fieldsOf(`fragment F on T { a @defer b }`);
+    expect(hasDirective(fields.a, 'defer')).toBe(true);
+    expect(hasDirective(fields.b, 'defer')).toBe(false);
+  });
+});
+
+describe('isOptionalSelection', () => {
+  it('is true for @include/@skip and false otherwise', () => {
+    const fields = fieldsOf(
+      `fragment F on T { a @include(if: true) b @skip(if: false) c }`
+    );
+    expect(isOptionalSelection(fields.a)).toBe(true);
+    expect(isOptionalSelection(fields.b)).toBe(true);
+    expect(isOptionalSelection(fields.c)).toBe(false);
+  });
+});
+
+describe('isHeuristicFragmentMatch', () => {
+  const fragment = getFragments(gql`
+    fragment AuthorFields on Author {
+      id
+      name
+      __typename
+    }
+  `.definitions).AuthorFields;
+
+  it('matches when the type condition equals __typename', () => {
+    expect(
+      isHeuristicFragmentMatch(fragment, { __typename: 'Author' }, {})
+    ).toBe(true);
+  });
+
+  it('matches heuristically when every selected field is present', () => {
+    expect(
+      isHeuristicFragmentMatch(
+        fragment,
+        { __typename: 'Other', id: '1', name: 'x' },
+        {}
+      )
+    ).toBe(true);
+  });
+
+  it('does not match when a selected field is missing', () => {
+    expect(
+      isHeuristicFragmentMatch(fragment, { __typename: 'Other', id: '1' }, {})
+    ).toBe(false);
+  });
+});

--- a/packages/core/src/utils/selection.test.ts
+++ b/packages/core/src/utils/selection.test.ts
@@ -96,4 +96,25 @@ describe('isHeuristicFragmentMatch', () => {
       isHeuristicFragmentMatch(fragment, { __typename: 'Other', id: '1' }, {})
     ).toBe(false);
   });
+
+  it('matches when conditional fields are absent or present', () => {
+    const conditional = getFragments(gql`
+      fragment NodeFields on Node {
+        id
+        name @include(if: true)
+        email @skip(if: false)
+      }
+    `.definitions).NodeFields;
+
+    expect(
+      isHeuristicFragmentMatch(conditional, { __typename: 'User', id: '1' }, {})
+    ).toBe(true);
+    expect(
+      isHeuristicFragmentMatch(
+        conditional,
+        { __typename: 'User', id: '1', name: 'Jovi', email: 'jovi@test.dev' },
+        {}
+      )
+    ).toBe(true);
+  });
 });

--- a/packages/core/src/utils/selection.ts
+++ b/packages/core/src/utils/selection.ts
@@ -6,6 +6,16 @@ import type {
 } from '@0no-co/graphql.web';
 import { Kind } from '@0no-co/graphql.web';
 
+// NOTE: `@urql/exchange-graphcache` has its own AST helpers in
+// `ast/traversal.ts` (`getFragments`, `shouldInclude`, `isDeferred`, …). Those
+// are variable-aware (they evaluate `@include/@skip/@defer(if:)` arguments),
+// whereas these are presence-only. Unifying them is possible follow-up work but
+// would change behaviour/signatures, so the two are intentionally kept separate.
+
+/** A mapping from fragment names to their {@link FragmentDefinitionNode}.
+ *
+ * @internal
+ */
 export type FragmentMap = Record<string, FragmentDefinitionNode>;
 
 type DirectedNode = {
@@ -13,6 +23,10 @@ type DirectedNode = {
   _directives?: Record<string, unknown>;
 };
 
+/** Builds a {@link FragmentMap} from a document’s definitions.
+ *
+ * @internal
+ */
 export const getFragments = (
   definitions: readonly DefinitionNode[]
 ): FragmentMap =>
@@ -23,6 +37,15 @@ export const getFragments = (
     return acc;
   }, {});
 
+/** Returns whether a node carries a directive by `name`.
+ *
+ * @remarks
+ * This checks for the directive’s presence only and does not evaluate any
+ * arguments (e.g. `@include(if:)`). It reads both the formatted `_directives`
+ * record and the raw `directives` AST list.
+ *
+ * @internal
+ */
 export const hasDirective = (node: DirectedNode, name: string): boolean => {
   const directives = node._directives;
   return !!(
@@ -31,12 +54,29 @@ export const hasDirective = (node: DirectedNode, name: string): boolean => {
   );
 };
 
+/** Returns whether a node is conditionally included via `@include`/`@skip`.
+ *
+ * @internal
+ */
 export const isOptionalSelection = (node: DirectedNode): boolean =>
   hasDirective(node, 'include') || hasDirective(node, 'skip');
 
+/** Returns the response key (alias or name) for a field selection.
+ *
+ * @internal
+ */
 export const getFieldKey = (selection: FieldNode): string =>
   selection.alias ? selection.alias.value : selection.name.value;
 
+/** Heuristically determines whether a fragment applies to a piece of `data`.
+ *
+ * @remarks
+ * When the fragment’s type condition can’t be matched against `data.__typename`
+ * directly, this falls back to checking that every non-optional, non-deferred
+ * field the fragment selects is already present on `data`.
+ *
+ * @internal
+ */
 export const isHeuristicFragmentMatch = (
   fragment: InlineFragmentNode | FragmentDefinitionNode,
   data: any,

--- a/packages/core/src/utils/selection.ts
+++ b/packages/core/src/utils/selection.ts
@@ -93,7 +93,7 @@ export const isHeuristicFragmentMatch = (
     if (selection.kind === Kind.FIELD) {
       const couldBeExcluded =
         isOptionalSelection(selection) || hasDirective(selection, 'defer');
-      return data[getFieldKey(selection)] !== undefined && !couldBeExcluded;
+      return couldBeExcluded || data[getFieldKey(selection)] !== undefined;
     } else if (selection.kind === Kind.INLINE_FRAGMENT) {
       return isHeuristicFragmentMatch(selection, data, fragments);
     } else if (selection.kind === Kind.FRAGMENT_SPREAD) {

--- a/packages/preact-urql/src/hooks/cache.ts
+++ b/packages/preact-urql/src/hooks/cache.ts
@@ -1,4 +1,4 @@
-import type { Client, OperationResult, Cache } from '@urql/core';
+import type { Client, Cache } from '@urql/core';
 import { makeCache } from '@urql/core';
 
 export { getDeferredCacheForClient } from '@urql/core';
@@ -7,7 +7,7 @@ export { getDeferredCacheForClient } from '@urql/core';
  *
  * @remarks
  * `_resolve` is called once the masked fragment’s data is fully present,
- * which tells React to retry rendering the suspended boundary.
+ * which tells Preact to retry rendering the suspended boundary.
  *
  * @internal
  */
@@ -15,34 +15,19 @@ export type FragmentPromise = Promise<unknown> & {
   _resolve: () => void;
 };
 
-type CacheEntry = OperationResult | Promise<unknown> | undefined;
 type FragmentCacheEntry = FragmentPromise | undefined;
 
 interface ClientWithCache extends Client {
   _fragments?: Cache<FragmentCacheEntry>;
-  _react?: Cache<CacheEntry>;
 }
-
-export const getCacheForClient = (client: Client): Cache<CacheEntry> => {
-  if (!(client as ClientWithCache)._react) {
-    (client as ClientWithCache)._react = makeCache<CacheEntry>(
-      client,
-      undefined,
-      true
-    );
-  }
-
-  return (client as ClientWithCache)._react!;
-};
 
 /** Cache of pending `useFragment` suspense promises, keyed by an entity-aware key.
  *
  * @remarks
- * Unlike {@link getCacheForClient}, this cache stores the {@link FragmentPromise}
- * a `useFragment` hook throws while its deferred data is still streaming in. It’s
- * kept separately so that multiple `useFragment` hooks rendering different entities
- * (e.g. siblings in a list) don’t share — and prematurely resolve — each other’s
- * promises.
+ * Stores the {@link FragmentPromise} a `useFragment` hook throws while its
+ * deferred data is still streaming in, kept separately so that multiple
+ * `useFragment` hooks rendering different entities (e.g. siblings in a list)
+ * don’t share — and prematurely resolve — each other’s promises.
  *
  * @internal
  */

--- a/packages/preact-urql/src/hooks/cache.ts
+++ b/packages/preact-urql/src/hooks/cache.ts
@@ -1,12 +1,9 @@
+import type { FragmentDefinitionNode } from '@0no-co/graphql.web';
 import type { Client } from '@urql/core';
 
 export { getDeferredCacheForClient } from '@urql/core';
 
 /** A pending suspense {@link Promise} that the `useFragment` hook throws.
- *
- * @remarks
- * `_resolve` is called once the masked fragment’s data is fully present,
- * which tells Preact to retry rendering the suspended boundary.
  *
  * @internal
  */
@@ -14,117 +11,60 @@ export type FragmentPromise = Promise<unknown> & {
   _resolve: () => void;
 };
 
-/** An entity-aware cache of pending fragment suspense promises.
- *
- * @internal
- */
-export interface FragmentCache {
-  get(
-    key: number,
-    fragmentName: string,
-    data: any
-  ): FragmentPromise | undefined;
-  set(
-    key: number,
-    fragmentName: string,
-    data: any,
-    value: FragmentPromise
-  ): void;
-  dispose(key: number, fragmentName: string, data: any): void;
-}
+type FragmentCache = WeakMap<
+  FragmentDefinitionNode,
+  WeakMap<object, FragmentPromise>
+>;
 
 interface ClientWithCache extends Client {
   _fragments?: FragmentCache;
 }
 
-const makeFragmentCache = (): FragmentCache => {
-  const entities = new Map<string, FragmentPromise>();
-  const objects = new WeakMap<object, Map<string, FragmentPromise>>();
-  const primitives = new Map<string, FragmentPromise>();
-
-  const getScope = (key: number, fragmentName: string) =>
-    `${key}:${fragmentName}`;
-
-  const getEntityKey = (
-    key: number,
-    fragmentName: string,
-    data: any
-  ): string | undefined => {
-    if (data && typeof data === 'object' && !Array.isArray(data)) {
-      const id = data.id != null ? data.id : data._id;
-      if (data.__typename != null && id != null) {
-        return JSON.stringify([
-          key,
-          fragmentName,
-          String(data.__typename),
-          String(id),
-        ]);
-      }
-    }
-  };
-
-  const getObjectCache = (
-    data: object,
-    create: boolean
-  ): Map<string, FragmentPromise> | undefined => {
-    let cache = objects.get(data);
-    if (!cache && create) {
-      cache = new Map();
-      objects.set(data, cache);
-    }
-    return cache;
-  };
-
-  const getPrimitiveKey = (key: number, fragmentName: string, data: any) =>
-    `${getScope(key, fragmentName)}:${typeof data}:${String(data)}`;
-
-  return {
-    get(key, fragmentName, data) {
-      const entityKey = getEntityKey(key, fragmentName, data);
-      if (entityKey) return entities.get(entityKey);
-      if (data && typeof data === 'object') {
-        const cache = getObjectCache(data, false);
-        return cache && cache.get(getScope(key, fragmentName));
-      }
-      return primitives.get(getPrimitiveKey(key, fragmentName, data));
-    },
-    set(key, fragmentName, data, value) {
-      const entityKey = getEntityKey(key, fragmentName, data);
-      if (entityKey) {
-        entities.set(entityKey, value);
-      } else if (data && typeof data === 'object') {
-        getObjectCache(data, true)!.set(getScope(key, fragmentName), value);
-      } else {
-        primitives.set(getPrimitiveKey(key, fragmentName, data), value);
-      }
-    },
-    dispose(key, fragmentName, data) {
-      const entityKey = getEntityKey(key, fragmentName, data);
-      if (entityKey) {
-        entities.delete(entityKey);
-      } else if (data && typeof data === 'object') {
-        const cache = getObjectCache(data, false);
-        if (cache) cache.delete(getScope(key, fragmentName));
-      } else {
-        primitives.delete(getPrimitiveKey(key, fragmentName, data));
-      }
-    },
-  };
-};
-
-/** Cache of pending `useFragment` suspense promises, scoped by fragment and entity.
+/** Returns a pending fragment promise for this exact fragment and data object.
  *
  * @remarks
- * Identifiable entities use `__typename` and `id`/`_id`. Other objects are
- * tracked by reference in a {@link WeakMap}, preventing unrelated siblings from
- * sharing promises and allowing abandoned entries to be garbage-collected.
+ * Weak keys keep sibling objects and named fragments independent and allow
+ * abandoned suspended renders to be garbage-collected without an effect.
  *
  * @internal
  */
-export const getFragmentCacheForClient = (client: Client): FragmentCache => {
-  if (!(client as ClientWithCache)._fragments) {
-    (client as ClientWithCache)._fragments = makeFragmentCache();
-  }
+export const getFragmentPromise = (
+  client: Client,
+  fragment: FragmentDefinitionNode,
+  data: object
+): FragmentPromise | undefined => {
+  const cache = (client as ClientWithCache)._fragments;
+  const entries = cache && cache.get(fragment);
+  return entries && entries.get(data);
+};
 
-  return (client as ClientWithCache)._fragments!;
+/** Stores a pending promise for this exact fragment and data object.
+ *
+ * @internal
+ */
+export const setFragmentPromise = (
+  client: Client,
+  fragment: FragmentDefinitionNode,
+  data: object,
+  promise: FragmentPromise
+): void => {
+  const target = client as ClientWithCache;
+  const cache = target._fragments || (target._fragments = new WeakMap());
+  let entries = cache.get(fragment);
+  if (!entries) cache.set(fragment, (entries = new WeakMap()));
+  entries.set(data, promise);
+};
+
+/** Deletes a settled fragment promise.
+ *
+ * @internal
+ */
+export const deleteFragmentPromise = (
+  client: Client,
+  fragment: FragmentDefinitionNode,
+  data: object
+): void => {
+  const cache = (client as ClientWithCache)._fragments;
+  const entries = cache && cache.get(fragment);
+  if (entries) entries.delete(data);
 };

--- a/packages/preact-urql/src/hooks/cache.ts
+++ b/packages/preact-urql/src/hooks/cache.ts
@@ -1,5 +1,4 @@
-import type { Client, Cache } from '@urql/core';
-import { makeCache } from '@urql/core';
+import type { Client } from '@urql/core';
 
 export { getDeferredCacheForClient } from '@urql/core';
 
@@ -15,27 +14,116 @@ export type FragmentPromise = Promise<unknown> & {
   _resolve: () => void;
 };
 
-type FragmentCacheEntry = FragmentPromise | undefined;
-
-interface ClientWithCache extends Client {
-  _fragments?: Cache<FragmentCacheEntry>;
-}
-
-/** Cache of pending `useFragment` suspense promises, keyed by an entity-aware key.
- *
- * @remarks
- * Stores the {@link FragmentPromise} a `useFragment` hook throws while its
- * deferred data is still streaming in, kept separately so that multiple
- * `useFragment` hooks rendering different entities (e.g. siblings in a list)
- * don’t share — and prematurely resolve — each other’s promises.
+/** An entity-aware cache of pending fragment suspense promises.
  *
  * @internal
  */
-export const getFragmentCacheForClient = (
-  client: Client
-): Cache<FragmentCacheEntry> => {
+export interface FragmentCache {
+  get(
+    key: number,
+    fragmentName: string,
+    data: any
+  ): FragmentPromise | undefined;
+  set(
+    key: number,
+    fragmentName: string,
+    data: any,
+    value: FragmentPromise
+  ): void;
+  dispose(key: number, fragmentName: string, data: any): void;
+}
+
+interface ClientWithCache extends Client {
+  _fragments?: FragmentCache;
+}
+
+const makeFragmentCache = (): FragmentCache => {
+  const entities = new Map<string, FragmentPromise>();
+  const objects = new WeakMap<object, Map<string, FragmentPromise>>();
+  const primitives = new Map<string, FragmentPromise>();
+
+  const getScope = (key: number, fragmentName: string) =>
+    `${key}:${fragmentName}`;
+
+  const getEntityKey = (
+    key: number,
+    fragmentName: string,
+    data: any
+  ): string | undefined => {
+    if (data && typeof data === 'object' && !Array.isArray(data)) {
+      const id = data.id != null ? data.id : data._id;
+      if (data.__typename != null && id != null) {
+        return JSON.stringify([
+          key,
+          fragmentName,
+          String(data.__typename),
+          String(id),
+        ]);
+      }
+    }
+  };
+
+  const getObjectCache = (
+    data: object,
+    create: boolean
+  ): Map<string, FragmentPromise> | undefined => {
+    let cache = objects.get(data);
+    if (!cache && create) {
+      cache = new Map();
+      objects.set(data, cache);
+    }
+    return cache;
+  };
+
+  const getPrimitiveKey = (key: number, fragmentName: string, data: any) =>
+    `${getScope(key, fragmentName)}:${typeof data}:${String(data)}`;
+
+  return {
+    get(key, fragmentName, data) {
+      const entityKey = getEntityKey(key, fragmentName, data);
+      if (entityKey) return entities.get(entityKey);
+      if (data && typeof data === 'object') {
+        const cache = getObjectCache(data, false);
+        return cache && cache.get(getScope(key, fragmentName));
+      }
+      return primitives.get(getPrimitiveKey(key, fragmentName, data));
+    },
+    set(key, fragmentName, data, value) {
+      const entityKey = getEntityKey(key, fragmentName, data);
+      if (entityKey) {
+        entities.set(entityKey, value);
+      } else if (data && typeof data === 'object') {
+        getObjectCache(data, true)!.set(getScope(key, fragmentName), value);
+      } else {
+        primitives.set(getPrimitiveKey(key, fragmentName, data), value);
+      }
+    },
+    dispose(key, fragmentName, data) {
+      const entityKey = getEntityKey(key, fragmentName, data);
+      if (entityKey) {
+        entities.delete(entityKey);
+      } else if (data && typeof data === 'object') {
+        const cache = getObjectCache(data, false);
+        if (cache) cache.delete(getScope(key, fragmentName));
+      } else {
+        primitives.delete(getPrimitiveKey(key, fragmentName, data));
+      }
+    },
+  };
+};
+
+/** Cache of pending `useFragment` suspense promises, scoped by fragment and entity.
+ *
+ * @remarks
+ * Identifiable entities use `__typename` and `id`/`_id`. Other objects are
+ * tracked by reference in a {@link WeakMap}, preventing unrelated siblings from
+ * sharing promises and allowing abandoned entries to be garbage-collected.
+ *
+ * @internal
+ */
+export const getFragmentCacheForClient = (client: Client): FragmentCache => {
   if (!(client as ClientWithCache)._fragments) {
-    (client as ClientWithCache)._fragments = makeCache<FragmentCacheEntry>();
+    (client as ClientWithCache)._fragments = makeFragmentCache();
   }
 
   return (client as ClientWithCache)._fragments!;

--- a/packages/preact-urql/src/hooks/index.ts
+++ b/packages/preact-urql/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export * from './useFragment';
 export * from './useQuery';
 export * from './useMutation';
 export * from './useSubscription';

--- a/packages/preact-urql/src/hooks/useFragment.test.tsx
+++ b/packages/preact-urql/src/hooks/useFragment.test.tsx
@@ -1,0 +1,153 @@
+// @vitest-environment jsdom
+
+import { FunctionalComponent as FC, h } from 'preact';
+import { render, cleanup } from '@testing-library/preact';
+import { expect, it, describe, beforeEach, afterEach } from 'vitest';
+
+import { useFragment, UseFragmentState } from './useFragment';
+import { Provider } from '../context';
+
+const makeClient = (overrides: Record<string, any> = {}): any => ({
+  suspense: false,
+  ...overrides,
+});
+
+let snapshot: UseFragmentState<any> | undefined;
+
+const Probe: FC<any> = props => {
+  snapshot = useFragment(props);
+  return null;
+};
+
+const renderProbe = (client: any, props: any) =>
+  render(h(Provider, { value: client, children: [h(Probe, props)] }));
+
+// Renders the hook and captures either the masked state or a thrown suspense
+// promise, without a Suspense boundary, so we can assert the suspense bridge.
+const captureSuspense = (client: any, props: any) => {
+  let thrown: unknown;
+  let rendered: UseFragmentState<any> | undefined;
+  const Catcher: FC = () => {
+    try {
+      rendered = useFragment(props);
+    } catch (error) {
+      thrown = error;
+    }
+    return null;
+  };
+  render(h(Provider, { value: client, children: [h(Catcher, {})] }));
+  return { thrown, rendered };
+};
+
+beforeEach(() => {
+  snapshot = undefined;
+});
+
+afterEach(() => cleanup());
+
+describe('useFragment masking', () => {
+  it('masks data to the selected fields', () => {
+    renderProbe(makeClient(), {
+      query: `fragment TodoFields on Todo { id name __typename }`,
+      data: {
+        __typename: 'Todo',
+        id: '1',
+        name: 'Learn urql',
+        completed: true,
+      },
+    });
+
+    expect(snapshot).toEqual({
+      fetching: false,
+      data: { __typename: 'Todo', id: '1', name: 'Learn urql' },
+    });
+  });
+
+  it('takes a named fragment to mask data', () => {
+    renderProbe(makeClient(), {
+      query: `fragment x on X { foo } fragment TodoFields on Todo { id name __typename }`,
+      name: 'TodoFields',
+      data: {
+        __typename: 'Todo',
+        id: '1',
+        name: 'Learn urql',
+        completed: true,
+      },
+    });
+
+    expect(snapshot).toEqual({
+      fetching: false,
+      data: { __typename: 'Todo', id: '1', name: 'Learn urql' },
+    });
+  });
+
+  it('marks fetching for a missing non-optional field', () => {
+    renderProbe(makeClient(), {
+      query: `fragment TodoFields on Todo { id name __typename }`,
+      data: { __typename: 'Todo', id: '1', name: undefined },
+    });
+
+    expect(snapshot).toEqual({
+      fetching: true,
+      data: { __typename: 'Todo', id: '1' },
+    });
+  });
+
+  it('treats a missing @defer-red fragment spread as fulfilled', () => {
+    renderProbe(makeClient(), {
+      query: `
+        fragment TodoFields on Todo {
+          id name __typename
+          ...AuthorFields @defer
+        }
+
+        fragment AuthorFields on Todo { author { id name __typename } }
+      `,
+      name: 'TodoFields',
+      data: { __typename: 'Todo', id: '1', name: null, author: undefined },
+    });
+
+    expect(snapshot).toEqual({
+      fetching: false,
+      data: { __typename: 'Todo', id: '1', name: null },
+    });
+  });
+
+  it('returns null data without masking when data is null', () => {
+    renderProbe(makeClient(), {
+      query: `fragment TodoFields on Todo { id name __typename }`,
+      data: null,
+    });
+
+    expect(snapshot).toEqual({ fetching: false, data: null });
+  });
+});
+
+describe('useFragment suspense', () => {
+  const SongFields = `fragment SongFields on Song { id title __typename }`;
+
+  it('throws a suspense promise while a field is missing', () => {
+    const { thrown, rendered } = captureSuspense(makeClient(), {
+      query: SongFields,
+      data: { __typename: 'Song', id: '1', title: undefined },
+      context: { suspense: true },
+    });
+
+    expect(rendered).toBeUndefined();
+    expect(thrown).toBeInstanceOf(Promise);
+  });
+
+  it('does not suspend when the data is already complete', () => {
+    const { thrown, rendered } = captureSuspense(makeClient(), {
+      query: SongFields,
+      data: { __typename: 'Song', id: '1', title: 'World' },
+      context: { suspense: true },
+    });
+
+    expect(thrown).toBeUndefined();
+    expect(rendered).toEqual({
+      fetching: false,
+      data: { __typename: 'Song', id: '1', title: 'World' },
+    });
+  });
+});

--- a/packages/preact-urql/src/hooks/useFragment.test.tsx
+++ b/packages/preact-urql/src/hooks/useFragment.test.tsx
@@ -81,6 +81,41 @@ describe('useFragment masking', () => {
     });
   });
 
+  it('updates the masked data when the fragment name changes', () => {
+    const client = makeClient();
+    const query = `
+      fragment TodoIdentity on Todo { id __typename }
+      fragment TodoDetails on Todo { name __typename }
+    `;
+    const data = {
+      __typename: 'Todo',
+      id: '1',
+      name: 'Learn urql',
+    };
+    const view = renderProbe(client, {
+      query,
+      name: 'TodoIdentity',
+      data,
+    });
+
+    expect(snapshot).toEqual({
+      fetching: false,
+      data: { __typename: 'Todo', id: '1' },
+    });
+
+    view.rerender(
+      h(Provider, {
+        value: client,
+        children: [h(Probe, { query, name: 'TodoDetails', data })],
+      })
+    );
+
+    expect(snapshot).toEqual({
+      fetching: false,
+      data: { __typename: 'Todo', name: 'Learn urql' },
+    });
+  });
+
   it('marks fetching for a missing non-optional field', () => {
     renderProbe(makeClient(), {
       query: `fragment TodoFields on Todo { id name __typename }`,

--- a/packages/preact-urql/src/hooks/useFragment.test.tsx
+++ b/packages/preact-urql/src/hooks/useFragment.test.tsx
@@ -48,7 +48,7 @@ afterEach(() => cleanup());
 describe('useFragment masking', () => {
   it('masks data to the selected fields', () => {
     renderProbe(makeClient(), {
-      query: `fragment TodoFields on Todo { id name __typename }`,
+      fragment: `fragment TodoFields on Todo { id name __typename }`,
       data: {
         __typename: 'Todo',
         id: '1',
@@ -65,7 +65,7 @@ describe('useFragment masking', () => {
 
   it('takes a named fragment to mask data', () => {
     renderProbe(makeClient(), {
-      query: `fragment x on X { foo } fragment TodoFields on Todo { id name __typename }`,
+      fragment: `fragment x on X { foo } fragment TodoFields on Todo { id name __typename }`,
       name: 'TodoFields',
       data: {
         __typename: 'Todo',
@@ -93,7 +93,7 @@ describe('useFragment masking', () => {
       name: 'Learn urql',
     };
     const view = renderProbe(client, {
-      query,
+      fragment: query,
       name: 'TodoIdentity',
       data,
     });
@@ -106,7 +106,7 @@ describe('useFragment masking', () => {
     view.rerender(
       h(Provider, {
         value: client,
-        children: [h(Probe, { query, name: 'TodoDetails', data })],
+        children: [h(Probe, { fragment: query, name: 'TodoDetails', data })],
       })
     );
 
@@ -118,7 +118,7 @@ describe('useFragment masking', () => {
 
   it('marks fetching for a missing non-optional field', () => {
     renderProbe(makeClient(), {
-      query: `fragment TodoFields on Todo { id name __typename }`,
+      fragment: `fragment TodoFields on Todo { id name __typename }`,
       data: { __typename: 'Todo', id: '1', name: undefined },
     });
 
@@ -130,7 +130,7 @@ describe('useFragment masking', () => {
 
   it('treats a missing @defer-red fragment spread as fulfilled', () => {
     renderProbe(makeClient(), {
-      query: `
+      fragment: `
         fragment TodoFields on Todo {
           id name __typename
           ...AuthorFields @defer
@@ -150,11 +150,20 @@ describe('useFragment masking', () => {
 
   it('returns null data without masking when data is null', () => {
     renderProbe(makeClient(), {
-      query: `fragment TodoFields on Todo { id name __typename }`,
+      fragment: `fragment TodoFields on Todo { id name __typename }`,
       data: null,
     });
 
     expect(snapshot).toEqual({ fetching: false, data: null });
+  });
+
+  it('returns undefined data without masking when data is undefined', () => {
+    renderProbe(makeClient(), {
+      fragment: `fragment TodoFields on Todo { id name __typename }`,
+      data: undefined,
+    });
+
+    expect(snapshot).toEqual({ fetching: false, data: undefined });
   });
 });
 
@@ -163,7 +172,7 @@ describe('useFragment suspense', () => {
 
   it('throws a suspense promise while a field is missing', () => {
     const { thrown, rendered } = captureSuspense(makeClient(), {
-      query: SongFields,
+      fragment: SongFields,
       data: { __typename: 'Song', id: '1', title: undefined },
       context: { suspense: true },
     });
@@ -175,12 +184,12 @@ describe('useFragment suspense', () => {
   it('does not share suspense promises between unidentified objects', () => {
     const client = makeClient();
     const first = captureSuspense(client, {
-      query: SongFields,
+      fragment: SongFields,
       data: { title: undefined },
       context: { suspense: true },
     });
     const second = captureSuspense(client, {
-      query: SongFields,
+      fragment: SongFields,
       data: { title: undefined },
       context: { suspense: true },
     });
@@ -203,13 +212,13 @@ describe('useFragment suspense', () => {
       artist: undefined,
     };
     const title = captureSuspense(client, {
-      query,
+      fragment: query,
       name: 'SongTitle',
       data,
       context: { suspense: true },
     });
     const artist = captureSuspense(client, {
-      query,
+      fragment: query,
       name: 'SongArtist',
       data,
       context: { suspense: true },
@@ -222,7 +231,7 @@ describe('useFragment suspense', () => {
 
   it('does not suspend when the data is already complete', () => {
     const { thrown, rendered } = captureSuspense(makeClient(), {
-      query: SongFields,
+      fragment: SongFields,
       data: { __typename: 'Song', id: '1', title: 'World' },
       context: { suspense: true },
     });

--- a/packages/preact-urql/src/hooks/useFragment.test.tsx
+++ b/packages/preact-urql/src/hooks/useFragment.test.tsx
@@ -172,6 +172,54 @@ describe('useFragment suspense', () => {
     expect(thrown).toBeInstanceOf(Promise);
   });
 
+  it('does not share suspense promises between unidentified objects', () => {
+    const client = makeClient();
+    const first = captureSuspense(client, {
+      query: SongFields,
+      data: { title: undefined },
+      context: { suspense: true },
+    });
+    const second = captureSuspense(client, {
+      query: SongFields,
+      data: { title: undefined },
+      context: { suspense: true },
+    });
+
+    expect(first.thrown).toBeInstanceOf(Promise);
+    expect(second.thrown).toBeInstanceOf(Promise);
+    expect(second.thrown).not.toBe(first.thrown);
+  });
+
+  it('scopes suspense promises by fragment name', () => {
+    const client = makeClient();
+    const query = `
+      fragment SongTitle on Song { title }
+      fragment SongArtist on Song { artist }
+    `;
+    const data = {
+      __typename: 'Song',
+      id: '1',
+      title: undefined,
+      artist: undefined,
+    };
+    const title = captureSuspense(client, {
+      query,
+      name: 'SongTitle',
+      data,
+      context: { suspense: true },
+    });
+    const artist = captureSuspense(client, {
+      query,
+      name: 'SongArtist',
+      data,
+      context: { suspense: true },
+    });
+
+    expect(title.thrown).toBeInstanceOf(Promise);
+    expect(artist.thrown).toBeInstanceOf(Promise);
+    expect(artist.thrown).not.toBe(title.thrown);
+  });
+
   it('does not suspend when the data is already complete', () => {
     const { thrown, rendered } = captureSuspense(makeClient(), {
       query: SongFields,

--- a/packages/preact-urql/src/hooks/useFragment.ts
+++ b/packages/preact-urql/src/hooks/useFragment.ts
@@ -1,8 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 
-import * as React from 'react';
-import type { FragmentDefinitionNode } from '@0no-co/graphql.web';
-import { Kind } from '@0no-co/graphql.web';
+import { useMemo, useCallback, useState } from 'preact/hooks';
 
 import type {
   GraphQLRequestParams,
@@ -18,8 +16,6 @@ import { useRequest } from './useRequest';
 import type { FragmentPromise } from './cache';
 import { getFragmentCacheForClient } from './cache';
 
-import { hasDepsChanged } from './state';
-
 /** Input arguments for the {@link useFragment} hook. */
 export type UseFragmentArgs<Data = any> = {
   /** Partial {@link OperationContext} used to configure this hook.
@@ -29,15 +25,6 @@ export type UseFragmentArgs<Data = any> = {
    * so only `context.suspense` is read here. When set, it overrides the
    * {@link Client.suspense} flag for this hook and controls whether it suspends
    * while a fragment’s deferred data is still incomplete.
-   *
-   * @example
-   * ```ts
-   * const result = useFragment({
-   *   query,
-   *   data,
-   *   context: { suspense: true },
-   * });
-   * ```
    */
   context?: Partial<OperationContext>;
   /** A GraphQL document to mask this fragment against.
@@ -55,12 +42,7 @@ export type UseFragmentArgs<Data = any> = {
   name?: string;
 };
 
-/** State of the current query, your {@link useFragment} hook is executing.
- *
- * @remarks
- * `UseFragmentState` is returned by {@link useFragment} and
- * gives you the masked data for the fragment.
- */
+/** State of the masked fragment your {@link useFragment} hook returns. */
 export interface UseFragmentState<Data> {
   /** Indicates whether `useFragment` is waiting for a new result.
    *
@@ -106,9 +88,14 @@ const getFragmentCacheKey = (
   return key;
 };
 
+const hasDepsChanged = <T extends { length: number }>(a: T, b: T) => {
+  for (let i = 0, l = b.length; i < l; i++) if (a[i] !== b[i]) return true;
+  return false;
+};
+
 /** Hook to mask a GraphQL Fragment given its data. (BETA)
  *
- * @param args - a {@link UseFragmentArgs} object, to pass a `fragment` and `data`.
+ * @param args - a {@link UseFragmentArgs} object, to pass a `query` and `data`.
  * @returns a {@link UseFragmentState} result.
  *
  * @remarks
@@ -123,7 +110,7 @@ const getFragmentCacheKey = (
  *
  * @example
  * ```ts
- * import { gql, useFragment } from 'urql';
+ * import { gql, useFragment } from '@urql/preact';
  *
  * const TodoFields = gql`
  *   fragment TodoFields on Todo { id name }
@@ -147,13 +134,15 @@ export function useFragment<Data>(
 
   const request = useRequest(args.query, EMPTY_VARIABLES);
 
-  const fragment = React.useMemo(() => {
-    return request.query.definitions.find(
-      x =>
-        x.kind === Kind.FRAGMENT_DEFINITION &&
-        ((args.name && x.name.value === args.name) || !args.name)
-    ) as FragmentDefinitionNode | undefined;
-  }, [request.query, args.name]);
+  const fragments = useMemo(
+    () => getFragments(request.query.definitions),
+    [request.query]
+  );
+
+  const fragment = useMemo(
+    () => (args.name ? fragments[args.name] : Object.values(fragments)[0]),
+    [fragments, args.name]
+  );
 
   if (!fragment) {
     throw new Error(
@@ -163,12 +152,7 @@ export function useFragment<Data>(
     );
   }
 
-  const fragments = React.useMemo(
-    () => getFragments(request.query.definitions),
-    [request.query]
-  );
-
-  const getSnapshot = React.useCallback(
+  const getSnapshot = useCallback(
     (
       request: GraphQLRequest<Data, AnyVariables>,
       data: Data | null,
@@ -206,7 +190,7 @@ export function useFragment<Data>(
         throw newResult.pending;
       } else if (cached) {
         // We're still waiting on data and already suspended once; re-throw the
-        // same promise so React keeps showing the suspense boundary's fallback.
+        // same promise so Preact keeps showing the suspense boundary's fallback.
         throw cached;
       } else {
         let _resolve!: () => void;
@@ -223,7 +207,7 @@ export function useFragment<Data>(
 
   const deps = [client, request, args.data, suspense] as const;
 
-  const [state, setState] = React.useState(
+  const [state, setState] = useState(
     () => [getSnapshot(request, args.data, suspense), deps] as const
   );
 

--- a/packages/preact-urql/src/hooks/useFragment.ts
+++ b/packages/preact-urql/src/hooks/useFragment.ts
@@ -205,7 +205,7 @@ export function useFragment<Data>(
     [cache, fragment, fragments]
   );
 
-  const deps = [client, request, args.data, suspense] as const;
+  const deps = [client, request, fragment, args.data, suspense] as const;
 
   const [state, setState] = useState(
     () => [getSnapshot(request, args.data, suspense), deps] as const

--- a/packages/preact-urql/src/hooks/useFragment.ts
+++ b/packages/preact-urql/src/hooks/useFragment.ts
@@ -7,17 +7,20 @@ import type {
   AnyVariables,
   Client,
   OperationContext,
-  GraphQLRequest,
 } from '@urql/core';
 import { maskFragment, getFragments } from '@urql/core';
 
 import { useClient } from '../context';
 import { useRequest } from './useRequest';
 import type { FragmentPromise } from './cache';
-import { getFragmentCacheForClient } from './cache';
+import {
+  deleteFragmentPromise,
+  getFragmentPromise,
+  setFragmentPromise,
+} from './cache';
 
 /** Input arguments for the {@link useFragment} hook. */
-export type UseFragmentArgs<Data = any> = {
+export type UseFragmentArgs<Data = any, Input = Data> = {
   /** Partial {@link OperationContext} used to configure this hook.
    *
    * @remarks
@@ -33,11 +36,15 @@ export type UseFragmentArgs<Data = any> = {
    * This Document should contain atleast one FragmentDefinitionNode or
    * a FragmentDefinitionNode with the same name as the `name` property.
    */
-  query: GraphQLRequestParams<Data, AnyVariables>['query'];
-  /** A JSON object which we will extract properties from to get to the
-   * masked fragment.
+  fragment: GraphQLRequestParams<Data, any>['query'];
+  /** A JSON object containing this fragment's fields.
+   *
+   * @remarks
+   * `Input` is separate from `Data` so fragment-reference types from gql.tada
+   * and GraphQL Code Generator can be passed directly. `null` and `undefined`
+   * are returned unchanged.
    */
-  data: Data | null;
+  data: Input | null | undefined;
   /** An optional name of the fragment to use from the passed Document. */
   name?: string;
 };
@@ -70,13 +77,13 @@ const hasDepsChanged = <T extends { length: number }>(a: T, b: T) => {
 
 /** Hook to mask a GraphQL Fragment given its data. (BETA)
  *
- * @param args - a {@link UseFragmentArgs} object, to pass a `query` and `data`.
+ * @param args - a {@link UseFragmentArgs} object, to pass a `fragment` and `data`.
  * @returns a {@link UseFragmentState} result.
  *
  * @remarks
  * `useFragment` allows GraphQL fragments to mask their data.
- * Given {@link UseFragmentArgs.query} and {@link UseFragmentArgs.data}, it will
- * return the masked data for the fragment contained in query.
+ * Given {@link UseFragmentArgs.fragment} and {@link UseFragmentArgs.data}, it
+ * returns the data selected by that fragment.
  *
  * Additionally, if the `suspense` option is enabled on the `Client`,
  * the `useFragment` hook will suspend instead of indicating that it’s
@@ -94,20 +101,19 @@ const hasDepsChanged = <T extends { length: number }>(a: T, b: T) => {
  * const Todo = (props) => {
  *   const result = useFragment({
  *     data: props.todo,
- *     query: TodoFields,
+ *     fragment: TodoFields,
  *   });
  *   // ...
  * };
  * ```
  */
-export function useFragment<Data>(
-  args: UseFragmentArgs<Data>
+export function useFragment<Data = any, Input = Data>(
+  args: UseFragmentArgs<Data, Input>
 ): UseFragmentState<Data> {
   const client = useClient();
-  const cache = getFragmentCacheForClient(client);
   const suspense = isSuspense(client, args.context);
 
-  const request = useRequest(args.query, EMPTY_VARIABLES);
+  const request = useRequest(args.fragment, EMPTY_VARIABLES);
 
   const fragments = useMemo(
     () => getFragments(request.query.definitions),
@@ -129,15 +135,16 @@ export function useFragment<Data>(
 
   const getSnapshot = useCallback(
     (
-      request: GraphQLRequest<Data, AnyVariables>,
-      data: Data | null,
+      data: Input | null | undefined,
       suspense: boolean
     ): UseFragmentState<Data> => {
-      if (data === null) {
-        return { data: null, fetching: false };
+      if (data == null) {
+        return { data: data as null | undefined, fetching: false };
+      } else if (typeof data !== 'object' || Array.isArray(data)) {
+        throw new Error('useFragment expects data to be a fragment object.');
       } else if (!suspense) {
         const newResult = maskFragment<Data>(
-          data,
+          data as Data,
           fragment.selectionSet,
           fragments
         );
@@ -145,11 +152,9 @@ export function useFragment<Data>(
         return { data: newResult.data, fetching: !newResult.fulfilled };
       }
 
-      const key = request.key;
-      const fragmentName = fragment.name.value;
-      const cached = cache.get(key, fragmentName, data);
+      const cached = getFragmentPromise(client, fragment, data);
       const newResult = maskFragment<Data>(
-        data,
+        data as Data,
         fragment.selectionSet,
         fragments
       );
@@ -157,7 +162,7 @@ export function useFragment<Data>(
       if (newResult.fulfilled) {
         if (cached) {
           cached._resolve();
-          cache.dispose(key, fragmentName, data);
+          deleteFragmentPromise(client, fragment, data);
         }
         return { data: newResult.data, fetching: false };
       } else if (newResult.pending) {
@@ -174,22 +179,22 @@ export function useFragment<Data>(
           _resolve = () => resolve(undefined);
         }) as FragmentPromise;
         promise._resolve = _resolve;
-        cache.set(key, fragmentName, data, promise);
+        setFragmentPromise(client, fragment, data, promise);
         throw promise;
       }
     },
-    [cache, fragment, fragments]
+    [client, fragment, fragments]
   );
 
   const deps = [client, request, fragment, args.data, suspense] as const;
 
   const [state, setState] = useState(
-    () => [getSnapshot(request, args.data, suspense), deps] as const
+    () => [getSnapshot(args.data, suspense), deps] as const
   );
 
   const currentResult = state[0];
   if (hasDepsChanged(state[1], deps)) {
-    setState([getSnapshot(request, args.data, suspense), deps]);
+    setState([getSnapshot(args.data, suspense), deps]);
   }
 
   return currentResult;

--- a/packages/preact-urql/src/hooks/useFragment.ts
+++ b/packages/preact-urql/src/hooks/useFragment.ts
@@ -63,31 +63,6 @@ const isSuspense = (client: Client, context?: Partial<OperationContext>) =>
     ? !!context.suspense
     : client.suspense;
 
-/** Derives a cache key for a fragment’s suspense promise.
- *
- * @remarks
- * The base {@link GraphQLRequest.key} only identifies the fragment document, so
- * it’s shared across every `useFragment` hook using the same fragment. To avoid
- * sibling hooks (e.g. items in a list) sharing — and prematurely resolving —
- * each other’s suspense promises, we fold the entity’s identity (`__typename`
- * and `id`/`_id`) into the key when it’s available.
- */
-const getFragmentCacheKey = (
-  request: GraphQLRequest<any, AnyVariables>,
-  data: any
-): number => {
-  let key = request.key;
-  if (data && typeof data === 'object' && !Array.isArray(data)) {
-    const id = data.id != null ? data.id : data._id;
-    if (data.__typename != null && id != null) {
-      const identity = `${data.__typename}:${id}`;
-      for (let i = 0, l = identity.length; i < l; i++)
-        key = (key << 5) + key + identity.charCodeAt(i);
-    }
-  }
-  return key;
-};
-
 const hasDepsChanged = <T extends { length: number }>(a: T, b: T) => {
   for (let i = 0, l = b.length; i < l; i++) if (a[i] !== b[i]) return true;
   return false;
@@ -170,8 +145,9 @@ export function useFragment<Data>(
         return { data: newResult.data, fetching: !newResult.fulfilled };
       }
 
-      const key = getFragmentCacheKey(request, data);
-      const cached = cache.get(key);
+      const key = request.key;
+      const fragmentName = fragment.name.value;
+      const cached = cache.get(key, fragmentName, data);
       const newResult = maskFragment<Data>(
         data,
         fragment.selectionSet,
@@ -181,7 +157,7 @@ export function useFragment<Data>(
       if (newResult.fulfilled) {
         if (cached) {
           cached._resolve();
-          cache.dispose(key);
+          cache.dispose(key, fragmentName, data);
         }
         return { data: newResult.data, fetching: false };
       } else if (newResult.pending) {
@@ -198,7 +174,7 @@ export function useFragment<Data>(
           _resolve = () => resolve(undefined);
         }) as FragmentPromise;
         promise._resolve = _resolve;
-        cache.set(key, promise);
+        cache.set(key, fragmentName, data, promise);
         throw promise;
       }
     },

--- a/packages/preact-urql/src/hooks/useQuery.ts
+++ b/packages/preact-urql/src/hooks/useQuery.ts
@@ -22,10 +22,12 @@ import type {
   OperationResult,
   Operation,
 } from '@urql/core';
+import { makeDeferredState, updateDeferredResult } from '@urql/core';
 
 import { useClient } from '../context';
 import { useSource } from './useSource';
 import { useRequest } from './useRequest';
+import { getDeferredCacheForClient } from './cache';
 import { initialState } from './constants';
 
 /** Input arguments for the {@link useQuery} hook.
@@ -283,6 +285,21 @@ export function useQuery<
 
         // Create a suspense source and cache it for the given request
         if (suspense) {
+          // Install stable promises for missing fields inside `@defer`
+          // selections so masked fragment boundaries can resolve directly
+          // from the stream as later patches arrive.
+          const deferredCache = getDeferredCacheForClient(client);
+          let deferredState = deferredCache.get(request.key);
+          if (!deferredState) {
+            deferredState = makeDeferredState();
+            deferredCache.set(request.key, deferredState);
+          }
+
+          source = pipe(
+            source,
+            map(result => updateDeferredResult(request, result, deferredState!))
+          );
+
           source = toSuspenseSource(source);
           if (typeof window !== 'undefined') {
             sources.set(request.key, source);
@@ -350,6 +367,11 @@ export function useQuery<
   useEffect(() => {
     sources.delete(request.key); // Delete any cached suspense source
     if (!isSuspense(client, args.context)) update(query$);
+    return () => {
+      // Reclaim the operation's deferred state (resolving any still-pending
+      // promises) once it tears down, so no suspended boundary hangs.
+      getDeferredCacheForClient(client).dispose(request.key);
+    };
   }, [update, client, query$, request, args.context]);
 
   if (isSuspense(client, args.context)) {

--- a/packages/react-urql/package.json
+++ b/packages/react-urql/package.json
@@ -60,6 +60,7 @@
     "react": ">= 16.8.0"
   },
   "dependencies": {
+    "@0no-co/graphql.web": "^1.0.13",
     "@urql/core": "workspace:^6.0.3",
     "wonka": "^6.3.2"
   },

--- a/packages/react-urql/src/hooks/cache.ts
+++ b/packages/react-urql/src/hooks/cache.ts
@@ -1,20 +1,38 @@
 import { pipe, subscribe } from 'wonka';
 import type { Client, OperationResult } from '@urql/core';
+import type { DeferredState } from './defer';
+
+/** A pending suspense {@link Promise} that the `useFragment` hook throws.
+ *
+ * @remarks
+ * `_resolve` is called once the masked fragment’s data is fully present,
+ * which tells React to retry rendering the suspended boundary.
+ *
+ * @internal
+ */
+export type FragmentPromise = Promise<unknown> & {
+  _resolve: () => void;
+};
 
 type CacheEntry = OperationResult | Promise<unknown> | undefined;
 
-interface Cache {
-  get(key: number): CacheEntry;
-  set(key: number, value: CacheEntry): void;
+type FragmentCacheEntry = FragmentPromise | undefined;
+type DeferredCacheEntry = DeferredState | undefined;
+
+interface Cache<Entry> {
+  get(key: number): Entry;
+  set(key: number, value: Entry): void;
   clear(key: number): void;
   dispose(key: number): void;
 }
 
 interface ClientWithCache extends Client {
-  _react?: Cache;
+  _deferred?: Cache<DeferredCacheEntry>;
+  _fragments?: Cache<FragmentCacheEntry>;
+  _react?: Cache<CacheEntry>;
 }
 
-export const getCacheForClient = (client: Client): Cache => {
+export const getCacheForClient = (client: Client): Cache<CacheEntry> => {
   if (!(client as ClientWithCache)._react) {
     const reclaim = new Set();
     const map = new Map<number, CacheEntry>();
@@ -50,4 +68,74 @@ export const getCacheForClient = (client: Client): Cache => {
   }
 
   return (client as ClientWithCache)._react!;
+};
+
+/** Cache of pending `useFragment` suspense promises, keyed by an entity-aware key.
+ *
+ * @remarks
+ * Unlike {@link getCacheForClient}, this cache stores the {@link FragmentPromise}
+ * a `useFragment` hook throws while its deferred data is still streaming in. It’s
+ * kept separately so that multiple `useFragment` hooks rendering different entities
+ * (e.g. siblings in a list) don’t share — and prematurely resolve — each other’s
+ * promises.
+ *
+ * @internal
+ */
+export const getFragmentCacheForClient = (
+  client: Client
+): Cache<FragmentCacheEntry> => {
+  if (!(client as ClientWithCache)._fragments) {
+    const map = new Map<number, FragmentCacheEntry>();
+
+    (client as ClientWithCache)._fragments = {
+      get(key) {
+        return map.get(key);
+      },
+      set(key, value) {
+        map.set(key, value);
+      },
+      clear(key) {
+        map.delete(key);
+      },
+      dispose(key) {
+        map.delete(key);
+      },
+    };
+  }
+
+  return (client as ClientWithCache)._fragments!;
+};
+
+/** Cache of per-operation deferred promises that are resolved by `useQuery`.
+ *
+ * @remarks
+ * These promises are embedded into streamed query results so `useFragment`
+ * can throw the same stable promise that the query stream resolves directly
+ * when the matching deferred patch arrives.
+ *
+ * @internal
+ */
+export const getDeferredCacheForClient = (
+  client: Client
+): Cache<DeferredCacheEntry> => {
+  if (!(client as ClientWithCache)._deferred) {
+    const map = new Map<number, DeferredCacheEntry>();
+
+    (client as ClientWithCache)._deferred = {
+      get(key) {
+        return map.get(key);
+      },
+      set(key, value) {
+        map.set(key, value);
+      },
+      clear(key) {
+        map.delete(key);
+      },
+      dispose(key) {
+        map.delete(key);
+      },
+    };
+  }
+
+  return (client as ClientWithCache)._deferred!;
 };

--- a/packages/react-urql/src/hooks/cache.ts
+++ b/packages/react-urql/src/hooks/cache.ts
@@ -120,12 +120,13 @@ export const getDeferredCacheForClient = (
   client: Client
 ): Cache<DeferredCacheEntry> => {
   if (!(client as ClientWithCache)._deferred) {
+    const operations$ = (client as Partial<Client>).operations$;
     const reclaim = new Set();
     const map = new Map<number, DeferredCacheEntry>();
 
-    if (client.operations$ /* not available in mocks */) {
+    if (operations$ /* not available in mocks */) {
       pipe(
-        client.operations$,
+        operations$,
         subscribe(operation => {
           if (operation.kind === 'teardown' && reclaim.has(operation.key)) {
             const state = map.get(operation.key);
@@ -149,7 +150,7 @@ export const getDeferredCacheForClient = (
         map.delete(key);
       },
       dispose(key) {
-        if (client.operations$) {
+        if (operations$) {
           reclaim.add(key);
         } else {
           const state = map.get(key);

--- a/packages/react-urql/src/hooks/cache.ts
+++ b/packages/react-urql/src/hooks/cache.ts
@@ -1,6 +1,7 @@
 import { pipe, subscribe } from 'wonka';
 import type { Client, OperationResult } from '@urql/core';
 import type { DeferredState } from './defer';
+import { resolveDeferredState } from './defer';
 
 /** A pending suspense {@link Promise} that the `useFragment` hook throws.
  *
@@ -119,20 +120,42 @@ export const getDeferredCacheForClient = (
   client: Client
 ): Cache<DeferredCacheEntry> => {
   if (!(client as ClientWithCache)._deferred) {
+    const reclaim = new Set();
     const map = new Map<number, DeferredCacheEntry>();
+
+    if (client.operations$ /* not available in mocks */) {
+      pipe(
+        client.operations$,
+        subscribe(operation => {
+          if (operation.kind === 'teardown' && reclaim.has(operation.key)) {
+            const state = map.get(operation.key);
+            if (state) resolveDeferredState(state);
+            reclaim.delete(operation.key);
+            map.delete(operation.key);
+          }
+        })
+      );
+    }
 
     (client as ClientWithCache)._deferred = {
       get(key) {
         return map.get(key);
       },
       set(key, value) {
+        reclaim.delete(key);
         map.set(key, value);
       },
       clear(key) {
         map.delete(key);
       },
       dispose(key) {
-        map.delete(key);
+        if (client.operations$) {
+          reclaim.add(key);
+        } else {
+          const state = map.get(key);
+          if (state) resolveDeferredState(state);
+          map.delete(key);
+        }
       },
     };
   }

--- a/packages/react-urql/src/hooks/cache.ts
+++ b/packages/react-urql/src/hooks/cache.ts
@@ -21,7 +21,7 @@ type FragmentCacheEntry = FragmentPromise | undefined;
 type DeferredCacheEntry = DeferredState | undefined;
 
 interface Cache<Entry> {
-  get(key: number): Entry;
+  get(key: number): Entry | undefined;
   set(key: number, value: Entry): void;
   clear(key: number): void;
   dispose(key: number): void;
@@ -33,39 +33,59 @@ interface ClientWithCache extends Client {
   _react?: Cache<CacheEntry>;
 }
 
+const makeCache = <Entry>(
+  client?: Client,
+  onClear?: (value: Entry) => void,
+  deferDispose?: boolean
+): Cache<Entry> => {
+  const operations$ = client && (client as Partial<Client>).operations$;
+  const reclaim = new Set<number>();
+  const map = new Map<number, Entry>();
+
+  const clear = (key: number) => {
+    const value = map.get(key);
+    if (value !== undefined && onClear) onClear(value);
+    reclaim.delete(key);
+    map.delete(key);
+  };
+
+  if (operations$ /* not available in mocks */) {
+    pipe(
+      operations$,
+      subscribe(operation => {
+        if (operation.kind === 'teardown' && reclaim.has(operation.key)) {
+          clear(operation.key);
+        }
+      })
+    );
+  }
+
+  return {
+    get(key) {
+      return map.get(key);
+    },
+    set(key, value) {
+      reclaim.delete(key);
+      map.set(key, value);
+    },
+    clear,
+    dispose(key) {
+      if (operations$ || deferDispose) {
+        reclaim.add(key);
+      } else {
+        clear(key);
+      }
+    },
+  };
+};
+
 export const getCacheForClient = (client: Client): Cache<CacheEntry> => {
   if (!(client as ClientWithCache)._react) {
-    const reclaim = new Set();
-    const map = new Map<number, CacheEntry>();
-
-    if (client.operations$ /* not available in mocks */) {
-      pipe(
-        client.operations$,
-        subscribe(operation => {
-          if (operation.kind === 'teardown' && reclaim.has(operation.key)) {
-            reclaim.delete(operation.key);
-            map.delete(operation.key);
-          }
-        })
-      );
-    }
-
-    (client as ClientWithCache)._react = {
-      get(key) {
-        return map.get(key);
-      },
-      set(key, value) {
-        reclaim.delete(key);
-        map.set(key, value);
-      },
-      clear(key) {
-        reclaim.delete(key);
-        map.delete(key);
-      },
-      dispose(key) {
-        reclaim.add(key);
-      },
-    };
+    (client as ClientWithCache)._react = makeCache<CacheEntry>(
+      client,
+      undefined,
+      true
+    );
   }
 
   return (client as ClientWithCache)._react!;
@@ -86,22 +106,7 @@ export const getFragmentCacheForClient = (
   client: Client
 ): Cache<FragmentCacheEntry> => {
   if (!(client as ClientWithCache)._fragments) {
-    const map = new Map<number, FragmentCacheEntry>();
-
-    (client as ClientWithCache)._fragments = {
-      get(key) {
-        return map.get(key);
-      },
-      set(key, value) {
-        map.set(key, value);
-      },
-      clear(key) {
-        map.delete(key);
-      },
-      dispose(key) {
-        map.delete(key);
-      },
-    };
+    (client as ClientWithCache)._fragments = makeCache<FragmentCacheEntry>();
   }
 
   return (client as ClientWithCache)._fragments!;
@@ -120,45 +125,12 @@ export const getDeferredCacheForClient = (
   client: Client
 ): Cache<DeferredCacheEntry> => {
   if (!(client as ClientWithCache)._deferred) {
-    const operations$ = (client as Partial<Client>).operations$;
-    const reclaim = new Set();
-    const map = new Map<number, DeferredCacheEntry>();
-
-    if (operations$ /* not available in mocks */) {
-      pipe(
-        operations$,
-        subscribe(operation => {
-          if (operation.kind === 'teardown' && reclaim.has(operation.key)) {
-            const state = map.get(operation.key);
-            if (state) resolveDeferredState(state);
-            reclaim.delete(operation.key);
-            map.delete(operation.key);
-          }
-        })
-      );
-    }
-
-    (client as ClientWithCache)._deferred = {
-      get(key) {
-        return map.get(key);
-      },
-      set(key, value) {
-        reclaim.delete(key);
-        map.set(key, value);
-      },
-      clear(key) {
-        map.delete(key);
-      },
-      dispose(key) {
-        if (operations$) {
-          reclaim.add(key);
-        } else {
-          const state = map.get(key);
-          if (state) resolveDeferredState(state);
-          map.delete(key);
-        }
-      },
-    };
+    (client as ClientWithCache)._deferred = makeCache<DeferredCacheEntry>(
+      client,
+      state => {
+        if (state) resolveDeferredState(state);
+      }
+    );
   }
 
   return (client as ClientWithCache)._deferred!;

--- a/packages/react-urql/src/hooks/cache.ts
+++ b/packages/react-urql/src/hooks/cache.ts
@@ -16,10 +16,28 @@ export type FragmentPromise = Promise<unknown> & {
 };
 
 type CacheEntry = OperationResult | Promise<unknown> | undefined;
-type FragmentCacheEntry = FragmentPromise | undefined;
+
+/** An entity-aware cache of pending fragment suspense promises.
+ *
+ * @internal
+ */
+export interface FragmentCache {
+  get(
+    key: number,
+    fragmentName: string,
+    data: any
+  ): FragmentPromise | undefined;
+  set(
+    key: number,
+    fragmentName: string,
+    data: any,
+    value: FragmentPromise
+  ): void;
+  dispose(key: number, fragmentName: string, data: any): void;
+}
 
 interface ClientWithCache extends Client {
-  _fragments?: Cache<FragmentCacheEntry>;
+  _fragments?: FragmentCache;
   _react?: Cache<CacheEntry>;
 }
 
@@ -35,22 +53,93 @@ export const getCacheForClient = (client: Client): Cache<CacheEntry> => {
   return (client as ClientWithCache)._react!;
 };
 
-/** Cache of pending `useFragment` suspense promises, keyed by an entity-aware key.
+const makeFragmentCache = (): FragmentCache => {
+  const entities = new Map<string, FragmentPromise>();
+  const objects = new WeakMap<object, Map<string, FragmentPromise>>();
+  const primitives = new Map<string, FragmentPromise>();
+
+  const getScope = (key: number, fragmentName: string) =>
+    `${key}:${fragmentName}`;
+
+  const getEntityKey = (
+    key: number,
+    fragmentName: string,
+    data: any
+  ): string | undefined => {
+    if (data && typeof data === 'object' && !Array.isArray(data)) {
+      const id = data.id != null ? data.id : data._id;
+      if (data.__typename != null && id != null) {
+        return JSON.stringify([
+          key,
+          fragmentName,
+          String(data.__typename),
+          String(id),
+        ]);
+      }
+    }
+  };
+
+  const getObjectCache = (
+    data: object,
+    create: boolean
+  ): Map<string, FragmentPromise> | undefined => {
+    let cache = objects.get(data);
+    if (!cache && create) {
+      cache = new Map();
+      objects.set(data, cache);
+    }
+    return cache;
+  };
+
+  const getPrimitiveKey = (key: number, fragmentName: string, data: any) =>
+    `${getScope(key, fragmentName)}:${typeof data}:${String(data)}`;
+
+  return {
+    get(key, fragmentName, data) {
+      const entityKey = getEntityKey(key, fragmentName, data);
+      if (entityKey) return entities.get(entityKey);
+      if (data && typeof data === 'object') {
+        const cache = getObjectCache(data, false);
+        return cache && cache.get(getScope(key, fragmentName));
+      }
+      return primitives.get(getPrimitiveKey(key, fragmentName, data));
+    },
+    set(key, fragmentName, data, value) {
+      const entityKey = getEntityKey(key, fragmentName, data);
+      if (entityKey) {
+        entities.set(entityKey, value);
+      } else if (data && typeof data === 'object') {
+        getObjectCache(data, true)!.set(getScope(key, fragmentName), value);
+      } else {
+        primitives.set(getPrimitiveKey(key, fragmentName, data), value);
+      }
+    },
+    dispose(key, fragmentName, data) {
+      const entityKey = getEntityKey(key, fragmentName, data);
+      if (entityKey) {
+        entities.delete(entityKey);
+      } else if (data && typeof data === 'object') {
+        const cache = getObjectCache(data, false);
+        if (cache) cache.delete(getScope(key, fragmentName));
+      } else {
+        primitives.delete(getPrimitiveKey(key, fragmentName, data));
+      }
+    },
+  };
+};
+
+/** Cache of pending `useFragment` suspense promises, scoped by fragment and entity.
  *
  * @remarks
- * Unlike {@link getCacheForClient}, this cache stores the {@link FragmentPromise}
- * a `useFragment` hook throws while its deferred data is still streaming in. It’s
- * kept separately so that multiple `useFragment` hooks rendering different entities
- * (e.g. siblings in a list) don’t share — and prematurely resolve — each other’s
- * promises.
+ * Identifiable entities use `__typename` and `id`/`_id`. Other objects are
+ * tracked by reference in a {@link WeakMap}, preventing unrelated siblings from
+ * sharing promises and allowing abandoned entries to be garbage-collected.
  *
  * @internal
  */
-export const getFragmentCacheForClient = (
-  client: Client
-): Cache<FragmentCacheEntry> => {
+export const getFragmentCacheForClient = (client: Client): FragmentCache => {
   if (!(client as ClientWithCache)._fragments) {
-    (client as ClientWithCache)._fragments = makeCache<FragmentCacheEntry>();
+    (client as ClientWithCache)._fragments = makeFragmentCache();
   }
 
   return (client as ClientWithCache)._fragments!;

--- a/packages/react-urql/src/hooks/cache.ts
+++ b/packages/react-urql/src/hooks/cache.ts
@@ -1,13 +1,10 @@
+import type { FragmentDefinitionNode } from '@0no-co/graphql.web';
 import type { Client, OperationResult, Cache } from '@urql/core';
 import { makeCache } from '@urql/core';
 
 export { getDeferredCacheForClient } from '@urql/core';
 
 /** A pending suspense {@link Promise} that the `useFragment` hook throws.
- *
- * @remarks
- * `_resolve` is called once the masked fragment’s data is fully present,
- * which tells React to retry rendering the suspended boundary.
  *
  * @internal
  */
@@ -17,24 +14,10 @@ export type FragmentPromise = Promise<unknown> & {
 
 type CacheEntry = OperationResult | Promise<unknown> | undefined;
 
-/** An entity-aware cache of pending fragment suspense promises.
- *
- * @internal
- */
-export interface FragmentCache {
-  get(
-    key: number,
-    fragmentName: string,
-    data: any
-  ): FragmentPromise | undefined;
-  set(
-    key: number,
-    fragmentName: string,
-    data: any,
-    value: FragmentPromise
-  ): void;
-  dispose(key: number, fragmentName: string, data: any): void;
-}
+type FragmentCache = WeakMap<
+  FragmentDefinitionNode,
+  WeakMap<object, FragmentPromise>
+>;
 
 interface ClientWithCache extends Client {
   _fragments?: FragmentCache;
@@ -53,94 +36,51 @@ export const getCacheForClient = (client: Client): Cache<CacheEntry> => {
   return (client as ClientWithCache)._react!;
 };
 
-const makeFragmentCache = (): FragmentCache => {
-  const entities = new Map<string, FragmentPromise>();
-  const objects = new WeakMap<object, Map<string, FragmentPromise>>();
-  const primitives = new Map<string, FragmentPromise>();
-
-  const getScope = (key: number, fragmentName: string) =>
-    `${key}:${fragmentName}`;
-
-  const getEntityKey = (
-    key: number,
-    fragmentName: string,
-    data: any
-  ): string | undefined => {
-    if (data && typeof data === 'object' && !Array.isArray(data)) {
-      const id = data.id != null ? data.id : data._id;
-      if (data.__typename != null && id != null) {
-        return JSON.stringify([
-          key,
-          fragmentName,
-          String(data.__typename),
-          String(id),
-        ]);
-      }
-    }
-  };
-
-  const getObjectCache = (
-    data: object,
-    create: boolean
-  ): Map<string, FragmentPromise> | undefined => {
-    let cache = objects.get(data);
-    if (!cache && create) {
-      cache = new Map();
-      objects.set(data, cache);
-    }
-    return cache;
-  };
-
-  const getPrimitiveKey = (key: number, fragmentName: string, data: any) =>
-    `${getScope(key, fragmentName)}:${typeof data}:${String(data)}`;
-
-  return {
-    get(key, fragmentName, data) {
-      const entityKey = getEntityKey(key, fragmentName, data);
-      if (entityKey) return entities.get(entityKey);
-      if (data && typeof data === 'object') {
-        const cache = getObjectCache(data, false);
-        return cache && cache.get(getScope(key, fragmentName));
-      }
-      return primitives.get(getPrimitiveKey(key, fragmentName, data));
-    },
-    set(key, fragmentName, data, value) {
-      const entityKey = getEntityKey(key, fragmentName, data);
-      if (entityKey) {
-        entities.set(entityKey, value);
-      } else if (data && typeof data === 'object') {
-        getObjectCache(data, true)!.set(getScope(key, fragmentName), value);
-      } else {
-        primitives.set(getPrimitiveKey(key, fragmentName, data), value);
-      }
-    },
-    dispose(key, fragmentName, data) {
-      const entityKey = getEntityKey(key, fragmentName, data);
-      if (entityKey) {
-        entities.delete(entityKey);
-      } else if (data && typeof data === 'object') {
-        const cache = getObjectCache(data, false);
-        if (cache) cache.delete(getScope(key, fragmentName));
-      } else {
-        primitives.delete(getPrimitiveKey(key, fragmentName, data));
-      }
-    },
-  };
-};
-
-/** Cache of pending `useFragment` suspense promises, scoped by fragment and entity.
+/** Returns a pending fragment promise for this exact fragment and data object.
  *
  * @remarks
- * Identifiable entities use `__typename` and `id`/`_id`. Other objects are
- * tracked by reference in a {@link WeakMap}, preventing unrelated siblings from
- * sharing promises and allowing abandoned entries to be garbage-collected.
+ * Weak keys keep sibling objects and named fragments independent and allow
+ * abandoned suspended renders to be garbage-collected without an effect.
  *
  * @internal
  */
-export const getFragmentCacheForClient = (client: Client): FragmentCache => {
-  if (!(client as ClientWithCache)._fragments) {
-    (client as ClientWithCache)._fragments = makeFragmentCache();
-  }
+export const getFragmentPromise = (
+  client: Client,
+  fragment: FragmentDefinitionNode,
+  data: object
+): FragmentPromise | undefined => {
+  const cache = (client as ClientWithCache)._fragments;
+  const entries = cache && cache.get(fragment);
+  return entries && entries.get(data);
+};
 
-  return (client as ClientWithCache)._fragments!;
+/** Stores a pending promise for this exact fragment and data object.
+ *
+ * @internal
+ */
+export const setFragmentPromise = (
+  client: Client,
+  fragment: FragmentDefinitionNode,
+  data: object,
+  promise: FragmentPromise
+): void => {
+  const target = client as ClientWithCache;
+  const cache = target._fragments || (target._fragments = new WeakMap());
+  let entries = cache.get(fragment);
+  if (!entries) cache.set(fragment, (entries = new WeakMap()));
+  entries.set(data, promise);
+};
+
+/** Deletes a settled fragment promise.
+ *
+ * @internal
+ */
+export const deleteFragmentPromise = (
+  client: Client,
+  fragment: FragmentDefinitionNode,
+  data: object
+): void => {
+  const cache = (client as ClientWithCache)._fragments;
+  const entries = cache && cache.get(fragment);
+  if (entries) entries.delete(data);
 };

--- a/packages/react-urql/src/hooks/defer.ts
+++ b/packages/react-urql/src/hooks/defer.ts
@@ -1,0 +1,326 @@
+import type {
+  FragmentDefinitionNode,
+  InlineFragmentNode,
+  SelectionSetNode,
+} from '@0no-co/graphql.web';
+import { Kind } from '@0no-co/graphql.web';
+import type { AnyVariables, GraphQLRequest, OperationResult } from '@urql/core';
+
+export type DeferredPromise = Promise<unknown> & {
+  _resolve: (value?: unknown) => void;
+  _resolved?: boolean;
+  /** The streamed-in value, once the deferred patch has arrived.
+   *
+   * @remarks
+   * `useFragment` reads this directly when re-masking after the promise has
+   * resolved. This is what allows a deferred boundary to resolve during a
+   * server stream, where the parent component holding `useQuery` won't
+   * re-render to hand down fresh data via props.
+   */
+  _value?: unknown;
+  _urqlDeferred: true;
+};
+
+export interface DeferredState {
+  promises: Map<string, DeferredPromise>;
+}
+
+export const makeDeferredState = (): DeferredState => ({
+  promises: new Map(),
+});
+
+export const isDeferredPromise = (value: any): value is DeferredPromise =>
+  !!value && value._urqlDeferred === true && typeof value.then === 'function';
+
+export const resolveDeferredState = (state: DeferredState) => {
+  state.promises.forEach(promise => promise._resolve());
+  state.promises.clear();
+};
+
+const makeDeferredPromise = (): DeferredPromise => {
+  let resolve!: () => void;
+  const promise = new Promise<void>(_resolve => {
+    resolve = _resolve;
+  }) as DeferredPromise;
+
+  promise._resolved = false;
+  promise._urqlDeferred = true;
+  promise._resolve = (value?: unknown) => {
+    if (!promise._resolved) {
+      promise._resolved = true;
+      promise._value = value;
+      resolve();
+    }
+  };
+
+  return promise;
+};
+
+const hasDirective = (
+  node: { directives?: readonly { name: { value: string } }[] },
+  name: string
+): boolean => {
+  const directives = (node as any)._directives;
+  return !!(
+    (directives && directives[name]) ||
+    (node.directives && node.directives.some(x => x.name.value === name))
+  );
+};
+
+const isOptionalSelection = (node: {
+  directives?: readonly { name: { value: string } }[];
+}): boolean => {
+  return hasDirective(node, 'include') || hasDirective(node, 'skip');
+};
+
+const getFieldKey = (selection: {
+  alias?: { value: string };
+  name: { value: string };
+}) => {
+  return selection.alias ? selection.alias.value : selection.name.value;
+};
+
+const getPathKey = (path: readonly (string | number)[]) => JSON.stringify(path);
+
+const getDeferredPromise = (
+  state: DeferredState,
+  path: readonly (string | number)[]
+) => {
+  const key = getPathKey(path);
+  let promise = state.promises.get(key);
+
+  if (!promise || promise._resolved) {
+    promise = makeDeferredPromise();
+    state.promises.set(key, promise);
+  }
+
+  return promise;
+};
+
+const resolveDeferredPath = (
+  state: DeferredState,
+  path: readonly (string | number)[],
+  value?: unknown
+) => {
+  const key = getPathKey(path);
+  const promise = state.promises.get(key);
+  if (promise) {
+    promise._resolve(value);
+    state.promises.delete(key);
+  }
+};
+
+const isObjectLike = (value: unknown): value is Record<string, any> =>
+  typeof value === 'object' && value !== null;
+
+const updateArray = (
+  data: readonly any[],
+  selectionSet: SelectionSetNode,
+  fragments: Record<string, FragmentDefinitionNode>,
+  state: DeferredState,
+  path: readonly (string | number)[],
+  isDeferred: boolean,
+  hasNext: boolean
+) => {
+  let next: any[] | undefined;
+
+  for (let i = 0, l = data.length; i < l; i++) {
+    const item = data[i];
+    const nextItem = updateSelectionSet(
+      item,
+      selectionSet,
+      fragments,
+      state,
+      [...path, i],
+      isDeferred,
+      hasNext
+    );
+
+    if (nextItem !== item) {
+      if (!next) next = [...data];
+      next[i] = nextItem;
+    }
+  }
+
+  return next || data;
+};
+
+const updateSelectionSet = (
+  data: any,
+  selectionSet: SelectionSetNode,
+  fragments: Record<string, FragmentDefinitionNode>,
+  state: DeferredState,
+  path: readonly (string | number)[],
+  isDeferred: boolean,
+  hasNext: boolean
+): any => {
+  if (!isObjectLike(data)) return data;
+
+  let next: Record<string, any> | undefined;
+
+  selectionSet.selections.forEach(selection => {
+    if (selection.kind === Kind.FIELD) {
+      const fieldKey = getFieldKey(selection);
+      const fieldPath = [...path, fieldKey];
+      const value = data[fieldKey];
+
+      if (value === undefined) {
+        if (isDeferred && hasNext && !isOptionalSelection(selection)) {
+          if (!next) next = { ...data };
+          next[fieldKey] = getDeferredPromise(state, fieldPath);
+        } else if (!hasNext) {
+          resolveDeferredPath(state, fieldPath);
+        }
+      } else {
+        let resolvedValue = value;
+
+        if (selection.selectionSet && value !== null) {
+          resolvedValue = Array.isArray(value)
+            ? updateArray(
+                value,
+                selection.selectionSet,
+                fragments,
+                state,
+                fieldPath,
+                isDeferred,
+                hasNext
+              )
+            : updateSelectionSet(
+                value,
+                selection.selectionSet,
+                fragments,
+                state,
+                fieldPath,
+                isDeferred,
+                hasNext
+              );
+
+          if (resolvedValue !== value) {
+            if (!next) next = { ...data };
+            next[fieldKey] = resolvedValue;
+          }
+        }
+
+        // Resolve the deferred promise for this path with the streamed-in
+        // value (already processed for nested defers) so a suspended
+        // `useFragment` can read it without waiting on a parent rerender.
+        resolveDeferredPath(state, fieldPath, resolvedValue);
+      }
+    } else if (selection.kind === Kind.INLINE_FRAGMENT) {
+      if (!isHeuristicFragmentMatch(selection, data, fragments)) {
+        return;
+      }
+
+      const nextValue = updateSelectionSet(
+        next || data,
+        selection.selectionSet,
+        fragments,
+        state,
+        path,
+        isDeferred || hasDirective(selection, 'defer'),
+        hasNext
+      );
+
+      if (nextValue !== (next || data)) {
+        next = nextValue;
+      }
+    } else if (selection.kind === Kind.FRAGMENT_SPREAD) {
+      const fragment = fragments[selection.name.value];
+
+      if (!fragment || !isHeuristicFragmentMatch(fragment, data, fragments)) {
+        return;
+      }
+
+      const nextValue = updateSelectionSet(
+        next || data,
+        fragment.selectionSet,
+        fragments,
+        state,
+        path,
+        isDeferred || hasDirective(selection, 'defer'),
+        hasNext
+      );
+
+      if (nextValue !== (next || data)) {
+        next = nextValue;
+      }
+    }
+  });
+
+  return next || data;
+};
+
+const isHeuristicFragmentMatch = (
+  fragment: InlineFragmentNode | FragmentDefinitionNode,
+  data: any,
+  fragments: Record<string, FragmentDefinitionNode>
+): boolean => {
+  if (
+    !fragment.typeCondition ||
+    fragment.typeCondition.name.value === data.__typename
+  ) {
+    return true;
+  }
+
+  return fragment.selectionSet.selections.every(selection => {
+    if (selection.kind === Kind.FIELD) {
+      const fieldKey = getFieldKey(selection);
+      const couldBeExcluded =
+        isOptionalSelection(selection) || hasDirective(selection, 'defer');
+      return data[fieldKey] !== undefined && !couldBeExcluded;
+    } else if (selection.kind === Kind.INLINE_FRAGMENT) {
+      return isHeuristicFragmentMatch(selection, data, fragments);
+    } else if (selection.kind === Kind.FRAGMENT_SPREAD) {
+      const fragment = fragments[selection.name.value];
+      return !!fragment && isHeuristicFragmentMatch(fragment, data, fragments);
+    }
+
+    return true;
+  });
+};
+
+export const updateDeferredResult = <
+  Data = any,
+  Variables extends AnyVariables = AnyVariables,
+>(
+  request: GraphQLRequest<Data, Variables>,
+  result: OperationResult<Data, Variables>,
+  state: DeferredState
+): OperationResult<Data, Variables> => {
+  if (!result.data) {
+    if (!result.hasNext) resolveDeferredState(state);
+    return result;
+  }
+
+  const operation = request.query.definitions.find(
+    definition => definition.kind === Kind.OPERATION_DEFINITION
+  );
+
+  if (!operation || operation.kind !== Kind.OPERATION_DEFINITION) {
+    if (!result.hasNext) resolveDeferredState(state);
+    return result;
+  }
+
+  const fragments = request.query.definitions.reduce<
+    Record<string, FragmentDefinitionNode>
+  >((acc, definition) => {
+    if (definition.kind === Kind.FRAGMENT_DEFINITION) {
+      acc[definition.name.value] = definition;
+    }
+    return acc;
+  }, {});
+
+  const data = updateSelectionSet(
+    result.data,
+    operation.selectionSet,
+    fragments,
+    state,
+    [],
+    false,
+    result.hasNext
+  );
+
+  if (!result.hasNext) resolveDeferredState(state);
+
+  return data === result.data ? result : { ...result, data };
+};

--- a/packages/react-urql/src/hooks/defer.ts
+++ b/packages/react-urql/src/hooks/defer.ts
@@ -1,10 +1,14 @@
-import type {
-  FragmentDefinitionNode,
-  InlineFragmentNode,
-  SelectionSetNode,
-} from '@0no-co/graphql.web';
+import type { SelectionSetNode } from '@0no-co/graphql.web';
 import { Kind } from '@0no-co/graphql.web';
 import type { AnyVariables, GraphQLRequest, OperationResult } from '@urql/core';
+import {
+  getFieldKey,
+  getFragments,
+  hasDirective,
+  isHeuristicFragmentMatch,
+  isOptionalSelection,
+  type FragmentMap,
+} from './selection';
 
 export type DeferredPromise = Promise<unknown> & {
   _resolve: (value?: unknown) => void;
@@ -56,30 +60,6 @@ const makeDeferredPromise = (): DeferredPromise => {
   return promise;
 };
 
-const hasDirective = (
-  node: { directives?: readonly { name: { value: string } }[] },
-  name: string
-): boolean => {
-  const directives = (node as any)._directives;
-  return !!(
-    (directives && directives[name]) ||
-    (node.directives && node.directives.some(x => x.name.value === name))
-  );
-};
-
-const isOptionalSelection = (node: {
-  directives?: readonly { name: { value: string } }[];
-}): boolean => {
-  return hasDirective(node, 'include') || hasDirective(node, 'skip');
-};
-
-const getFieldKey = (selection: {
-  alias?: { value: string };
-  name: { value: string };
-}) => {
-  return selection.alias ? selection.alias.value : selection.name.value;
-};
-
 const getPathKey = (path: readonly (string | number)[]) => JSON.stringify(path);
 
 const getDeferredPromise = (
@@ -116,7 +96,7 @@ const isObjectLike = (value: unknown): value is Record<string, any> =>
 const updateArray = (
   data: readonly any[],
   selectionSet: SelectionSetNode,
-  fragments: Record<string, FragmentDefinitionNode>,
+  fragments: FragmentMap,
   state: DeferredState,
   path: readonly (string | number)[],
   isDeferred: boolean,
@@ -148,7 +128,7 @@ const updateArray = (
 const updateSelectionSet = (
   data: any,
   selectionSet: SelectionSetNode,
-  fragments: Record<string, FragmentDefinitionNode>,
+  fragments: FragmentMap,
   state: DeferredState,
   path: readonly (string | number)[],
   isDeferred: boolean,
@@ -250,35 +230,6 @@ const updateSelectionSet = (
   return next || data;
 };
 
-const isHeuristicFragmentMatch = (
-  fragment: InlineFragmentNode | FragmentDefinitionNode,
-  data: any,
-  fragments: Record<string, FragmentDefinitionNode>
-): boolean => {
-  if (
-    !fragment.typeCondition ||
-    fragment.typeCondition.name.value === data.__typename
-  ) {
-    return true;
-  }
-
-  return fragment.selectionSet.selections.every(selection => {
-    if (selection.kind === Kind.FIELD) {
-      const fieldKey = getFieldKey(selection);
-      const couldBeExcluded =
-        isOptionalSelection(selection) || hasDirective(selection, 'defer');
-      return data[fieldKey] !== undefined && !couldBeExcluded;
-    } else if (selection.kind === Kind.INLINE_FRAGMENT) {
-      return isHeuristicFragmentMatch(selection, data, fragments);
-    } else if (selection.kind === Kind.FRAGMENT_SPREAD) {
-      const fragment = fragments[selection.name.value];
-      return !!fragment && isHeuristicFragmentMatch(fragment, data, fragments);
-    }
-
-    return true;
-  });
-};
-
 export const updateDeferredResult = <
   Data = any,
   Variables extends AnyVariables = AnyVariables,
@@ -301,14 +252,7 @@ export const updateDeferredResult = <
     return result;
   }
 
-  const fragments = request.query.definitions.reduce<
-    Record<string, FragmentDefinitionNode>
-  >((acc, definition) => {
-    if (definition.kind === Kind.FRAGMENT_DEFINITION) {
-      acc[definition.name.value] = definition;
-    }
-    return acc;
-  }, {});
+  const fragments = getFragments(request.query.definitions);
 
   const data = updateSelectionSet(
     result.data,

--- a/packages/react-urql/src/hooks/index.ts
+++ b/packages/react-urql/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export * from './useFragment';
 export * from './useMutation';
 export * from './useQuery';
 export * from './useSubscription';

--- a/packages/react-urql/src/hooks/selection.ts
+++ b/packages/react-urql/src/hooks/selection.ts
@@ -1,0 +1,66 @@
+import type {
+  DefinitionNode,
+  FieldNode,
+  FragmentDefinitionNode,
+  InlineFragmentNode,
+} from '@0no-co/graphql.web';
+import { Kind } from '@0no-co/graphql.web';
+
+export type FragmentMap = Record<string, FragmentDefinitionNode>;
+
+type DirectedNode = {
+  directives?: readonly { name: { value: string } }[];
+  _directives?: Record<string, unknown>;
+};
+
+export const getFragments = (
+  definitions: readonly DefinitionNode[]
+): FragmentMap =>
+  definitions.reduce<FragmentMap>((acc, definition) => {
+    if (definition.kind === Kind.FRAGMENT_DEFINITION) {
+      acc[definition.name.value] = definition;
+    }
+    return acc;
+  }, {});
+
+export const hasDirective = (node: DirectedNode, name: string): boolean => {
+  const directives = node._directives;
+  return !!(
+    (directives && directives[name]) ||
+    (node.directives && node.directives.some(x => x.name.value === name))
+  );
+};
+
+export const isOptionalSelection = (node: DirectedNode): boolean =>
+  hasDirective(node, 'include') || hasDirective(node, 'skip');
+
+export const getFieldKey = (selection: FieldNode): string =>
+  selection.alias ? selection.alias.value : selection.name.value;
+
+export const isHeuristicFragmentMatch = (
+  fragment: InlineFragmentNode | FragmentDefinitionNode,
+  data: any,
+  fragments: FragmentMap
+): boolean => {
+  if (
+    !fragment.typeCondition ||
+    fragment.typeCondition.name.value === data.__typename
+  ) {
+    return true;
+  }
+
+  return fragment.selectionSet.selections.every(selection => {
+    if (selection.kind === Kind.FIELD) {
+      const couldBeExcluded =
+        isOptionalSelection(selection) || hasDirective(selection, 'defer');
+      return data[getFieldKey(selection)] !== undefined && !couldBeExcluded;
+    } else if (selection.kind === Kind.INLINE_FRAGMENT) {
+      return isHeuristicFragmentMatch(selection, data, fragments);
+    } else if (selection.kind === Kind.FRAGMENT_SPREAD) {
+      const fragment = fragments[selection.name.value];
+      return !!fragment && isHeuristicFragmentMatch(fragment, data, fragments);
+    }
+
+    return true;
+  });
+};

--- a/packages/react-urql/src/hooks/useFragment.ssr.test.tsx
+++ b/packages/react-urql/src/hooks/useFragment.ssr.test.tsx
@@ -1,0 +1,245 @@
+// @vitest-environment node
+
+import { vi, expect, it, describe, beforeEach } from 'vitest';
+
+vi.mock('../context', () => {
+  const mock = {};
+
+  return {
+    useClient: () => mock,
+  };
+});
+
+import * as React from 'react';
+import { Suspense } from 'react';
+import { renderToPipeableStream } from 'react-dom/server';
+import { Writable } from 'stream';
+import { makeSubject } from 'wonka';
+
+import { useQuery } from './useQuery';
+import { useFragment } from './useFragment';
+import { useClient } from '../context';
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+/** Render `element` to a string via React's streaming server renderer.
+ *
+ * @remarks
+ * `drive` is invoked after rendering starts so the test can push results into
+ * the mocked query stream. The promise resolves with the fully streamed HTML,
+ * i.e. after every Suspense boundary has resolved.
+ */
+const renderToString = (
+  element: React.ReactElement,
+  drive: () => void | Promise<void>
+): Promise<string> =>
+  new Promise((resolve, reject) => {
+    let html = '';
+    const writable = new Writable({
+      write(chunk, _encoding, callback) {
+        html += chunk.toString();
+        callback();
+      },
+    });
+    writable.on('finish', () => resolve(html));
+
+    const { pipe } = renderToPipeableStream(element, {
+      onShellReady() {
+        pipe(writable);
+      },
+      onError(error) {
+        reject(error);
+      },
+    });
+
+    Promise.resolve().then(drive).catch(reject);
+  });
+
+beforeEach(() => {
+  const client = useClient() as any;
+  delete client._deferred;
+  delete client._fragments;
+  delete client._react;
+  delete client.executeQuery;
+  delete client.suspense;
+});
+
+describe('useFragment SSR streaming', () => {
+  // This is the layout that the client-only mechanism couldn't satisfy: the
+  // Suspense boundary sits *below* `useQuery` and `useFragment` lives in a
+  // child. On the server `Page` never re-renders, so the deferred fragment can
+  // only resolve by reading the value off the stream-owned promise directly.
+  it('streams a deferred fragment whose boundary is below useQuery', async () => {
+    const client = useClient() as any;
+    const subject = makeSubject<any>();
+    client.executeQuery = vi.fn(() => subject.source);
+
+    const Deferred = ({ data }: { data: any }) => {
+      const fragment = useFragment<any>({
+        query: `fragment SongFields on Song { title }`,
+        data,
+        context: { suspense: true },
+      });
+      return <p>{fragment.data.title}</p>;
+    };
+
+    const Page = () => {
+      const [result] = useQuery<any>({
+        query: `
+          query {
+            song {
+              id
+              __typename
+              ...SongFields @defer
+            }
+          }
+
+          fragment SongFields on Song {
+            title
+          }
+        `,
+        context: { suspense: true },
+      });
+
+      return (
+        <main>
+          <span>{result.data.song.__typename}</span>
+          <Suspense fallback={<p>loading</p>}>
+            <Deferred data={result.data.song} />
+          </Suspense>
+        </main>
+      );
+    };
+
+    const html = await renderToString(<Page />, async () => {
+      // Initial payload: non-deferred fields only, `title` is still pending.
+      subject.next({
+        data: { song: { __typename: 'Song', id: '1' } },
+        hasNext: true,
+        stale: false,
+      });
+
+      // Let React render the shell with the boundary's fallback before the
+      // deferred patch arrives, so the child genuinely suspends.
+      await sleep(20);
+
+      // The deferred patch streams in; the query stream resolves the promise.
+      subject.next({
+        data: { song: { __typename: 'Song', id: '1', title: 'Hello' } },
+        hasNext: false,
+        stale: false,
+      });
+    });
+
+    // The non-deferred field is in the shell, and the deferred fragment was
+    // streamed in and resolved server-side — without any parent rerender.
+    expect(html).toContain('Song');
+    expect(html).toContain('Hello');
+  });
+
+  it('streams a nested deferred fragment', async () => {
+    const client = useClient() as any;
+    const subject = makeSubject<any>();
+    client.executeQuery = vi.fn(() => subject.source);
+
+    const Author = ({ data }: { data: any }) => {
+      const fragment = useFragment<any>({
+        query: `fragment AuthorFields on Author { name }`,
+        data,
+        context: { suspense: true },
+      });
+      return <span>{fragment.data.name}</span>;
+    };
+
+    const Page = () => {
+      const [result] = useQuery<any>({
+        query: `
+          query {
+            post {
+              id
+              __typename
+              ...PostFields @defer
+            }
+          }
+
+          fragment PostFields on Post {
+            author {
+              __typename
+              ...AuthorFields @defer
+            }
+          }
+
+          fragment AuthorFields on Author {
+            name
+          }
+        `,
+        context: { suspense: true },
+      });
+
+      const post = result.data.post;
+      return (
+        <Suspense fallback={<p>loading-post</p>}>
+          <PostBody post={post} />
+        </Suspense>
+      );
+    };
+
+    const PostBody = ({ post }: { post: any }) => {
+      const fragment = useFragment<any>({
+        query: `
+          fragment PostFields on Post {
+            author {
+              __typename
+              ...AuthorFields @defer
+            }
+          }
+
+          fragment AuthorFields on Author {
+            name
+          }
+        `,
+        data: post,
+        context: { suspense: true },
+      });
+      return (
+        <Suspense fallback={<p>loading-author</p>}>
+          <Author data={fragment.data.author} />
+        </Suspense>
+      );
+    };
+
+    const html = await renderToString(<Page />, async () => {
+      subject.next({
+        data: { post: { __typename: 'Post', id: '1' } },
+        hasNext: true,
+        stale: false,
+      });
+      await sleep(20);
+      subject.next({
+        data: {
+          post: {
+            __typename: 'Post',
+            id: '1',
+            author: { __typename: 'Author' },
+          },
+        },
+        hasNext: true,
+        stale: false,
+      });
+      await sleep(20);
+      subject.next({
+        data: {
+          post: {
+            __typename: 'Post',
+            id: '1',
+            author: { __typename: 'Author', name: 'Jovi' },
+          },
+        },
+        hasNext: false,
+        stale: false,
+      });
+    });
+
+    expect(html).toContain('Jovi');
+  });
+});

--- a/packages/react-urql/src/hooks/useFragment.ssr.test.tsx
+++ b/packages/react-urql/src/hooks/useFragment.ssr.test.tsx
@@ -76,7 +76,7 @@ describe('useFragment SSR streaming', () => {
 
     const Deferred = ({ data }: { data: any }) => {
       const fragment = useFragment<any>({
-        query: `fragment SongFields on Song { title }`,
+        fragment: `fragment SongFields on Song { title }`,
         data,
         context: { suspense: true },
       });
@@ -144,7 +144,7 @@ describe('useFragment SSR streaming', () => {
 
     const Author = ({ data }: { data: any }) => {
       const fragment = useFragment<any>({
-        query: `fragment AuthorFields on Author { name }`,
+        fragment: `fragment AuthorFields on Author { name }`,
         data,
         context: { suspense: true },
       });
@@ -186,7 +186,7 @@ describe('useFragment SSR streaming', () => {
 
     const PostBody = ({ post }: { post: any }) => {
       const fragment = useFragment<any>({
-        query: `
+        fragment: `
           fragment PostFields on Post {
             author {
               __typename

--- a/packages/react-urql/src/hooks/useFragment.test.tsx
+++ b/packages/react-urql/src/hooks/useFragment.test.tsx
@@ -13,6 +13,7 @@ vi.mock('../context', () => {
 import React, { Suspense } from 'react';
 import { renderHook, render, act, cleanup } from '@testing-library/react';
 import { makeSubject } from 'wonka';
+import { createRequest } from '@urql/core';
 
 import { useFragment } from './useFragment';
 import { useQuery } from './useQuery';
@@ -194,6 +195,48 @@ describe('useFragment masking', () => {
         id: '1',
         name: null,
         author: null,
+      },
+    });
+  });
+
+  it('should preserve null items in nullable lists', () => {
+    const { result } = renderHook(() =>
+      useFragment({
+        query: `
+          fragment TodoFields on Todo {
+            id
+            __typename
+            assignees { id name __typename }
+          }`,
+        data: {
+          __typename: 'Todo',
+          id: '1',
+          assignees: [
+            null,
+            {
+              __typename: 'User',
+              id: '2',
+              name: 'Jovi',
+              role: 'admin',
+            },
+          ],
+        },
+      })
+    );
+
+    expect(result.current).toEqual({
+      fetching: false,
+      data: {
+        __typename: 'Todo',
+        id: '1',
+        assignees: [
+          null,
+          {
+            __typename: 'User',
+            id: '2',
+            name: 'Jovi',
+          },
+        ],
       },
     });
   });
@@ -434,5 +477,53 @@ describe('useFragment suspense', () => {
     await act(async () => {});
 
     expect(view.container.textContent).toBe('Hello');
+  });
+
+  it('disposes deferred cache entries on unmount', async () => {
+    const client = useClient() as any;
+    const subject = makeSubject<any>();
+    client.suspense = true;
+    client.executeQuery = vi.fn(() => subject.source);
+
+    const query = `
+      query {
+        song {
+          id
+          __typename
+          ...SongFields @defer
+        }
+      }
+
+      fragment SongFields on Song {
+        title
+      }
+    `;
+
+    const SongFromQuery = () => {
+      useQuery<any>({ query });
+      return null;
+    };
+
+    const view = render(
+      <Suspense fallback={<p>loading</p>}>
+        <SongFromQuery />
+      </Suspense>
+    );
+
+    act(() => {
+      subject.next({
+        data: { song: { __typename: 'Song', id: '1' } },
+        hasNext: true,
+        stale: false,
+      });
+    });
+    await act(async () => {});
+
+    const key = createRequest(query, undefined).key;
+    expect(client._deferred.get(key)).toBeTruthy();
+
+    view.unmount();
+
+    expect(client._deferred.get(key)).toBeUndefined();
   });
 });

--- a/packages/react-urql/src/hooks/useFragment.test.tsx
+++ b/packages/react-urql/src/hooks/useFragment.test.tsx
@@ -1,0 +1,438 @@
+// @vitest-environment jsdom
+
+import { vi, expect, it, describe, beforeEach } from 'vitest';
+
+vi.mock('../context', () => {
+  const mock = {};
+
+  return {
+    useClient: () => mock,
+  };
+});
+
+import React, { Suspense } from 'react';
+import { renderHook, render, act, cleanup } from '@testing-library/react';
+import { makeSubject } from 'wonka';
+
+import { useFragment } from './useFragment';
+import { useQuery } from './useQuery';
+import { useClient } from '../context';
+
+const mockQuery = `
+  fragment TodoFields on Todo {
+    id
+    name
+    __typename
+  }
+`;
+
+beforeEach(() => {
+  cleanup();
+  const client = useClient() as any;
+  // Reset the per-client suspense caches between tests.
+  delete client._deferred;
+  delete client._fragments;
+  delete client._react;
+  delete client.executeQuery;
+  delete client.suspense;
+});
+
+describe('useFragment masking', () => {
+  it('should correctly mask data', () => {
+    const { result } = renderHook(
+      ({ query }) =>
+        useFragment({
+          query,
+          data: {
+            __typename: 'Todo',
+            id: '1',
+            name: 'Learn urql',
+            completed: true,
+          },
+        }),
+      { initialProps: { query: mockQuery } }
+    );
+
+    expect(result.current).toEqual({
+      fetching: false,
+      data: {
+        __typename: 'Todo',
+        id: '1',
+        name: 'Learn urql',
+      },
+    });
+  });
+
+  it('should correctly take a named fragment to mask data', () => {
+    const { result } = renderHook(() =>
+      useFragment({
+        query: `fragment x on X { foo bar } fragment TodoFields on Todo { id name __typename }`,
+        name: 'TodoFields',
+        data: {
+          __typename: 'Todo',
+          id: '1',
+          name: 'Learn urql',
+          completed: true,
+        },
+      })
+    );
+
+    expect(result.current).toEqual({
+      fetching: false,
+      data: {
+        __typename: 'Todo',
+        id: '1',
+        name: 'Learn urql',
+      },
+    });
+  });
+
+  it('should correctly mask data w/ null attribute', () => {
+    const { result } = renderHook(() =>
+      useFragment({
+        query: mockQuery,
+        data: { __typename: 'Todo', id: '1', name: null, completed: true },
+      })
+    );
+
+    expect(result.current).toEqual({
+      fetching: false,
+      data: {
+        __typename: 'Todo',
+        id: '1',
+        name: null,
+      },
+    });
+  });
+
+  it('should correctly indicate loading w/ undefined attribute', () => {
+    const { result } = renderHook(() =>
+      useFragment({
+        query: mockQuery,
+        data: {
+          __typename: 'Todo',
+          id: '1',
+          name: undefined,
+          completed: true,
+        },
+      })
+    );
+
+    expect(result.current).toEqual({
+      fetching: true,
+      data: {
+        __typename: 'Todo',
+        id: '1',
+      },
+    });
+  });
+
+  it('should correctly mask data w/ nested object', () => {
+    const { result } = renderHook(() =>
+      useFragment({
+        query: `
+          fragment TodoFields on Todo {
+            id
+            name
+            __typename
+            author { id name __typename }
+          }`,
+        data: {
+          __typename: 'Todo',
+          id: '1',
+          name: null,
+          completed: true,
+          author: {
+            id: '1',
+            name: 'Jovi',
+            __typename: 'Author',
+            awardWinner: true,
+          },
+        },
+      })
+    );
+
+    expect(result.current).toEqual({
+      fetching: false,
+      data: {
+        __typename: 'Todo',
+        id: '1',
+        name: null,
+        author: {
+          __typename: 'Author',
+          id: '1',
+          name: 'Jovi',
+        },
+      },
+    });
+  });
+
+  it('should correctly mask data w/ nested selection that is null', () => {
+    const { result } = renderHook(() =>
+      useFragment({
+        query: `
+          fragment TodoFields on Todo {
+            id
+            name
+            __typename
+            author { id name __typename }
+          }`,
+        data: {
+          __typename: 'Todo',
+          id: '1',
+          name: null,
+          completed: true,
+          author: null,
+        },
+      })
+    );
+
+    expect(result.current).toEqual({
+      fetching: false,
+      data: {
+        __typename: 'Todo',
+        id: '1',
+        name: null,
+        author: null,
+      },
+    });
+  });
+
+  it('should correctly mark loading w/ nested selection that is undefined', () => {
+    const { result } = renderHook(() =>
+      useFragment({
+        query: `
+          fragment TodoFields on Todo {
+            id
+            name
+            __typename
+            author { id name __typename }
+          }`,
+        data: {
+          __typename: 'Todo',
+          id: '1',
+          name: null,
+          completed: true,
+          author: undefined,
+        },
+      })
+    );
+
+    expect(result.current).toEqual({
+      fetching: true,
+      data: {
+        __typename: 'Todo',
+        id: '1',
+        name: null,
+      },
+    });
+  });
+
+  it('should correctly mark resolved w/ deferred nested fragment-selection that is undefined', () => {
+    const { result } = renderHook(() =>
+      useFragment({
+        query: `
+          fragment TodoFields on Todo {
+            id
+            name
+            __typename
+            ...AuthorFields @defer
+          }
+
+          fragment AuthorFields on Todo { author { id name __typename } }
+        `,
+        data: {
+          __typename: 'Todo',
+          id: '1',
+          name: null,
+          completed: true,
+          author: undefined,
+        },
+      })
+    );
+
+    expect(result.current).toEqual({
+      fetching: false,
+      data: {
+        __typename: 'Todo',
+        id: '1',
+        name: null,
+      },
+    });
+  });
+
+  it('should correctly mark loading w/ non-deferred nested fragment-selection that is undefined', () => {
+    const { result } = renderHook(() =>
+      useFragment({
+        query: `
+          fragment TodoFields on Todo {
+            id
+            name
+            __typename
+            ...AuthorFields
+          }
+
+          fragment AuthorFields on Todo { author { id name __typename } }
+        `,
+        data: {
+          __typename: 'Todo',
+          id: '1',
+          name: null,
+          completed: true,
+          author: undefined,
+        },
+      })
+    );
+
+    expect(result.current).toEqual({
+      fetching: true,
+      data: {
+        __typename: 'Todo',
+        id: '1',
+        name: null,
+      },
+    });
+  });
+
+  it('returns null data without masking when data is null', () => {
+    const { result } = renderHook(() =>
+      useFragment({ query: mockQuery, data: null })
+    );
+
+    expect(result.current).toEqual({ fetching: false, data: null });
+  });
+});
+
+describe('useFragment suspense', () => {
+  const Song = ({ data }: { data: any }) => {
+    const result = useFragment<any>({
+      query: `fragment SongFields on Song { id title __typename }`,
+      data,
+      context: { suspense: true },
+    });
+    return <p>{result.data ? result.data.title : 'no-title'}</p>;
+  };
+
+  it('suspends while a deferred field is missing, then renders once it arrives', async () => {
+    const incomplete = { __typename: 'Song', id: '1', title: undefined };
+    const complete = { __typename: 'Song', id: '1', title: 'Hello' };
+
+    const view = render(
+      <Suspense fallback={<p>loading</p>}>
+        <Song data={incomplete} />
+      </Suspense>
+    );
+
+    // The fragment isn't fulfilled yet, so the boundary shows its fallback.
+    expect(view.container.textContent).toBe('loading');
+
+    // The deferred patch arrives: the parent re-renders with the merged data.
+    view.rerender(
+      <Suspense fallback={<p>loading</p>}>
+        <Song data={complete} />
+      </Suspense>
+    );
+    // Flush the resolution of the suspense promise inside act(...).
+    await act(async () => {});
+
+    expect(view.container.textContent).toBe('Hello');
+  });
+
+  it('does not suspend when the data is already complete', () => {
+    const complete = { __typename: 'Song', id: '2', title: 'World' };
+
+    const view = render(
+      <Suspense fallback={<p>loading</p>}>
+        <Song data={complete} />
+      </Suspense>
+    );
+
+    expect(view.container.textContent).toBe('World');
+  });
+
+  it('suspends siblings independently by their entity identity', async () => {
+    const view = render(
+      <Suspense fallback={<p>loading</p>}>
+        <Song data={{ __typename: 'Song', id: 'a', title: 'A' }} />
+        <Song data={{ __typename: 'Song', id: 'b', title: undefined }} />
+      </Suspense>
+    );
+
+    // One sibling is still pending, so the shared boundary shows the fallback.
+    expect(view.container.textContent).toBe('loading');
+
+    view.rerender(
+      <Suspense fallback={<p>loading</p>}>
+        <Song data={{ __typename: 'Song', id: 'a', title: 'A' }} />
+        <Song data={{ __typename: 'Song', id: 'b', title: 'B' }} />
+      </Suspense>
+    );
+    await act(async () => {});
+
+    expect(view.container.textContent).toBe('AB');
+  });
+
+  it('resolves deferred fragment suspense from the query stream without a parent rerender', async () => {
+    const client = useClient() as any;
+    const subject = makeSubject<any>();
+    client.suspense = true;
+    client.executeQuery = vi.fn(() => subject.source);
+
+    const SongFromQuery = () => {
+      const [queryResult] = useQuery<any>({
+        query: `
+          query {
+            song {
+              id
+              __typename
+              ...SongFields @defer
+            }
+          }
+
+          fragment SongFields on Song {
+            title
+          }
+        `,
+      });
+
+      const fragment = useFragment<any>({
+        query: `fragment SongFields on Song { title }`,
+        data: queryResult.data.song,
+      });
+
+      return <p>{fragment.data.title}</p>;
+    };
+
+    const view = render(
+      <Suspense fallback={<p>loading</p>}>
+        <SongFromQuery />
+      </Suspense>
+    );
+
+    expect(view.container.textContent).toBe('loading');
+
+    act(() => {
+      subject.next({
+        data: { song: { __typename: 'Song', id: '1' } },
+        hasNext: true,
+        stale: false,
+      });
+    });
+    await act(async () => {});
+
+    expect(view.container.textContent).toBe('loading');
+
+    act(() => {
+      subject.next({
+        data: {
+          song: { __typename: 'Song', id: '1', title: 'Hello' },
+        },
+        hasNext: false,
+        stale: false,
+      });
+    });
+    await act(async () => {});
+
+    expect(view.container.textContent).toBe('Hello');
+  });
+});

--- a/packages/react-urql/src/hooks/useFragment.test.tsx
+++ b/packages/react-urql/src/hooks/useFragment.test.tsx
@@ -88,6 +88,35 @@ describe('useFragment masking', () => {
     });
   });
 
+  it('updates the masked data when the fragment name changes', () => {
+    const query = `
+      fragment TodoIdentity on Todo { id __typename }
+      fragment TodoDetails on Todo { name __typename }
+    `;
+    const data = {
+      __typename: 'Todo',
+      id: '1',
+      name: 'Learn urql',
+    };
+
+    const { result, rerender } = renderHook(
+      ({ name }) => useFragment({ query, name, data }),
+      { initialProps: { name: 'TodoIdentity' } }
+    );
+
+    expect(result.current).toEqual({
+      fetching: false,
+      data: { __typename: 'Todo', id: '1' },
+    });
+
+    rerender({ name: 'TodoDetails' });
+
+    expect(result.current).toEqual({
+      fetching: false,
+      data: { __typename: 'Todo', name: 'Learn urql' },
+    });
+  });
+
   it('should correctly mask data w/ null attribute', () => {
     const { result } = renderHook(() =>
       useFragment({

--- a/packages/react-urql/src/hooks/useFragment.test.tsx
+++ b/packages/react-urql/src/hooks/useFragment.test.tsx
@@ -376,9 +376,11 @@ describe('useFragment masking', () => {
 });
 
 describe('useFragment suspense', () => {
+  const SongFields = `fragment SongFields on Song { id title __typename }`;
+
   const Song = ({ data }: { data: any }) => {
     const result = useFragment<any>({
-      query: `fragment SongFields on Song { id title __typename }`,
+      query: SongFields,
       data,
       context: { suspense: true },
     });
@@ -408,6 +410,80 @@ describe('useFragment suspense', () => {
     await act(async () => {});
 
     expect(view.container.textContent).toBe('Hello');
+  });
+
+  it('does not share suspense promises between unidentified objects', () => {
+    const client = useClient() as any;
+    const first = { title: undefined };
+    const second = { title: undefined };
+    const request = createRequest(SongFields, {});
+
+    render(
+      <Suspense fallback={<p>loading</p>}>
+        <Song data={first} />
+      </Suspense>
+    );
+    const firstPromise = client._fragments.get(
+      request.key,
+      'SongFields',
+      first
+    );
+
+    render(
+      <Suspense fallback={<p>loading</p>}>
+        <Song data={second} />
+      </Suspense>
+    );
+    const secondPromise = client._fragments.get(
+      request.key,
+      'SongFields',
+      second
+    );
+
+    expect(firstPromise).toBeInstanceOf(Promise);
+    expect(secondPromise).toBeInstanceOf(Promise);
+    expect(secondPromise).not.toBe(firstPromise);
+  });
+
+  it('scopes suspense promises by fragment name', () => {
+    const client = useClient() as any;
+    const query = `
+      fragment SongTitle on Song { title }
+      fragment SongArtist on Song { artist }
+    `;
+    const data = {
+      __typename: 'Song',
+      id: '1',
+      title: undefined,
+      artist: undefined,
+    };
+    const request = createRequest(query, {});
+    const Fragment = ({ name }: { name: string }) => {
+      useFragment({ query, name, data, context: { suspense: true } });
+      return null;
+    };
+
+    render(
+      <Suspense fallback={<p>loading</p>}>
+        <Fragment name="SongTitle" />
+      </Suspense>
+    );
+    const titlePromise = client._fragments.get(request.key, 'SongTitle', data);
+
+    render(
+      <Suspense fallback={<p>loading</p>}>
+        <Fragment name="SongArtist" />
+      </Suspense>
+    );
+    const artistPromise = client._fragments.get(
+      request.key,
+      'SongArtist',
+      data
+    );
+
+    expect(titlePromise).toBeInstanceOf(Promise);
+    expect(artistPromise).toBeInstanceOf(Promise);
+    expect(artistPromise).not.toBe(titlePromise);
   });
 
   it('does not suspend when the data is already complete', () => {

--- a/packages/react-urql/src/hooks/useFragment.test.tsx
+++ b/packages/react-urql/src/hooks/useFragment.test.tsx
@@ -14,8 +14,11 @@ import React, { Suspense } from 'react';
 import { renderHook, render, act, cleanup } from '@testing-library/react';
 import { makeSubject } from 'wonka';
 import { createRequest } from '@urql/core';
+import type { TypedDocumentNode } from '@urql/core';
 
+import { getFragmentPromise } from './cache';
 import { useFragment } from './useFragment';
+import type { UseFragmentState } from './useFragment';
 import { useQuery } from './useQuery';
 import { useClient } from '../context';
 
@@ -26,6 +29,41 @@ const mockQuery = `
     __typename
   }
 `;
+
+type FilmData = { __typename: 'Film'; id: string; title: string };
+declare const tadaFragmentRefs: unique symbol;
+type TadaFragmentOf = {
+  readonly [tadaFragmentRefs]: { FilmItem: 'Film' };
+};
+type Incremental<Data> =
+  | Data
+  | { [Key in keyof Data]?: Key extends '__typename' ? Data[Key] : never };
+type CodegenFragmentType<Data> = {
+  ' $fragmentRefs'?: { FilmItemFragment: Data };
+};
+
+// Compile-time coverage for gql.tada's opaque FragmentOf shape and GraphQL
+// Code Generator's incremental FragmentType shape. The fragment document alone
+// determines the returned data type; the masked input has its own generic.
+const useCheckFragmentReferenceInterop = (
+  tadaFragment: TypedDocumentNode<FilmData, never>,
+  codegenFragment: TypedDocumentNode<FilmData, unknown>,
+  tada: TadaFragmentOf | null | undefined,
+  codegen:
+    | CodegenFragmentType<Incremental<FilmData>>
+    | Record<PropertyKey, never>
+) => {
+  const tadaResult: UseFragmentState<FilmData> = useFragment({
+    fragment: tadaFragment,
+    data: tada,
+  });
+  const codegenResult: UseFragmentState<FilmData> = useFragment({
+    fragment: codegenFragment,
+    data: codegen,
+  });
+  return [tadaResult, codegenResult];
+};
+void useCheckFragmentReferenceInterop;
 
 beforeEach(() => {
   cleanup();
@@ -41,9 +79,9 @@ beforeEach(() => {
 describe('useFragment masking', () => {
   it('should correctly mask data', () => {
     const { result } = renderHook(
-      ({ query }) =>
+      ({ fragment }) =>
         useFragment({
-          query,
+          fragment,
           data: {
             __typename: 'Todo',
             id: '1',
@@ -51,7 +89,7 @@ describe('useFragment masking', () => {
             completed: true,
           },
         }),
-      { initialProps: { query: mockQuery } }
+      { initialProps: { fragment: mockQuery } }
     );
 
     expect(result.current).toEqual({
@@ -67,7 +105,7 @@ describe('useFragment masking', () => {
   it('should correctly take a named fragment to mask data', () => {
     const { result } = renderHook(() =>
       useFragment({
-        query: `fragment x on X { foo bar } fragment TodoFields on Todo { id name __typename }`,
+        fragment: `fragment x on X { foo bar } fragment TodoFields on Todo { id name __typename }`,
         name: 'TodoFields',
         data: {
           __typename: 'Todo',
@@ -100,7 +138,7 @@ describe('useFragment masking', () => {
     };
 
     const { result, rerender } = renderHook(
-      ({ name }) => useFragment({ query, name, data }),
+      ({ name }) => useFragment({ fragment: query, name, data }),
       { initialProps: { name: 'TodoIdentity' } }
     );
 
@@ -120,7 +158,7 @@ describe('useFragment masking', () => {
   it('should correctly mask data w/ null attribute', () => {
     const { result } = renderHook(() =>
       useFragment({
-        query: mockQuery,
+        fragment: mockQuery,
         data: { __typename: 'Todo', id: '1', name: null, completed: true },
       })
     );
@@ -138,7 +176,7 @@ describe('useFragment masking', () => {
   it('should correctly indicate loading w/ undefined attribute', () => {
     const { result } = renderHook(() =>
       useFragment({
-        query: mockQuery,
+        fragment: mockQuery,
         data: {
           __typename: 'Todo',
           id: '1',
@@ -160,7 +198,7 @@ describe('useFragment masking', () => {
   it('should correctly mask data w/ nested object', () => {
     const { result } = renderHook(() =>
       useFragment({
-        query: `
+        fragment: `
           fragment TodoFields on Todo {
             id
             name
@@ -200,7 +238,7 @@ describe('useFragment masking', () => {
   it('should correctly mask data w/ nested selection that is null', () => {
     const { result } = renderHook(() =>
       useFragment({
-        query: `
+        fragment: `
           fragment TodoFields on Todo {
             id
             name
@@ -231,7 +269,7 @@ describe('useFragment masking', () => {
   it('should preserve null items in nullable lists', () => {
     const { result } = renderHook(() =>
       useFragment({
-        query: `
+        fragment: `
           fragment TodoFields on Todo {
             id
             __typename
@@ -273,7 +311,7 @@ describe('useFragment masking', () => {
   it('should correctly mark loading w/ nested selection that is undefined', () => {
     const { result } = renderHook(() =>
       useFragment({
-        query: `
+        fragment: `
           fragment TodoFields on Todo {
             id
             name
@@ -303,7 +341,7 @@ describe('useFragment masking', () => {
   it('should correctly mark resolved w/ deferred nested fragment-selection that is undefined', () => {
     const { result } = renderHook(() =>
       useFragment({
-        query: `
+        fragment: `
           fragment TodoFields on Todo {
             id
             name
@@ -336,7 +374,7 @@ describe('useFragment masking', () => {
   it('should correctly mark loading w/ non-deferred nested fragment-selection that is undefined', () => {
     const { result } = renderHook(() =>
       useFragment({
-        query: `
+        fragment: `
           fragment TodoFields on Todo {
             id
             name
@@ -368,10 +406,18 @@ describe('useFragment masking', () => {
 
   it('returns null data without masking when data is null', () => {
     const { result } = renderHook(() =>
-      useFragment({ query: mockQuery, data: null })
+      useFragment({ fragment: mockQuery, data: null })
     );
 
     expect(result.current).toEqual({ fetching: false, data: null });
+  });
+
+  it('returns undefined data without masking when data is undefined', () => {
+    const { result } = renderHook(() =>
+      useFragment({ fragment: mockQuery, data: undefined })
+    );
+
+    expect(result.current).toEqual({ fetching: false, data: undefined });
   });
 });
 
@@ -380,7 +426,7 @@ describe('useFragment suspense', () => {
 
   const Song = ({ data }: { data: any }) => {
     const result = useFragment<any>({
-      query: SongFields,
+      fragment: SongFields,
       data,
       context: { suspense: true },
     });
@@ -417,28 +463,21 @@ describe('useFragment suspense', () => {
     const first = { title: undefined };
     const second = { title: undefined };
     const request = createRequest(SongFields, {});
+    const fragment = request.query.definitions[0] as any;
 
     render(
       <Suspense fallback={<p>loading</p>}>
         <Song data={first} />
       </Suspense>
     );
-    const firstPromise = client._fragments.get(
-      request.key,
-      'SongFields',
-      first
-    );
+    const firstPromise = getFragmentPromise(client, fragment, first);
 
     render(
       <Suspense fallback={<p>loading</p>}>
         <Song data={second} />
       </Suspense>
     );
-    const secondPromise = client._fragments.get(
-      request.key,
-      'SongFields',
-      second
-    );
+    const secondPromise = getFragmentPromise(client, fragment, second);
 
     expect(firstPromise).toBeInstanceOf(Promise);
     expect(secondPromise).toBeInstanceOf(Promise);
@@ -458,8 +497,18 @@ describe('useFragment suspense', () => {
       artist: undefined,
     };
     const request = createRequest(query, {});
+    const fragments = request.query.definitions;
+    const fragmentByName = (name: string) =>
+      fragments.find(
+        fragment => 'name' in fragment && fragment.name?.value === name
+      ) as any;
     const Fragment = ({ name }: { name: string }) => {
-      useFragment({ query, name, data, context: { suspense: true } });
+      useFragment({
+        fragment: query,
+        name,
+        data,
+        context: { suspense: true },
+      });
       return null;
     };
 
@@ -468,16 +517,20 @@ describe('useFragment suspense', () => {
         <Fragment name="SongTitle" />
       </Suspense>
     );
-    const titlePromise = client._fragments.get(request.key, 'SongTitle', data);
+    const titlePromise = getFragmentPromise(
+      client,
+      fragmentByName('SongTitle'),
+      data
+    );
 
     render(
       <Suspense fallback={<p>loading</p>}>
         <Fragment name="SongArtist" />
       </Suspense>
     );
-    const artistPromise = client._fragments.get(
-      request.key,
-      'SongArtist',
+    const artistPromise = getFragmentPromise(
+      client,
+      fragmentByName('SongArtist'),
       data
     );
 
@@ -520,6 +573,98 @@ describe('useFragment suspense', () => {
     expect(view.container.textContent).toBe('AB');
   });
 
+  it('suspends siblings without entity IDs independently', async () => {
+    const Title = ({ data }: { data: any }) => {
+      const result = useFragment<any>({
+        fragment: `fragment TitleFields on Song { title __typename }`,
+        data,
+        context: { suspense: true },
+      });
+      return <p>{result.data.title}</p>;
+    };
+    const first: { __typename: string; title: string | undefined } = {
+      __typename: 'Song',
+      title: undefined,
+    };
+    const second: { __typename: string; title: string | undefined } = {
+      __typename: 'Song',
+      title: undefined,
+    };
+
+    const view = render(
+      <>
+        <Suspense fallback={<p>loading-first</p>}>
+          <Title data={first} />
+        </Suspense>
+        <Suspense fallback={<p>loading-second</p>}>
+          <Title data={second} />
+        </Suspense>
+      </>
+    );
+    expect(view.container.textContent).toBe('loading-firstloading-second');
+
+    first.title = 'First';
+    view.rerender(
+      <>
+        <Suspense fallback={<p>loading-first</p>}>
+          <Title data={first} />
+        </Suspense>
+        <Suspense fallback={<p>loading-second</p>}>
+          <Title data={second} />
+        </Suspense>
+      </>
+    );
+    await act(async () => {});
+    expect(view.container.textContent).toBe('Firstloading-second');
+  });
+
+  it('keeps named fragments in one document independent', async () => {
+    const document = `
+      fragment TitleFields on Song { title __typename }
+      fragment ArtistFields on Song { artist __typename }
+    `;
+    const data = {
+      __typename: 'Song',
+      title: undefined as string | undefined,
+      artist: undefined as string | undefined,
+    };
+    const Field = ({ name }: { name: string }) => {
+      const result = useFragment<any>({
+        fragment: document,
+        name,
+        data,
+        context: { suspense: true },
+      });
+      return <p>{result.data.title || result.data.artist}</p>;
+    };
+
+    const view = render(
+      <>
+        <Suspense fallback={<p>loading-title</p>}>
+          <Field name="TitleFields" />
+        </Suspense>
+        <Suspense fallback={<p>loading-artist</p>}>
+          <Field name="ArtistFields" />
+        </Suspense>
+      </>
+    );
+    expect(view.container.textContent).toBe('loading-titleloading-artist');
+
+    data.title = 'Hello';
+    view.rerender(
+      <>
+        <Suspense fallback={<p>loading-title</p>}>
+          <Field name="TitleFields" />
+        </Suspense>
+        <Suspense fallback={<p>loading-artist</p>}>
+          <Field name="ArtistFields" />
+        </Suspense>
+      </>
+    );
+    await act(async () => {});
+    expect(view.container.textContent).toBe('Helloloading-artist');
+  });
+
   it('resolves deferred fragment suspense from the query stream without a parent rerender', async () => {
     const client = useClient() as any;
     const subject = makeSubject<any>();
@@ -544,7 +689,7 @@ describe('useFragment suspense', () => {
       });
 
       const fragment = useFragment<any>({
-        query: `fragment SongFields on Song { title }`,
+        fragment: `fragment SongFields on Song { title }`,
         data: queryResult.data.song,
       });
 

--- a/packages/react-urql/src/hooks/useFragment.ts
+++ b/packages/react-urql/src/hooks/useFragment.ts
@@ -1,0 +1,396 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+
+import * as React from 'react';
+import type {
+  FragmentDefinitionNode,
+  InlineFragmentNode,
+  SelectionSetNode,
+} from '@0no-co/graphql.web';
+import { Kind } from '@0no-co/graphql.web';
+
+import type {
+  GraphQLRequestParams,
+  AnyVariables,
+  Client,
+  OperationContext,
+  GraphQLRequest,
+} from '@urql/core';
+
+import { useClient } from '../context';
+import { useRequest } from './useRequest';
+import type { FragmentPromise } from './cache';
+import { getFragmentCacheForClient } from './cache';
+import { isDeferredPromise } from './defer';
+
+import { hasDepsChanged } from './state';
+
+/** Input arguments for the {@link useFragment} hook. */
+export type UseFragmentArgs<Data = any> = {
+  /** Partial {@link OperationContext} used to configure this hook.
+   *
+   * @remarks
+   * Unlike {@link useQuery}, `useFragment` doesn’t execute a GraphQL operation,
+   * so only `context.suspense` is read here. When set, it overrides the
+   * {@link Client.suspense} flag for this hook and controls whether it suspends
+   * while a fragment’s deferred data is still incomplete.
+   *
+   * @example
+   * ```ts
+   * const result = useFragment({
+   *   query,
+   *   data,
+   *   context: { suspense: true },
+   * });
+   * ```
+   */
+  context?: Partial<OperationContext>;
+  /** A GraphQL document to mask this fragment against.
+   *
+   * @remarks
+   * This Document should contain atleast one FragmentDefinitionNode or
+   * a FragmentDefinitionNode with the same name as the `name` property.
+   */
+  query: GraphQLRequestParams<Data, AnyVariables>['query'];
+  /** A JSON object which we will extract properties from to get to the
+   * masked fragment.
+   */
+  data: Data | null;
+  /** An optional name of the fragment to use from the passed Document. */
+  name?: string;
+};
+
+/** State of the current query, your {@link useFragment} hook is executing.
+ *
+ * @remarks
+ * `UseFragmentState` is returned by {@link useFragment} and
+ * gives you the masked data for the fragment.
+ */
+export interface UseFragmentState<Data> {
+  /** Indicates whether `useFragment` is waiting for a new result.
+   *
+   * @remarks
+   * When `useFragment` is masking a fragment whose data isn’t fully present
+   * yet — for instance while a `@defer`-red part of it is still streaming in —
+   * `fetching` is set to `true` until the remaining data arrives.
+   */
+  fetching: boolean;
+  /** The data for the masked fragment. */
+  data?: Data | null;
+}
+
+const EMPTY_VARIABLES: AnyVariables = {};
+
+const isSuspense = (client: Client, context?: Partial<OperationContext>) =>
+  context && context.suspense !== undefined
+    ? !!context.suspense
+    : client.suspense;
+
+/** Derives a cache key for a fragment’s suspense promise.
+ *
+ * @remarks
+ * The base {@link GraphQLRequest.key} only identifies the fragment document, so
+ * it’s shared across every `useFragment` hook using the same fragment. To avoid
+ * sibling hooks (e.g. items in a list) sharing — and prematurely resolving —
+ * each other’s suspense promises, we fold the entity’s identity (`__typename`
+ * and `id`/`_id`) into the key when it’s available.
+ */
+const getFragmentCacheKey = (
+  request: GraphQLRequest<any, AnyVariables>,
+  data: any
+): number => {
+  let key = request.key;
+  if (data && typeof data === 'object' && !Array.isArray(data)) {
+    const id = data.id != null ? data.id : data._id;
+    if (data.__typename != null && id != null) {
+      const identity = `${data.__typename}:${id}`;
+      for (let i = 0, l = identity.length; i < l; i++)
+        key = (key << 5) + key + identity.charCodeAt(i);
+    }
+  }
+  return key;
+};
+
+/** Hook to mask a GraphQL Fragment given its data. (BETA)
+ *
+ * @param args - a {@link UseFragmentArgs} object, to pass a `fragment` and `data`.
+ * @returns a {@link UseFragmentState} result.
+ *
+ * @remarks
+ * `useFragment` allows GraphQL fragments to mask their data.
+ * Given {@link UseFragmentArgs.query} and {@link UseFragmentArgs.data}, it will
+ * return the masked data for the fragment contained in query.
+ *
+ * Additionally, if the `suspense` option is enabled on the `Client`,
+ * the `useFragment` hook will suspend instead of indicating that it’s
+ * waiting for a result via {@link UseFragmentState.fetching}. This is useful
+ * to render `@defer`-red parts of a query incrementally as they stream in.
+ *
+ * @example
+ * ```ts
+ * import { gql, useFragment } from 'urql';
+ *
+ * const TodoFields = gql`
+ *   fragment TodoFields on Todo { id name }
+ * `;
+ *
+ * const Todo = (props) => {
+ *   const result = useFragment({
+ *     data: props.todo,
+ *     query: TodoFields,
+ *   });
+ *   // ...
+ * };
+ * ```
+ */
+export function useFragment<Data>(
+  args: UseFragmentArgs<Data>
+): UseFragmentState<Data> {
+  const client = useClient();
+  const cache = getFragmentCacheForClient(client);
+  const suspense = isSuspense(client, args.context);
+
+  const request = useRequest(args.query, EMPTY_VARIABLES);
+
+  const fragment = React.useMemo(() => {
+    return request.query.definitions.find(
+      x =>
+        x.kind === Kind.FRAGMENT_DEFINITION &&
+        ((args.name && x.name.value === args.name) || !args.name)
+    ) as FragmentDefinitionNode | undefined;
+  }, [request.query, args.name]);
+
+  if (!fragment) {
+    throw new Error(
+      `Passed document did not contain a fragment definition${
+        args.name ? ` for "${args.name}"` : ''
+      }.`
+    );
+  }
+
+  const fragments = React.useMemo(() => {
+    return request.query.definitions.reduce<
+      Record<string, FragmentDefinitionNode>
+    >((acc, frag) => {
+      if (frag.kind === Kind.FRAGMENT_DEFINITION) {
+        acc[frag.name.value] = frag;
+      }
+      return acc;
+    }, {});
+  }, [request.query]);
+
+  const getSnapshot = React.useCallback(
+    (
+      request: GraphQLRequest<Data, AnyVariables>,
+      data: Data | null,
+      suspense: boolean
+    ): UseFragmentState<Data> => {
+      if (data === null) {
+        return { data: null, fetching: false };
+      } else if (!suspense) {
+        const newResult = maskFragment<Data>(
+          data,
+          fragment.selectionSet,
+          fragments
+        );
+
+        return { data: newResult.data, fetching: !newResult.fulfilled };
+      }
+
+      const key = getFragmentCacheKey(request, data);
+      const cached = cache.get(key);
+      const newResult = maskFragment<Data>(
+        data,
+        fragment.selectionSet,
+        fragments
+      );
+
+      if (newResult.fulfilled) {
+        if (cached) {
+          cached._resolve();
+          cache.dispose(key);
+        }
+        return { data: newResult.data, fetching: false };
+      } else if (newResult.pending) {
+        // The query stream owns this promise and will resolve it directly when
+        // the deferred patch is merged, which also works during server streams.
+        throw newResult.pending;
+      } else if (cached) {
+        // We're still waiting on data and already suspended once; re-throw the
+        // same promise so React keeps showing the suspense boundary's fallback.
+        throw cached;
+      } else {
+        let _resolve!: () => void;
+        const promise = new Promise(resolve => {
+          _resolve = () => resolve(undefined);
+        }) as FragmentPromise;
+        promise._resolve = _resolve;
+        cache.set(key, promise);
+        throw promise;
+      }
+    },
+    [cache, fragment, fragments]
+  );
+
+  const deps = [client, request, args.data, suspense] as const;
+
+  const [state, setState] = React.useState(
+    () => [getSnapshot(request, args.data, suspense), deps] as const
+  );
+
+  const currentResult = state[0];
+  if (hasDepsChanged(state[1], deps)) {
+    setState([getSnapshot(request, args.data, suspense), deps]);
+  }
+
+  return currentResult;
+}
+
+const maskFragment = <Data>(
+  data: Data,
+  selectionSet: SelectionSetNode,
+  fragments: Record<string, FragmentDefinitionNode>
+): { data: Data; fulfilled: boolean; pending?: Promise<unknown> } => {
+  const maskedData = {};
+  let isDataComplete = true;
+  let pending: Promise<unknown> | undefined;
+
+  selectionSet.selections.forEach(selection => {
+    const hasIncludeOrSkip =
+      selection.directives &&
+      selection.directives.some(
+        x => x.name.value === 'include' || x.name.value === 'skip'
+      );
+
+    if (selection.kind === Kind.FIELD) {
+      const fieldAlias = selection.alias
+        ? selection.alias.value
+        : selection.name.value;
+
+      let value = data[fieldAlias];
+      if (isDeferredPromise(value)) {
+        if (!value._resolved) {
+          // The deferred patch hasn't arrived yet; suspend on the stream-owned
+          // promise. `useQuery` resolves it directly when the patch is merged.
+          // The promise is preserved on the masked data so that a nested
+          // `useFragment` rendering this field can suspend on it in turn.
+          isDataComplete = false;
+          if (!pending) pending = value;
+          maskedData[fieldAlias] = value;
+          return;
+        }
+        // The deferred patch has streamed in: read its value directly off the
+        // resolved promise, rather than relying on a parent rerender to hand
+        // down fresh data via props (which doesn't happen during SSR streams).
+        value = value._value;
+      }
+
+      if (value === undefined) {
+        if (hasIncludeOrSkip) return;
+        isDataComplete = false;
+      } else if (value === null) {
+        maskedData[fieldAlias] = null;
+      } else if (Array.isArray(value)) {
+        if (selection.selectionSet) {
+          maskedData[fieldAlias] = value.map(item => {
+            const result = maskFragment(
+              item,
+              selection.selectionSet as SelectionSetNode,
+              fragments
+            );
+
+            if (!result.fulfilled) {
+              isDataComplete = false;
+              if (!pending) pending = result.pending;
+            }
+
+            return result.data;
+          });
+        } else {
+          maskedData[fieldAlias] = value.map(item => item);
+        }
+      } else {
+        if (selection.selectionSet) {
+          const result = maskFragment(value, selection.selectionSet, fragments);
+
+          if (!result.fulfilled) {
+            isDataComplete = false;
+            if (!pending) pending = result.pending;
+          }
+
+          maskedData[fieldAlias] = result.data;
+        } else {
+          maskedData[fieldAlias] = value;
+        }
+      }
+    } else if (selection.kind === Kind.INLINE_FRAGMENT) {
+      if (!isHeuristicFragmentMatch(selection, data, fragments)) {
+        return;
+      }
+
+      const hasDefer =
+        selection.directives &&
+        selection.directives.some(x => x.name.value === 'defer');
+
+      const result = maskFragment(data, selection.selectionSet, fragments);
+      if (!result.fulfilled && !hasIncludeOrSkip && !hasDefer) {
+        isDataComplete = false;
+        if (!pending) pending = result.pending;
+      }
+
+      Object.assign(maskedData, result.data);
+    } else if (selection.kind === Kind.FRAGMENT_SPREAD) {
+      const fragment = fragments[selection.name.value];
+
+      const hasDefer =
+        selection.directives &&
+        selection.directives.some(x => x.name.value === 'defer');
+
+      if (!fragment || !isHeuristicFragmentMatch(fragment, data, fragments)) {
+        return;
+      }
+
+      const result = maskFragment(data, fragment.selectionSet, fragments);
+      if (!result.fulfilled && !hasIncludeOrSkip && !hasDefer) {
+        isDataComplete = false;
+        if (!pending) pending = result.pending;
+      }
+      Object.assign(maskedData, result.data);
+    }
+  });
+
+  return { data: maskedData as Data, fulfilled: isDataComplete, pending };
+};
+
+const isHeuristicFragmentMatch = (
+  fragment: InlineFragmentNode | FragmentDefinitionNode,
+  data: any,
+  fragments: Record<string, FragmentDefinitionNode>
+): boolean => {
+  if (
+    !fragment.typeCondition ||
+    fragment.typeCondition.name.value === data.__typename
+  )
+    return true;
+
+  return fragment.selectionSet.selections.every(selection => {
+    if (selection.kind === Kind.FIELD) {
+      const fieldAlias = selection.alias
+        ? selection.alias.value
+        : selection.name.value;
+      const couldBeExcluded =
+        selection.directives &&
+        selection.directives.some(
+          x =>
+            x.name.value === 'include' ||
+            x.name.value === 'skip' ||
+            x.name.value === 'defer'
+        );
+      return data[fieldAlias] !== undefined && !couldBeExcluded;
+    } else if (selection.kind === Kind.INLINE_FRAGMENT) {
+      return isHeuristicFragmentMatch(selection, data, fragments);
+    } else if (selection.kind === Kind.FRAGMENT_SPREAD) {
+      const fragment = fragments[selection.name.value];
+      return !!fragment && isHeuristicFragmentMatch(fragment, data, fragments);
+    }
+  });
+};

--- a/packages/react-urql/src/hooks/useFragment.ts
+++ b/packages/react-urql/src/hooks/useFragment.ts
@@ -3,7 +3,6 @@
 import * as React from 'react';
 import type {
   FragmentDefinitionNode,
-  InlineFragmentNode,
   SelectionSetNode,
 } from '@0no-co/graphql.web';
 import { Kind } from '@0no-co/graphql.web';
@@ -21,6 +20,14 @@ import { useRequest } from './useRequest';
 import type { FragmentPromise } from './cache';
 import { getFragmentCacheForClient } from './cache';
 import { isDeferredPromise } from './defer';
+import {
+  getFieldKey,
+  getFragments,
+  hasDirective,
+  isHeuristicFragmentMatch,
+  isOptionalSelection,
+  type FragmentMap,
+} from './selection';
 
 import { hasDepsChanged } from './state';
 
@@ -167,16 +174,10 @@ export function useFragment<Data>(
     );
   }
 
-  const fragments = React.useMemo(() => {
-    return request.query.definitions.reduce<
-      Record<string, FragmentDefinitionNode>
-    >((acc, frag) => {
-      if (frag.kind === Kind.FRAGMENT_DEFINITION) {
-        acc[frag.name.value] = frag;
-      }
-      return acc;
-    }, {});
-  }, [request.query]);
+  const fragments = React.useMemo(
+    () => getFragments(request.query.definitions),
+    [request.query]
+  );
 
   const getSnapshot = React.useCallback(
     (
@@ -248,23 +249,17 @@ export function useFragment<Data>(
 const maskFragment = <Data>(
   data: Data,
   selectionSet: SelectionSetNode,
-  fragments: Record<string, FragmentDefinitionNode>
+  fragments: FragmentMap
 ): { data: Data; fulfilled: boolean; pending?: Promise<unknown> } => {
   const maskedData = {};
   let isDataComplete = true;
   let pending: Promise<unknown> | undefined;
 
   selectionSet.selections.forEach(selection => {
-    const hasIncludeOrSkip =
-      selection.directives &&
-      selection.directives.some(
-        x => x.name.value === 'include' || x.name.value === 'skip'
-      );
+    const hasIncludeOrSkip = isOptionalSelection(selection);
 
     if (selection.kind === Kind.FIELD) {
-      const fieldAlias = selection.alias
-        ? selection.alias.value
-        : selection.name.value;
+      const fieldAlias = getFieldKey(selection);
 
       let value = data[fieldAlias];
       if (isDeferredPromise(value)) {
@@ -329,9 +324,7 @@ const maskFragment = <Data>(
         return;
       }
 
-      const hasDefer =
-        selection.directives &&
-        selection.directives.some(x => x.name.value === 'defer');
+      const hasDefer = hasDirective(selection, 'defer');
 
       const result = maskFragment(data, selection.selectionSet, fragments);
       if (!result.fulfilled && !hasIncludeOrSkip && !hasDefer) {
@@ -343,9 +336,7 @@ const maskFragment = <Data>(
     } else if (selection.kind === Kind.FRAGMENT_SPREAD) {
       const fragment = fragments[selection.name.value];
 
-      const hasDefer =
-        selection.directives &&
-        selection.directives.some(x => x.name.value === 'defer');
+      const hasDefer = hasDirective(selection, 'defer');
 
       if (!fragment || !isHeuristicFragmentMatch(fragment, data, fragments)) {
         return;
@@ -361,38 +352,4 @@ const maskFragment = <Data>(
   });
 
   return { data: maskedData as Data, fulfilled: isDataComplete, pending };
-};
-
-const isHeuristicFragmentMatch = (
-  fragment: InlineFragmentNode | FragmentDefinitionNode,
-  data: any,
-  fragments: Record<string, FragmentDefinitionNode>
-): boolean => {
-  if (
-    !fragment.typeCondition ||
-    fragment.typeCondition.name.value === data.__typename
-  )
-    return true;
-
-  return fragment.selectionSet.selections.every(selection => {
-    if (selection.kind === Kind.FIELD) {
-      const fieldAlias = selection.alias
-        ? selection.alias.value
-        : selection.name.value;
-      const couldBeExcluded =
-        selection.directives &&
-        selection.directives.some(
-          x =>
-            x.name.value === 'include' ||
-            x.name.value === 'skip' ||
-            x.name.value === 'defer'
-        );
-      return data[fieldAlias] !== undefined && !couldBeExcluded;
-    } else if (selection.kind === Kind.INLINE_FRAGMENT) {
-      return isHeuristicFragmentMatch(selection, data, fragments);
-    } else if (selection.kind === Kind.FRAGMENT_SPREAD) {
-      const fragment = fragments[selection.name.value];
-      return !!fragment && isHeuristicFragmentMatch(fragment, data, fragments);
-    }
-  });
 };

--- a/packages/react-urql/src/hooks/useFragment.ts
+++ b/packages/react-urql/src/hooks/useFragment.ts
@@ -292,6 +292,8 @@ const maskFragment = <Data>(
       } else if (Array.isArray(value)) {
         if (selection.selectionSet) {
           maskedData[fieldAlias] = value.map(item => {
+            if (item === null) return null;
+
             const result = maskFragment(
               item,
               selection.selectionSet as SelectionSetNode,

--- a/packages/react-urql/src/hooks/useFragment.ts
+++ b/packages/react-urql/src/hooks/useFragment.ts
@@ -221,7 +221,7 @@ export function useFragment<Data>(
     [cache, fragment, fragments]
   );
 
-  const deps = [client, request, args.data, suspense] as const;
+  const deps = [client, request, fragment, args.data, suspense] as const;
 
   const [state, setState] = React.useState(
     () => [getSnapshot(request, args.data, suspense), deps] as const

--- a/packages/react-urql/src/hooks/useFragment.ts
+++ b/packages/react-urql/src/hooks/useFragment.ts
@@ -9,19 +9,22 @@ import type {
   AnyVariables,
   Client,
   OperationContext,
-  GraphQLRequest,
 } from '@urql/core';
 import { maskFragment, getFragments } from '@urql/core';
 
 import { useClient } from '../context';
 import { useRequest } from './useRequest';
 import type { FragmentPromise } from './cache';
-import { getFragmentCacheForClient } from './cache';
+import {
+  deleteFragmentPromise,
+  getFragmentPromise,
+  setFragmentPromise,
+} from './cache';
 
 import { hasDepsChanged } from './state';
 
 /** Input arguments for the {@link useFragment} hook. */
-export type UseFragmentArgs<Data = any> = {
+export type UseFragmentArgs<Data = any, Input = Data> = {
   /** Partial {@link OperationContext} used to configure this hook.
    *
    * @remarks
@@ -33,7 +36,7 @@ export type UseFragmentArgs<Data = any> = {
    * @example
    * ```ts
    * const result = useFragment({
-   *   query,
+   *   fragment,
    *   data,
    *   context: { suspense: true },
    * });
@@ -46,16 +49,20 @@ export type UseFragmentArgs<Data = any> = {
    * This Document should contain atleast one FragmentDefinitionNode or
    * a FragmentDefinitionNode with the same name as the `name` property.
    */
-  query: GraphQLRequestParams<Data, AnyVariables>['query'];
-  /** A JSON object which we will extract properties from to get to the
-   * masked fragment.
+  fragment: GraphQLRequestParams<Data, any>['query'];
+  /** A JSON object containing this fragment's fields.
+   *
+   * @remarks
+   * `Input` is separate from `Data` so fragment-reference types from gql.tada
+   * and GraphQL Code Generator can be passed directly. `null` and `undefined`
+   * are returned unchanged.
    */
-  data: Data | null;
+  data: Input | null | undefined;
   /** An optional name of the fragment to use from the passed Document. */
   name?: string;
 };
 
-/** State of the current query, your {@link useFragment} hook is executing.
+/** State of the fragment your {@link useFragment} hook is reading.
  *
  * @remarks
  * `UseFragmentState` is returned by {@link useFragment} and
@@ -88,8 +95,8 @@ const isSuspense = (client: Client, context?: Partial<OperationContext>) =>
  *
  * @remarks
  * `useFragment` allows GraphQL fragments to mask their data.
- * Given {@link UseFragmentArgs.query} and {@link UseFragmentArgs.data}, it will
- * return the masked data for the fragment contained in query.
+ * Given {@link UseFragmentArgs.fragment} and {@link UseFragmentArgs.data}, it
+ * returns the data selected by that fragment.
  *
  * Additionally, if the `suspense` option is enabled on the `Client`,
  * the `useFragment` hook will suspend instead of indicating that it’s
@@ -107,20 +114,19 @@ const isSuspense = (client: Client, context?: Partial<OperationContext>) =>
  * const Todo = (props) => {
  *   const result = useFragment({
  *     data: props.todo,
- *     query: TodoFields,
+ *     fragment: TodoFields,
  *   });
  *   // ...
  * };
  * ```
  */
-export function useFragment<Data>(
-  args: UseFragmentArgs<Data>
+export function useFragment<Data = any, Input = Data>(
+  args: UseFragmentArgs<Data, Input>
 ): UseFragmentState<Data> {
   const client = useClient();
-  const cache = getFragmentCacheForClient(client);
   const suspense = isSuspense(client, args.context);
 
-  const request = useRequest(args.query, EMPTY_VARIABLES);
+  const request = useRequest(args.fragment, EMPTY_VARIABLES);
 
   const fragment = React.useMemo(() => {
     return request.query.definitions.find(
@@ -145,15 +151,16 @@ export function useFragment<Data>(
 
   const getSnapshot = React.useCallback(
     (
-      request: GraphQLRequest<Data, AnyVariables>,
-      data: Data | null,
+      data: Input | null | undefined,
       suspense: boolean
     ): UseFragmentState<Data> => {
-      if (data === null) {
-        return { data: null, fetching: false };
+      if (data == null) {
+        return { data: data as null | undefined, fetching: false };
+      } else if (typeof data !== 'object' || Array.isArray(data)) {
+        throw new Error('useFragment expects data to be a fragment object.');
       } else if (!suspense) {
         const newResult = maskFragment<Data>(
-          data,
+          data as Data,
           fragment.selectionSet,
           fragments
         );
@@ -161,11 +168,9 @@ export function useFragment<Data>(
         return { data: newResult.data, fetching: !newResult.fulfilled };
       }
 
-      const key = request.key;
-      const fragmentName = fragment.name.value;
-      const cached = cache.get(key, fragmentName, data);
+      const cached = getFragmentPromise(client, fragment, data);
       const newResult = maskFragment<Data>(
-        data,
+        data as Data,
         fragment.selectionSet,
         fragments
       );
@@ -173,7 +178,7 @@ export function useFragment<Data>(
       if (newResult.fulfilled) {
         if (cached) {
           cached._resolve();
-          cache.dispose(key, fragmentName, data);
+          deleteFragmentPromise(client, fragment, data);
         }
         return { data: newResult.data, fetching: false };
       } else if (newResult.pending) {
@@ -190,22 +195,22 @@ export function useFragment<Data>(
           _resolve = () => resolve(undefined);
         }) as FragmentPromise;
         promise._resolve = _resolve;
-        cache.set(key, fragmentName, data, promise);
+        setFragmentPromise(client, fragment, data, promise);
         throw promise;
       }
     },
-    [cache, fragment, fragments]
+    [client, fragment, fragments]
   );
 
   const deps = [client, request, fragment, args.data, suspense] as const;
 
   const [state, setState] = React.useState(
-    () => [getSnapshot(request, args.data, suspense), deps] as const
+    () => [getSnapshot(args.data, suspense), deps] as const
   );
 
   const currentResult = state[0];
   if (hasDepsChanged(state[1], deps)) {
-    setState([getSnapshot(request, args.data, suspense), deps]);
+    setState([getSnapshot(args.data, suspense), deps]);
   }
 
   return currentResult;

--- a/packages/react-urql/src/hooks/useFragment.ts
+++ b/packages/react-urql/src/hooks/useFragment.ts
@@ -81,31 +81,6 @@ const isSuspense = (client: Client, context?: Partial<OperationContext>) =>
     ? !!context.suspense
     : client.suspense;
 
-/** Derives a cache key for a fragment’s suspense promise.
- *
- * @remarks
- * The base {@link GraphQLRequest.key} only identifies the fragment document, so
- * it’s shared across every `useFragment` hook using the same fragment. To avoid
- * sibling hooks (e.g. items in a list) sharing — and prematurely resolving —
- * each other’s suspense promises, we fold the entity’s identity (`__typename`
- * and `id`/`_id`) into the key when it’s available.
- */
-const getFragmentCacheKey = (
-  request: GraphQLRequest<any, AnyVariables>,
-  data: any
-): number => {
-  let key = request.key;
-  if (data && typeof data === 'object' && !Array.isArray(data)) {
-    const id = data.id != null ? data.id : data._id;
-    if (data.__typename != null && id != null) {
-      const identity = `${data.__typename}:${id}`;
-      for (let i = 0, l = identity.length; i < l; i++)
-        key = (key << 5) + key + identity.charCodeAt(i);
-    }
-  }
-  return key;
-};
-
 /** Hook to mask a GraphQL Fragment given its data. (BETA)
  *
  * @param args - a {@link UseFragmentArgs} object, to pass a `fragment` and `data`.
@@ -186,8 +161,9 @@ export function useFragment<Data>(
         return { data: newResult.data, fetching: !newResult.fulfilled };
       }
 
-      const key = getFragmentCacheKey(request, data);
-      const cached = cache.get(key);
+      const key = request.key;
+      const fragmentName = fragment.name.value;
+      const cached = cache.get(key, fragmentName, data);
       const newResult = maskFragment<Data>(
         data,
         fragment.selectionSet,
@@ -197,7 +173,7 @@ export function useFragment<Data>(
       if (newResult.fulfilled) {
         if (cached) {
           cached._resolve();
-          cache.dispose(key);
+          cache.dispose(key, fragmentName, data);
         }
         return { data: newResult.data, fetching: false };
       } else if (newResult.pending) {
@@ -214,7 +190,7 @@ export function useFragment<Data>(
           _resolve = () => resolve(undefined);
         }) as FragmentPromise;
         promise._resolve = _resolve;
-        cache.set(key, promise);
+        cache.set(key, fragmentName, data, promise);
         throw promise;
       }
     },

--- a/packages/react-urql/src/hooks/useQuery.ts
+++ b/packages/react-urql/src/hooks/useQuery.ts
@@ -18,6 +18,7 @@ import type {
 import { useClient } from '../context';
 import { useRequest } from './useRequest';
 import { getCacheForClient, getDeferredCacheForClient } from './cache';
+import type { DeferredState } from './defer';
 import {
   makeDeferredState,
   resolveDeferredState,
@@ -232,6 +233,18 @@ export function useQuery<
   const suspense = isSuspense(client, args.context);
   const request = useRequest(args.query, args.variables as Variables);
 
+  const wrapSuspenseSource = React.useCallback(
+    (source: Source<OperationResult<Data, Variables>>, state: DeferredState) =>
+      pipe(
+        source,
+        map(result => updateDeferredResult(request, result, state)),
+        onPush(result => {
+          cache.set(request.key, result);
+        })
+      ),
+    [cache, request]
+  );
+
   const source = React.useMemo(() => {
     if (args.pause) return null;
 
@@ -250,25 +263,15 @@ export function useQuery<
         deferredCache.set(request.key, deferredState);
       }
 
-      source = pipe(
-        source,
-        map(result => updateDeferredResult(request, result, deferredState!))
-      );
-
-      return pipe(
-        source,
-        onPush(result => {
-          cache.set(request.key, result);
-        })
-      );
+      return wrapSuspenseSource(source, deferredState);
     }
 
     return source;
   }, [
-    cache,
     client,
     deferredCache,
     request,
+    wrapSuspenseSource,
     suspense,
     args.pause,
     args.requestPolicy,
@@ -415,13 +418,7 @@ export function useQuery<
           const deferredState = makeDeferredState();
           deferredCache.set(request.key, deferredState);
 
-          source = pipe(
-            source,
-            map(result => updateDeferredResult(request, result, deferredState)),
-            onPush(result => {
-              cache.set(request.key, result);
-            })
-          );
+          source = wrapSuspenseSource(source, deferredState);
         }
 
         return [source, state[1], deps];
@@ -429,9 +426,9 @@ export function useQuery<
     },
     [
       client,
-      cache,
       deferredCache,
       request,
+      wrapSuspenseSource,
       suspense,
       args.requestPolicy,
       args.context,

--- a/packages/react-urql/src/hooks/useQuery.ts
+++ b/packages/react-urql/src/hooks/useQuery.ts
@@ -1,7 +1,7 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 
 import type { Source } from 'wonka';
-import { pipe, subscribe, onEnd, onPush, takeWhile } from 'wonka';
+import { pipe, subscribe, onEnd, onPush, takeWhile, map } from 'wonka';
 import * as React from 'react';
 
 import type {
@@ -17,7 +17,12 @@ import type {
 
 import { useClient } from '../context';
 import { useRequest } from './useRequest';
-import { getCacheForClient } from './cache';
+import { getCacheForClient, getDeferredCacheForClient } from './cache';
+import {
+  makeDeferredState,
+  resolveDeferredState,
+  updateDeferredResult,
+} from './defer';
 
 import {
   deferDispatch,
@@ -223,28 +228,46 @@ export function useQuery<
 >(args: UseQueryArgs<Variables, Data>): UseQueryResponse<Data, Variables> {
   const client = useClient();
   const cache = getCacheForClient(client);
+  const deferredCache = getDeferredCacheForClient(client);
   const suspense = isSuspense(client, args.context);
   const request = useRequest(args.query, args.variables as Variables);
 
   const source = React.useMemo(() => {
     if (args.pause) return null;
 
-    const source = client.executeQuery(request, {
-      requestPolicy: args.requestPolicy,
-      ...args.context,
-    });
+    let source: Source<OperationResult<Data, Variables>> = client.executeQuery(
+      request,
+      {
+        requestPolicy: args.requestPolicy,
+        ...args.context,
+      }
+    );
 
-    return suspense
-      ? pipe(
-          source,
-          onPush(result => {
-            cache.set(request.key, result);
-          })
-        )
-      : source;
+    if (suspense) {
+      let deferredState = deferredCache.get(request.key);
+      if (!deferredState) {
+        deferredState = makeDeferredState();
+        deferredCache.set(request.key, deferredState);
+      }
+
+      source = pipe(
+        source,
+        map(result => updateDeferredResult(request, result, deferredState!))
+      );
+
+      return pipe(
+        source,
+        onPush(result => {
+          cache.set(request.key, result);
+        })
+      );
+    }
+
+    return source;
   }, [
     cache,
     client,
+    deferredCache,
     request,
     suspense,
     args.pause,
@@ -382,20 +405,31 @@ export function useQuery<
       };
 
       deferDispatch(setState, state => {
-        const source = suspense
-          ? pipe(
-              client.executeQuery(request, context),
-              onPush(result => {
-                cache.set(request.key, result);
-              })
-            )
-          : client.executeQuery(request, context);
+        let source: Source<OperationResult<Data, Variables>> =
+          client.executeQuery(request, context);
+        if (suspense) {
+          const currentDeferredState = deferredCache.get(request.key);
+          if (currentDeferredState) resolveDeferredState(currentDeferredState);
+
+          const deferredState = makeDeferredState();
+          deferredCache.set(request.key, deferredState);
+
+          source = pipe(
+            source,
+            map(result => updateDeferredResult(request, result, deferredState)),
+            onPush(result => {
+              cache.set(request.key, result);
+            })
+          );
+        }
+
         return [source, state[1], deps];
       });
     },
     [
       client,
       cache,
+      deferredCache,
       request,
       suspense,
       args.requestPolicy,

--- a/packages/react-urql/src/hooks/useQuery.ts
+++ b/packages/react-urql/src/hooks/useQuery.ts
@@ -388,13 +388,14 @@ export function useQuery<
       if (!hasResult) updateResult({ fetching: true });
 
       return () => {
+        deferredCache.dispose(request.key);
         cache.dispose(request.key);
         subscription.unsubscribe();
       };
     } else {
       updateResult({ fetching: false });
     }
-  }, [cache, state[0], state[2][1]]);
+  }, [cache, deferredCache, state[0], state[2][1]]);
 
   const executeQuery = React.useCallback(
     (opts?: Partial<OperationContext>) => {

--- a/packages/react-urql/src/hooks/useQuery.ts
+++ b/packages/react-urql/src/hooks/useQuery.ts
@@ -18,12 +18,12 @@ import type {
 import { useClient } from '../context';
 import { useRequest } from './useRequest';
 import { getCacheForClient, getDeferredCacheForClient } from './cache';
-import type { DeferredState } from './defer';
+import type { DeferredState } from '@urql/core';
 import {
   makeDeferredState,
   resolveDeferredState,
   updateDeferredResult,
-} from './defer';
+} from '@urql/core';
 
 import {
   deferDispatch,
@@ -248,13 +248,11 @@ export function useQuery<
   const source = React.useMemo(() => {
     if (args.pause) return null;
 
-    let source: Source<OperationResult<Data, Variables>> = client.executeQuery(
-      request,
-      {
+    const source: Source<OperationResult<Data, Variables>> =
+      client.executeQuery(request, {
         requestPolicy: args.requestPolicy,
         ...args.context,
-      }
-    );
+      });
 
     if (suspense) {
       let deferredState = deferredCache.get(request.key);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -400,6 +400,9 @@ importers:
 
   packages/react-urql:
     dependencies:
+      '@0no-co/graphql.web':
+        specifier: ^1.0.13
+        version: 1.0.13(graphql@16.9.0)
       '@urql/core':
         specifier: workspace:^6.0.3
         version: link:../core


### PR DESCRIPTION
## Summary

- Add a beta React `useFragment` hook for masking fragment data
- Add stable stream-backed promises for missing `@defer` selections in `useQuery`
- Resolve deferred fragment Suspense from later query results without requiring a parent rerender

Refs #3628.
