### PR TITLE
(solid-start) - Upgrade example to SolidStart 2

### DIFF
--- a/examples/with-solid-start/README.md
+++ b/examples/with-solid-start/README.md
@@ -12,6 +12,8 @@ This example demonstrates how to use URQL with SolidStart.
 
 ## Getting Started
 
+This example requires Node.js 24 or newer.
+
 ```bash
 pnpm install
 pnpm start

--- a/examples/with-solid-start/app.config.ts
+++ b/examples/with-solid-start/app.config.ts
@@ -1,3 +1,0 @@
-import { defineConfig } from '@solidjs/start/config';
-
-export default defineConfig({});

--- a/examples/with-solid-start/package.json
+++ b/examples/with-solid-start/package.json
@@ -4,20 +4,21 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "start": "vinxi dev",
-    "build": "vinxi build"
+    "start": "vite dev",
+    "build": "vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
-    "@solidjs/router": "^0.15.4",
-    "@solidjs/start": "^1.2.1",
+    "@solidjs/router": "^1.0.0",
+    "@solidjs/start": "^2.0.2",
     "@urql/core": "^6.0.3",
     "@urql/solid-start": "^0.2.0",
     "graphql": "^16.9.0",
-    "solid-js": "^1.9.10",
-    "vinxi": "^0.5.0"
+    "nitro": "^3.0.260610-beta",
+    "solid-js": "^1.9.15",
+    "vite": "^8.0.0"
   },
-  "devDependencies": {
-    "vite": "^7.3.1",
-    "vite-plugin-solid": "^2.11.10"
+  "engines": {
+    "node": ">=24"
   }
 }

--- a/examples/with-solid-start/vite.config.ts
+++ b/examples/with-solid-start/vite.config.ts
@@ -1,0 +1,7 @@
+import { solidStart } from '@solidjs/start/config';
+import { nitro } from 'nitro/vite';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  plugins: [solidStart(), nitro()],
+});

--- a/packages/solid-start-urql/package.json
+++ b/packages/solid-start-urql/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@solidjs/testing-library": "^0.8.10",
-    "@solidjs/start": "^1.2.1",
+    "@solidjs/start": "^1.3.2",
     "@urql/core": "workspace:*",
     "graphql": "^16.0.0",
     "jsdom": "^22.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -569,8 +569,8 @@ importers:
         version: 6.3.2
     devDependencies:
       '@solidjs/start':
-        specifier: ^1.2.1
-        version: 1.2.1(solid-js@1.9.10)(vinxi@0.5.10(@types/node@18.19.50)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.9.1)(jiti@2.6.1)(terser@5.43.1)(yaml@2.8.1))(vite@5.4.7(@types/node@18.19.50)(terser@5.43.1))
+        specifier: ^1.3.2
+        version: 1.3.2(solid-js@1.9.10)(vinxi@0.5.10(@types/node@18.19.50)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.9.1)(jiti@2.6.1)(terser@5.43.1)(yaml@2.8.1))(vite@5.4.7(@types/node@18.19.50)(terser@5.43.1))
       '@solidjs/testing-library':
         specifier: ^0.8.10
         version: 0.8.10(@solidjs/router@0.15.4(solid-js@1.9.10))(solid-js@1.9.10)
@@ -3355,8 +3355,8 @@ packages:
     peerDependencies:
       solid-js: ^1.8.6
 
-  '@solidjs/start@1.2.1':
-    resolution: {integrity: sha512-O5E7rcCwm2f8GlXKgS2xnU37Ld5vMVXJgo/qR7UI5iR5uFo9V2Ac+SSVNXkM98CeHKHt55h1UjbpxxTANEsHmA==}
+  '@solidjs/start@1.3.2':
+    resolution: {integrity: sha512-tasDl3utVbtP0rr4InB3ntBIFV2upvEiFrOOCkRrAA3yBfjx9elpxnc94sJQXo65PNYdAAAkPIC6h93vLrtwHg==}
     peerDependencies:
       vinxi: ^0.5.7
 
@@ -10109,8 +10109,8 @@ packages:
     peerDependencies:
       seroval: ^1.0
 
-  seroval-plugins@1.4.2:
-    resolution: {integrity: sha512-X7p4MEDTi+60o2sXZ4bnDBhgsUYDSkQEvzYZuJyFqWg9jcoPsHts5nrg5O956py2wyt28lUrBxk0M0/wU8URpA==}
+  seroval-plugins@1.6.2:
+    resolution: {integrity: sha512-TfxuUjlbBESzUOWdTkTKqvSmav0ABym+itetDXLK6mDz8SmrpdI30aF8RTXE8Bvq+tH/1yIDkvy3W0lfQb1ipQ==}
     engines: {node: '>=10'}
     peerDependencies:
       seroval: ^1.0
@@ -10123,8 +10123,8 @@ packages:
     resolution: {integrity: sha512-RbcPH1n5cfwKrru7v7+zrZvjLurgHhGyso3HTyGtRivGWgYjbOmGuivCQaORNELjNONoK35nj28EoWul9sb1zQ==}
     engines: {node: '>=10'}
 
-  seroval@1.4.2:
-    resolution: {integrity: sha512-N3HEHRCZYn3cQbsC4B5ldj9j+tHdf4JZoYPlcI4rRYu0Xy4qN8MQf1Z08EibzB0WpgRG5BGK08FTrmM66eSzKQ==}
+  seroval@1.6.2:
+    resolution: {integrity: sha512-mPT+SD2TrlB6wvte1KkYOYUkubaTbd6pZ/6Kk3C9nxzrHmCZyhxOO7XGAeL7f+yLKZglzGtM9odUVvg/EhO+vQ==}
     engines: {node: '>=10'}
 
   serve-handler@6.1.3:
@@ -15822,7 +15822,7 @@ snapshots:
     dependencies:
       solid-js: 1.9.10
 
-  '@solidjs/start@1.2.1(solid-js@1.9.10)(vinxi@0.5.10(@types/node@18.19.50)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.9.1)(jiti@2.6.1)(terser@5.43.1)(yaml@2.8.1))(vite@5.4.7(@types/node@18.19.50)(terser@5.43.1))':
+  '@solidjs/start@1.3.2(solid-js@1.9.10)(vinxi@0.5.10(@types/node@18.19.50)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.9.1)(jiti@2.6.1)(terser@5.43.1)(yaml@2.8.1))(vite@5.4.7(@types/node@18.19.50)(terser@5.43.1))':
     dependencies:
       '@tanstack/server-functions-plugin': 1.121.21(vite@5.4.7(@types/node@18.19.50)(terser@5.43.1))
       '@vinxi/plugin-directives': 0.5.1(vinxi@0.5.10(@types/node@18.19.50)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.9.1)(jiti@2.6.1)(terser@5.43.1)(yaml@2.8.1))
@@ -15832,8 +15832,8 @@ snapshots:
       error-stack-parser: 2.1.4
       html-to-image: 1.11.13
       radix3: 1.1.2
-      seroval: 1.4.2
-      seroval-plugins: 1.4.2(seroval@1.4.2)
+      seroval: 1.6.2
+      seroval-plugins: 1.6.2(seroval@1.6.2)
       shiki: 1.29.2
       source-map-js: 1.2.1
       terracotta: 1.1.0(solid-js@1.9.10)
@@ -24287,15 +24287,15 @@ snapshots:
     dependencies:
       seroval: 1.3.2
 
-  seroval-plugins@1.4.2(seroval@1.4.2):
+  seroval-plugins@1.6.2(seroval@1.6.2):
     dependencies:
-      seroval: 1.4.2
+      seroval: 1.6.2
 
   seroval@1.0.7: {}
 
   seroval@1.3.2: {}
 
-  seroval@1.4.2: {}
+  seroval@1.6.2: {}
 
   serve-handler@6.1.3:
     dependencies:


### PR DESCRIPTION
## Summary

Upgrade the SolidStart example to the supported and recommended SolidStart 2 setup so it remains a useful, buildable reference for `@urql/solid-start` users.

The published integration supports SolidStart 2. SolidStart 1 has been deprecated by the Solid team; the monorepo development dependency remains on its final release, 1.3.2, only because urql CI currently runs Node 22, while SolidStart 2 requires Node 24.

## Set of changes

- replace the Vinxi `app.config.ts` setup with the SolidStart 2 Vite and Nitro configuration
- update the example to SolidStart 2.0.2, Router 1, Vite 8, Solid 1.9.15, and Node 24+
- move the integration development target from SolidStart 1.2.1 to the final deprecated v1 release, 1.3.2
- verify the isolated example build and the integration package typecheck, lint, tests, and build

There is no runtime package or API change, so this does not include a changeset.