### PR TITLE
docs: add Deno to install instructions

### DIFF
--- a/docs/basics/react-preact.md
+++ b/docs/basics/react-preact.md
@@ -21,6 +21,8 @@ with at first. We'll install the package with our package manager of choice.
 yarn add urql
 # or
 npm install --save urql
+# or
+deno install urql
 ```
 
 To use `urql` with Preact, we have to install `@urql/preact` instead of `urql` and import from


### PR DESCRIPTION
## Summary

👋 Bartek from the Deno team here.

The install instructions list yarn and npm, but not Deno. Since Deno is a drop-in replacement for npm these days, I'd like to add a Deno line so Deno users have a copy-pasteable command, in parity with the others:

```sh
deno install urql
```

(As of Deno 2.8 there's no `npm:` prefix needed, it's the same command shape as `npm install urql`.)

Totally fine to close this if you'd rather keep the list short, no hard feelings. Happy to adjust wording, placement, or move it elsewhere.

_Disclosure: I work on Deno, so I have an interest here. The goal is parity with the package managers you already list, not promotion. This PR was prepared with AI assistance under human supervision: I review every change myself and personally respond to any comments or review feedback._

## Set of changes

- `docs/basics/react-preact.md`: added a `deno install urql` line to the existing install snippet, alongside the `yarn add` / `npm install` commands.
