### PR TITLE
docs: fix parentTypename casing in graphcache local resolvers

### DIFF
--- a/docs/graphcache/local-resolvers.md
+++ b/docs/graphcache/local-resolvers.md
@@ -516,7 +516,7 @@ information from `info` about our field. For instance, we can:
 - Read the current field's name using `info.fieldName`
 - Read the current field's key using `info.parentFieldKey`
 - Read the current parent entity's key using `info.parentKey`
-- Read the current parent entity's typename using `info.parentTypename`
+- Read the current parent entity's typename using `info.parentTypeName`
 - Access the current operation's raw variables using `info.variables`
 - Access the current operation's raw fragments using `info.fragments`
 


### PR DESCRIPTION
The local resolvers guide reads the parent typename from `info` as `info.parentTypename`:

> Read the current parent entity's typename using `info.parentTypename`

The actual `ResolveInfo` field is **`parentTypeName`** (capital N) — see `exchanges/graphcache/src/types.ts`, and it's already spelled correctly in the API reference (`docs/api/graphcache.md`). The lowercase `info.parentTypename` doesn't exist, so copying this example returns `undefined`. Corrected the casing.