### PR TITLE
fix(core): Block every reexecute of an in-flight operation

### DIFF
--- a/.changeset/brave-moons-repeat.md
+++ b/.changeset/brave-moons-repeat.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Fix `client.reexecuteOperation` letting every second reexecute of an in-flight operation through. The in-flight block cleared the operation's `dispatched` flag, so the next reexecute during the same request passed the deduplication check and sent a second network request. The flag is now only cleared when the reexecute replaced an operation that was already waiting in the queue.

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -860,6 +860,61 @@ describe('deduplication behavior', () => {
     expect(onOperation).toHaveBeenCalledTimes(2);
     expect(onResult).toHaveBeenCalledTimes(2);
   });
+
+  it('blocks repeated reexecutes of operations that are in-flight', async () => {
+    const onOperation = vi.fn();
+    const onResult = vi.fn();
+
+    let resolve;
+    const exchange: Exchange = () => ops$ =>
+      pipe(
+        ops$,
+        filter(op => op.kind !== 'teardown'),
+        onPush(onOperation),
+        mergeMap(op =>
+          fromPromise(
+            new Promise<void>(res => {
+              resolve = res;
+            }).then(() => ({
+              hasNext: false,
+              stale: false,
+              data: 'test',
+              operation: op,
+            }))
+          )
+        )
+      );
+
+    const client = createClient({
+      url: 'test',
+      exchanges: [exchange],
+    });
+
+    const operation = makeOperation('query', queryOperation, {
+      ...queryOperation.context,
+      requestPolicy: 'cache-first',
+    });
+
+    pipe(client.executeRequestOperation(operation), subscribe(onResult));
+    expect(onOperation).toHaveBeenCalledTimes(1);
+
+    client.reexecuteOperation(operation);
+    await Promise.resolve();
+    client.reexecuteOperation(operation);
+    await Promise.resolve();
+    client.reexecuteOperation(operation);
+    await Promise.resolve();
+
+    expect(onOperation).toHaveBeenCalledTimes(1);
+
+    resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(onOperation).toHaveBeenCalledTimes(1);
+    expect(onResult).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('shared sources behavior', () => {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -724,7 +724,7 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
           queue.push(operation);
           Promise.resolve().then(dispatchOperation);
         } else {
-          dispatched.delete(operation.key);
+          if (queued) dispatched.delete(operation.key);
           Promise.resolve().then(dispatchOperation);
         }
       }


### PR DESCRIPTION
## Summary

`client.reexecuteOperation` blocks a reexecute of an operation that is still in flight (#3573, fixing #3565), but the blocking `else` branch also clears that operation's `dispatched` flag. The next reexecute during the same request therefore passes `nextOperation`'s deduplication check, and a second network request goes out. In effect every second reexecute during one flight gets through.

We hit this with Graphcache, which reexecutes an active query on every dependency change. Under a stream of subscription events, every second event started another copy of a slow list query, so one page held several concurrent copies of the same request.

Repro against `@urql/core` alone — one slow exchange, no cache exchange — counting the operations that reach the exchange while a single `cache-first` query is in flight. Verified against a build of current `main`:

| scenario | `main` | this PR |
| --- | --- | --- |
| 1 / 2 / 3 / 4 reexecutes during one flight | 1 / 2 / 2 / 3 | 1 / 1 / 1 / 1 |
| stale first result, then a reexecute (#3254 shape) | 1 → 2 | 1 → 2 |
| one reexecute during a flight (#3565 shape) | 1 | 1 |
| reexecute after the result, subscriber still active | 2 | 2 |
| `network-only` reexecute during a flight | 1 | 1 |

The last four rows are the behaviours `unblocks stale operations` and `blocks reexecuting operations that are in-flight` already cover, and both stay green.

## Set of changes

`packages/core/src/client.ts` — the flag only has to be cleared when the reexecute replaced an operation already waiting in the queue, so that the queued operation is not deduplicated as the queue drains. An in-flight operation keeps its flag.

```ts
} else {
  if (queued) dispatched.delete(operation.key);
  Promise.resolve().then(dispatchOperation);
}
```

`packages/core/src/client.test.ts` — new test `blocks repeated reexecutes of operations that are in-flight`, placed after `blocks reexecuting operations that are in-flight`: three `reexecuteOperation` calls while the first request is pending must not dispatch again. It fails on `main` with 2 dispatches and passes with the change.

Plus a patch changeset for `@urql/core`. Only `@urql/core` is affected; `pnpm test`, `pnpm run check` and `pnpm run lint` are green across the monorepo.

### Why the flag was cleared, and why the stale path covers it

The clearing was introduced by #3363 to unblock an operation stalled after an optimistic mutation (#3254). Since then that case is handled by the stale-result path in `onPush` — `result.stale && !result.hasNext` is "an optimistic mutation or a partial result" and clears the key — which is what the existing `unblocks stale operations` test exercises. That leaves the queue case as the only reason to clear the flag in `reexecuteOperation`, and the `queued` check keeps it.

### One question for you

The unconditional clear was also a hedge for an operation that an exchange swallows without emitting any result — for example Graphcache dropping a `cache-first` miss that is blocked by an optimistic update, or one whose key is in its `reexecutingOperations` guard. With this change such an operation stays blocked until its teardown, whereas before it would have been let through on the next reexecute.

I could not construct that shape without the stale emission that `onPush` already handles, but you know the exchanges far better than I do. If it is reachable, this needs a release valve rather than the plain `queued` check, and I am happy to rework it.
