### PR TITLE
fix(site): restore Discord redirect

### DIFF
--- a/packages/site/public/_redirects
+++ b/packages/site/public/_redirects
@@ -1,0 +1,1 @@
+/discord https://discord.gg/NzUrbgz2dP 302


### PR DESCRIPTION
## Summary

- restore `/discord` at the currently deployed Cloudflare Pages layer
- preserve the existing non-expiring Discord invite from `urql-graphql/urql.dev`

The old Cloudflare Worker route is no longer serving `urql.dev/*`, so the request currently falls through to the docs site and returns its 404 page.

## Verification

- built `urql-docs` and verified the `_redirects` file is copied into the deployment artifact
- verified the Discord invite is active, non-expiring, and targets the urql discussions channel